### PR TITLE
feat: configurable BT check interval + auto-disable after N failed reconnects

### DIFF
--- a/bluetooth_manager.py
+++ b/bluetooth_manager.py
@@ -57,7 +57,7 @@ class BluetoothManager:
     """Manages Bluetooth speaker connections using bluetoothctl"""
 
     def __init__(self, mac_address: str, adapter: str = "", device_name: str = "", client=None,
-                 prefer_sbc: bool = False):
+                 prefer_sbc: bool = False, check_interval: int = 10, max_reconnect_fails: int = 0):
         self.mac_address = mac_address
         self.adapter = adapter        # "hci0", "hci1", etc. — empty = use default
         self.device_name = device_name or mac_address
@@ -65,7 +65,8 @@ class BluetoothManager:
         self.prefer_sbc = prefer_sbc
         self.connected = False
         self.last_check = 0
-        self.check_interval = 10  # Check every 10 seconds
+        self.check_interval = check_interval
+        self.max_reconnect_fails = max_reconnect_fails
 
         # Resolve adapter name to MAC for reliable 'select' in bridged D-Bus setups.
         # In LXC containers, 'select hci0' fails ("Controller hci0 not available");
@@ -465,6 +466,25 @@ class BluetoothManager:
                         if self.client:
                             self.client.status['reconnecting'] = True
                             self.client.status['reconnect_attempt'] = reconnect_attempt
+
+                        # Auto-disable BT management after too many consecutive failures
+                        if self.max_reconnect_fails > 0 and reconnect_attempt >= self.max_reconnect_fails:
+                            logger.warning(
+                                f"[{self.device_name}] {reconnect_attempt} consecutive failed reconnects "
+                                f"(threshold={self.max_reconnect_fails}) — auto-disabling BT management"
+                            )
+                            self.management_enabled = False
+                            if self.client:
+                                self.client.bt_management_enabled = False
+                                self.client.status['bt_management_enabled'] = False
+                                self.client.status['reconnecting'] = False
+                            try:
+                                from services.bluetooth import persist_device_enabled
+                                persist_device_enabled(self.device_name, False)
+                            except Exception as _e:
+                                logger.debug(f"persist_device_enabled failed: {_e}")
+                            reconnect_attempt = 0
+                            continue
 
                         # Kill sendspin daemon immediately — if the BT sink is gone,
                         # sendspin floods PortAudioErrors on every audio chunk, which

--- a/config.py
+++ b/config.py
@@ -17,6 +17,8 @@ DEFAULT_CONFIG = {
     'TZ': 'Australia/Melbourne',
     'PULSE_LATENCY_MSEC': 200,
     'PREFER_SBC_CODEC': False,
+    'BT_CHECK_INTERVAL': 10,
+    'BT_MAX_RECONNECT_FAILS': 0,
 }
 
 import json

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -612,6 +612,9 @@ async def main():
     if prefer_sbc:
         logger.info("PREFER_SBC_CODEC: enabled — will request SBC codec after BT connect")
 
+    bt_check_interval = int(config.get('BT_CHECK_INTERVAL', 10))
+    bt_max_reconnect_fails = int(config.get('BT_MAX_RECONNECT_FAILS', 0))
+
     # Normalise device list — fall back to legacy BLUETOOTH_MAC
     bt_devices = config.get('BLUETOOTH_DEVICES', [])
     if not bt_devices:
@@ -649,7 +652,9 @@ async def main():
                                 listen_host=listen_host, effective_bridge=effective_bridge)
         if mac:
             bt_mgr = BluetoothManager(mac, adapter=adapter, device_name=player_name, client=client,
-                                       prefer_sbc=prefer_sbc)
+                                       prefer_sbc=prefer_sbc,
+                                       check_interval=bt_check_interval,
+                                       max_reconnect_fails=bt_max_reconnect_fails)
             if not bt_mgr.check_bluetooth_available():
                 logger.warning(f"BT adapter '{adapter or 'default'}' not available for {player_name}")
             client.bt_manager = bt_mgr

--- a/static/app.js
+++ b/static/app.js
@@ -955,6 +955,9 @@ async function saveConfig() {
     config.BLUETOOTH_DEVICES = collectBtDevices();
     // Checkbox → bool (FormData only includes it when checked, with value "on")
     config.PREFER_SBC_CODEC = !!(document.getElementById('prefer-sbc-codec') || {}).checked;
+    // Cast numeric BT settings to integers
+    config.BT_CHECK_INTERVAL = parseInt(config.BT_CHECK_INTERVAL, 10) || 10;
+    config.BT_MAX_RECONNECT_FAILS = parseInt(config.BT_MAX_RECONNECT_FAILS, 10) || 0;
     // Pass current group slider value so backend can init volume for new devices
     var groupSlider = document.getElementById('group-vol-slider');
     config._new_device_default_volume = groupSlider ? parseInt(groupSlider.value, 10) : 100;
@@ -1000,7 +1003,8 @@ async function loadConfig() {
         var config = await resp.json();
 
         // Populate simple fields
-        ['SENDSPIN_SERVER', 'SENDSPIN_PORT', 'BRIDGE_NAME', 'TZ', 'PULSE_LATENCY_MSEC'].forEach(function(key) {
+        ['SENDSPIN_SERVER', 'SENDSPIN_PORT', 'BRIDGE_NAME', 'TZ', 'PULSE_LATENCY_MSEC',
+         'BT_CHECK_INTERVAL', 'BT_MAX_RECONNECT_FAILS'].forEach(function(key) {
             var input = document.querySelector('[name="' + key + '"]');
             if (input && config[key] !== undefined) input.value = config[key];
         });

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
     <div class="status-grid" id="status-grid"></div>
 
     <!-- Configuration -->
-    <details class="config-section" open>
+    <details class="config-section">
         <summary>&#9881;&#65039; Configuration</summary>
         <form id="config-form">
             <div class="form-group">
@@ -75,15 +75,20 @@
             </div>
 
             <div class="form-group">
+                <label>BT check interval (s) — how often to probe each device connection (default 10)</label>
+                <input type="number" name="BT_CHECK_INTERVAL" placeholder="10" min="5" max="300">
+            </div>
+
+            <div class="form-group">
+                <label>Auto-disable after N failed reconnects — set Enabled=Off after this many consecutive failures (0 = never)</label>
+                <input type="number" name="BT_MAX_RECONNECT_FAILS" placeholder="0" min="0" max="100">
+            </div>
+
+            <div class="form-group">
                 <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
                     <input type="checkbox" name="PREFER_SBC_CODEC" id="prefer-sbc-codec" style="width:auto;margin:0;">
                     Prefer SBC codec — forces the simplest A2DP codec after each BT connect, reducing encoder CPU load on slow hardware (requires PulseAudio 15+)
                 </label>
-                <div style="margin-top:6px;padding:8px 10px;background:var(--warning-color,#ff9800);color:#fff;border-radius:4px;font-size:12px;line-height:1.5;">
-                    <strong>Tip: biggest CPU saving</strong> — change audio format in Music&nbsp;Assistant:
-                    Settings &rarr; Providers &rarr; Sendspin &rarr; Audio&nbsp;Quality &rarr; <strong>PCM 44.1&nbsp;kHz / 16-bit</strong>.
-                    This eliminates FLAC decoding entirely (&minus;~30% CPU per player).
-                </div>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
## Changes

### UI fixes
- Config section collapsed by default (removed `open` attribute)
- Removed Sendspin provider tip disclaimer under PREFER_SBC_CODEC checkbox

### New feature: configurable BT reconnect settings
- **BT_CHECK_INTERVAL** — how often (seconds) to probe each device connection (default 10)
- **BT_MAX_RECONNECT_FAILS** — auto-set `enabled=False` after this many consecutive failed reconnects (0 = never)

Both settings exposed in the Configuration UI and persisted in `config.json`.

### Implementation
- `config.py`: added both keys to `DEFAULT_CONFIG`
- `bluetooth_manager.py`: `check_interval` / `max_reconnect_fails` constructor params; auto-disable logic in `monitor_and_reconnect()`
- `sendspin_client.py`: passes values from config at `BluetoothManager` instantiation
- `templates/index.html`: two new form fields, collapsed config by default, removed disclaimer
- `static/app.js`: load/save new keys with integer cast