### PR TITLE
feat: web UI authentication (v1.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-03-02
+
+### Added
+- **Web UI authentication** — optional password protection for standalone deployments
+  (`AUTH_ENABLED` setting, default off); configure via the Configuration panel
+- **Set password** — new "Set / change password" form in the Configuration panel;
+  stores a PBKDF2-SHA256 hash in `config.json`, never plaintext
+- **HA Ingress bypass** — when accessed via Home Assistant Ingress (`X-Ingress-Path`
+  header), local auth is automatically skipped (HA already authenticated the user)
+- **HA Supervisor auth** — when running as HA addon with `AUTH_ENABLED=true`, login
+  validates against the Home Assistant user database via the Supervisor auth API
+- **Sign out button** — shown in the page header when authentication is enabled
+- **`SECRET_KEY` persistence** — Flask session key generated once and persisted to
+  `config.json`, so sessions survive container restarts
+
+### Fixed
+- **`BT_CHECK_INTERVAL` / `BT_MAX_RECONNECT_FAILS` not loaded** — both settings were
+  missing from `allowed_keys` in `load_config()` and were never read from `config.json`;
+  fixed so saved values are correctly restored on startup
+- **Password hash / secret key not preserved on config save** — `AUTH_PASSWORD_HASH`
+  and `SECRET_KEY` are now preserved across `/api/config` POST saves (like `LAST_VOLUMES`)
+- **Sensitive fields in config GET** — `AUTH_PASSWORD_HASH` and `SECRET_KEY` are now
+  filtered out of the `/api/config` GET response
+
 ## [1.5.1] - 2026-03-02
 
 ### Added

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ Provides the config file path, a process-wide lock for atomic writes,
 and helpers for loading/persisting configuration.
 """
 
-VERSION = "1.5.1"
+VERSION = "1.6.0"
 BUILD_DATE = "2026-03-02"
 
 DEFAULT_CONFIG = {
@@ -19,11 +19,16 @@ DEFAULT_CONFIG = {
     'PREFER_SBC_CODEC': False,
     'BT_CHECK_INTERVAL': 10,
     'BT_MAX_RECONNECT_FAILS': 0,
+    'AUTH_ENABLED': False,
+    'AUTH_PASSWORD_HASH': '',
+    'SECRET_KEY': '',
 }
 
+import hashlib
 import json
 import logging
 import os
+import secrets as _secrets
 import threading
 import uuid as _uuid
 from pathlib import Path
@@ -71,6 +76,8 @@ def load_config() -> dict:
         'BLUETOOTH_MAC', 'BLUETOOTH_DEVICES', 'TZ', 'LAST_VOLUME',
         'LAST_VOLUMES', 'BLUETOOTH_ADAPTERS', 'BRIDGE_NAME_SUFFIX',
         'PULSE_LATENCY_MSEC', 'PREFER_SBC_CODEC',
+        'BT_CHECK_INTERVAL', 'BT_MAX_RECONNECT_FAILS',
+        'AUTH_ENABLED', 'AUTH_PASSWORD_HASH', 'SECRET_KEY',
     }
 
     if config_file.exists():
@@ -87,3 +94,51 @@ def load_config() -> dict:
         logger.info(f"Config file not found at {config_file}, using defaults")
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+_PBKDF2_ITERS = 260_000
+
+
+def hash_password(plain: str) -> str:
+    """Return PBKDF2-SHA256 hash with embedded random salt (salt_hex:hash_hex)."""
+    salt = _secrets.token_bytes(16)
+    h = hashlib.pbkdf2_hmac('sha256', plain.encode(), salt, _PBKDF2_ITERS)
+    return salt.hex() + ':' + h.hex()
+
+
+def check_password(plain: str, stored: str) -> bool:
+    """Verify plain password against a stored hash produced by hash_password()."""
+    try:
+        salt_hex, h_hex = stored.split(':', 1)
+        salt = bytes.fromhex(salt_hex)
+        h = hashlib.pbkdf2_hmac('sha256', plain.encode(), salt, _PBKDF2_ITERS)
+        return h.hex() == h_hex
+    except Exception:
+        return False
+
+
+def ensure_secret_key(config: dict) -> str:
+    """Return SECRET_KEY from config, generating and persisting one if absent."""
+    key = config.get('SECRET_KEY', '')
+    if key:
+        return key
+    key = _secrets.token_hex(32)
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        with _config_lock:
+            existing: dict = {}
+            if CONFIG_FILE.exists():
+                with open(CONFIG_FILE) as f:
+                    existing = json.load(f)
+            existing['SECRET_KEY'] = key
+            tmp = str(CONFIG_FILE) + '.tmp'
+            with open(tmp, 'w') as f:
+                json.dump(existing, f, indent=2)
+            os.replace(tmp, str(CONFIG_FILE))
+    except Exception as e:
+        logger.warning(f'Could not persist SECRET_KEY: {e}')
+    return key

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-03-02
+
+### Added
+- Optional web UI authentication (`AUTH_ENABLED`); disabled by default
+- Set-password form in Configuration panel (PBKDF2-SHA256, no plaintext)
+- HA Ingress bypass — auth skipped when accessed via HA Ingress
+- HA Supervisor auth integration — validates against HA user database when `AUTH_ENABLED=true`
+- Sign out button in page header when auth is active
+
+### Fixed
+- BT_CHECK_INTERVAL and BT_MAX_RECONNECT_FAILS not loaded from saved config
+- Password hash and secret key preserved across config saves
+
 ## [1.5.1] - 2026-03-02
 
 ### Added

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "1.5.1"
+version: "1.6.0"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"

--- a/routes/api.py
+++ b/routes/api.py
@@ -458,6 +458,10 @@ def api_config():
         else:
             config = DEFAULT_CONFIG.copy()
 
+        # Never expose secrets to the browser
+        config.pop('AUTH_PASSWORD_HASH', None)
+        config.pop('SECRET_KEY', None)
+
         # Enrich BLUETOOTH_DEVICES with resolved listen_port / listen_host from running clients
         client_map = {getattr(c, 'player_name', None): c for c in _clients}
         mac_map    = {getattr(getattr(c, 'bt_manager', None), 'mac_address', None): c
@@ -482,7 +486,8 @@ def api_config():
             try:
                 with open(CONFIG_FILE) as f:
                     existing = json.load(f)
-                for key in ('LAST_VOLUMES', 'LAST_VOLUME'):
+                # Preserve keys that are never submitted via the form
+                for key in ('LAST_VOLUMES', 'LAST_VOLUME', 'AUTH_PASSWORD_HASH', 'SECRET_KEY'):
                     if key in existing and key not in config:
                         config[key] = existing[key]
             except Exception:
@@ -570,6 +575,44 @@ def api_config():
                 _ur.urlopen(req, timeout=10)
         except Exception as e:
             logger.warning(f'Failed to sync Supervisor options: {e}')
+
+    return jsonify({'success': True})
+
+
+@api_bp.route('/api/set-password', methods=['POST'])
+def api_set_password():
+    """Set (or change) the standalone web UI password.
+
+    Only available in non-HA-addon mode.  Requires the request body to contain
+    a JSON object with a 'password' key (string, ≥8 characters).
+    """
+    if os.environ.get('SUPERVISOR_TOKEN'):
+        return jsonify({'error': 'Use HA user management in HA addon mode'}), 400
+
+    data = request.get_json(force=True, silent=True) or {}
+    password = data.get('password', '')
+    if not password:
+        return jsonify({'error': 'password is required'}), 400
+    if len(password) < 8:
+        return jsonify({'error': 'Password must be at least 8 characters'}), 400
+
+    from config import hash_password as _hash_pw
+    pw_hash = _hash_pw(password)
+
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with _config_lock:
+        existing: dict = {}
+        if CONFIG_FILE.exists():
+            try:
+                with open(CONFIG_FILE) as f:
+                    existing = json.load(f)
+            except Exception:
+                pass
+        existing['AUTH_PASSWORD_HASH'] = pw_hash
+        tmp = str(CONFIG_FILE) + '.tmp'
+        with open(tmp, 'w') as f:
+            json.dump(existing, f, indent=2)
+        os.replace(tmp, str(CONFIG_FILE))
 
     return jsonify({'success': True})
 

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,0 +1,81 @@
+"""Auth blueprint for sendspin-bt-bridge.
+
+Handles /login (GET/POST) and /logout.
+
+Two authentication backends are supported:
+  - HA addon mode  (SUPERVISOR_TOKEN env var present): validates via the
+    Home Assistant Supervisor auth API using the user's HA credentials.
+  - Standalone mode: compares against a PBKDF2-SHA256 password hash stored
+    in config.json as AUTH_PASSWORD_HASH.
+
+When AUTH_ENABLED is False (default) all requests bypass this entirely;
+the before_request hook in web_interface.py is the gatekeeper.
+"""
+import json
+import logging
+import os
+import urllib.request as _ur
+from urllib.error import HTTPError
+
+from flask import Blueprint, render_template, request, session, redirect, url_for
+
+from config import load_config, check_password
+
+logger = logging.getLogger(__name__)
+
+auth_bp = Blueprint('auth', __name__)
+
+
+def _is_ha_addon() -> bool:
+    """True when running as a Home Assistant addon (SUPERVISOR_TOKEN is set)."""
+    return bool(os.environ.get('SUPERVISOR_TOKEN'))
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    ha_mode = _is_ha_addon()
+
+    if request.method == 'POST':
+        config = load_config()
+        if ha_mode:
+            username = request.form.get('username', '').strip()
+            password = request.form.get('password', '')
+            token = os.environ.get('SUPERVISOR_TOKEN', '')
+            try:
+                body = json.dumps({'username': username, 'password': password}).encode()
+                req = _ur.Request(
+                    'http://supervisor/auth',
+                    data=body,
+                    headers={
+                        'Authorization': f'Bearer {token}',
+                        'Content-Type': 'application/json',
+                    },
+                    method='POST',
+                )
+                _ur.urlopen(req, timeout=10)
+                session['authenticated'] = True
+                return redirect(request.args.get('next', '/'))
+            except HTTPError:
+                error = 'Invalid credentials'
+            except Exception as exc:
+                logger.warning('HA supervisor auth error: %s', exc)
+                error = 'Authentication service unavailable'
+        else:
+            password = request.form.get('password', '')
+            stored = config.get('AUTH_PASSWORD_HASH', '')
+            if not stored:
+                error = 'No password configured — set one via the Configuration panel'
+            elif check_password(password, stored):
+                session['authenticated'] = True
+                return redirect(request.args.get('next', '/'))
+            else:
+                error = 'Invalid password'
+
+    return render_template('login.html', error=error, ha_mode=ha_mode)
+
+
+@auth_bp.route('/logout')
+def logout():
+    session.pop('authenticated', None)
+    return redirect(url_for('auth.login'))

--- a/routes/views.py
+++ b/routes/views.py
@@ -1,6 +1,9 @@
 """Views blueprint — serves the main HTML page."""
+import os
+
 from flask import Blueprint, render_template
-from config import VERSION, BUILD_DATE
+
+from config import VERSION, BUILD_DATE, load_config
 
 views_bp = Blueprint('views', __name__)
 
@@ -8,4 +11,11 @@ views_bp = Blueprint('views', __name__)
 @views_bp.route('/')
 def index():
     """Render the main page"""
-    return render_template('index.html', VERSION=VERSION, BUILD_DATE=BUILD_DATE)
+    config = load_config()
+    return render_template(
+        'index.html',
+        VERSION=VERSION,
+        BUILD_DATE=BUILD_DATE,
+        auth_enabled=bool(config.get('AUTH_ENABLED', False)),
+        ha_mode=bool(os.environ.get('SUPERVISOR_TOKEN')),
+    )

--- a/static/app.js
+++ b/static/app.js
@@ -32,11 +32,19 @@ var lastDevices = [];
 var volTimers = {};
 var volPending = {}; // deviceIndex -> true if user recently touched slider
 
+// ---- Auth helper ----
+
+function _handleUnauthorized() {
+    var loginUrl = (API_BASE || '') + '/login?next=' + encodeURIComponent(window.location.pathname);
+    window.location.href = loginUrl;
+}
+
 // ---- Status ----
 
 async function updateStatus() {
     try {
         var resp = await fetch(API_BASE + '/api/status');
+        if (resp.status === 401) { _handleUnauthorized(); return; }
         var status = await resp.json();
 
         var info = [];
@@ -955,6 +963,7 @@ async function saveConfig() {
     config.BLUETOOTH_DEVICES = collectBtDevices();
     // Checkbox → bool (FormData only includes it when checked, with value "on")
     config.PREFER_SBC_CODEC = !!(document.getElementById('prefer-sbc-codec') || {}).checked;
+    config.AUTH_ENABLED = !!(document.getElementById('auth-enabled') || {}).checked;
     // Cast numeric BT settings to integers
     config.BT_CHECK_INTERVAL = parseInt(config.BT_CHECK_INTERVAL, 10) || 10;
     config.BT_MAX_RECONNECT_FAILS = parseInt(config.BT_MAX_RECONNECT_FAILS, 10) || 0;
@@ -983,6 +992,34 @@ async function saveConfig() {
     }
 }
 
+// ---- Change password (standalone mode) ----
+
+async function setPassword() {
+    var pw  = (document.getElementById('new-password') || {}).value || '';
+    var pw2 = (document.getElementById('new-password-confirm') || {}).value || '';
+    if (!pw) { alert('Please enter a password.'); return; }
+    if (pw.length < 8) { alert('Password must be at least 8 characters.'); return; }
+    if (pw !== pw2) { alert('Passwords do not match.'); return; }
+    try {
+        var resp = await fetch(API_BASE + '/api/set-password', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password: pw }),
+        });
+        if (resp.status === 401) { _handleUnauthorized(); return; }
+        var data = await resp.json().catch(function() { return {}; });
+        if (resp.ok) {
+            alert('Password set successfully.');
+            document.getElementById('new-password').value = '';
+            document.getElementById('new-password-confirm').value = '';
+        } else {
+            alert('Error: ' + (data.error || 'Unknown error'));
+        }
+    } catch (err) {
+        alert('Error setting password: ' + err.message);
+    }
+}
+
 document.getElementById('config-form').addEventListener('submit', async function(e) {
     e.preventDefault();
     try {
@@ -1000,6 +1037,7 @@ document.getElementById('config-form').addEventListener('submit', async function
 async function loadConfig() {
     try {
         var resp = await fetch(API_BASE + '/api/config');
+        if (resp.status === 401) { _handleUnauthorized(); return; }
         var config = await resp.json();
 
         // Populate simple fields
@@ -1011,6 +1049,8 @@ async function loadConfig() {
         // Populate checkboxes
         var sbcCheck = document.getElementById('prefer-sbc-codec');
         if (sbcCheck) sbcCheck.checked = !!config.PREFER_SBC_CODEC;
+        var authCheck = document.getElementById('auth-enabled');
+        if (authCheck) authCheck.checked = !!config.AUTH_ENABLED;
         updateTzPreview();
 
         // Restore manual adapters before re-running loadBtAdapters so merging picks them up

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,15 @@
                 <div>{{ BUILD_DATE }}</div>
             </div>
             <div id="system-info" style="font-size:12px;color:#9ca3af;margin-top:4px;line-height:1.6;"></div>
+            {% if auth_enabled %}
+            <div style="margin-top:8px;">
+                <a href="{{ url_for('auth.logout') }}"
+                   style="color:rgba(255,255,255,0.8);font-size:12px;text-decoration:none;
+                          border:1px solid rgba(255,255,255,0.4);border-radius:4px;padding:3px 10px;">
+                    Sign out
+                </a>
+            </div>
+            {% endif %}
         </div>
     </div>
 
@@ -152,6 +161,27 @@
                     Save &amp; Restart
                 </button>
             </div>
+
+            {% if not ha_mode %}
+            <!-- Authentication (standalone mode only) -->
+            <hr style="border:none;border-top:1px solid var(--divider-color);margin:20px 0;">
+            <div class="form-group">
+                <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+                    <input type="checkbox" name="AUTH_ENABLED" id="auth-enabled" style="width:auto;margin:0;">
+                    Enable web UI authentication — protect the interface with a password
+                </label>
+            </div>
+            <div class="form-group">
+                <label>Set / change password <span style="font-size:11px;color:var(--secondary-text-color);">(minimum 8 characters — set before enabling auth)</span></label>
+                <div style="display:flex;gap:8px;flex-wrap:wrap;">
+                    <input type="password" id="new-password" autocomplete="new-password"
+                           placeholder="New password" style="flex:1;min-width:180px;">
+                    <input type="password" id="new-password-confirm" autocomplete="new-password"
+                           placeholder="Confirm password" style="flex:1;min-width:180px;">
+                    <button type="button" onclick="setPassword()" class="btn btn-sm">Set Password</button>
+                </div>
+            </div>
+            {% endif %}
         </form>
     </details>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign in — Sendspin Bluetooth Bridge</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <style>
+        .login-wrap {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .login-card {
+            background: var(--card-background-color);
+            border-radius: var(--ha-card-border-radius);
+            box-shadow: var(--ha-card-box-shadow);
+            padding: 36px 32px;
+            width: 100%;
+            max-width: 380px;
+        }
+        .login-header {
+            text-align: center;
+            margin-bottom: 28px;
+        }
+        .login-header h1 {
+            color: var(--primary-color);
+            font-size: 20px;
+            font-weight: 700;
+            margin-bottom: 6px;
+        }
+        .login-header p {
+            color: var(--secondary-text-color);
+            font-size: 13px;
+        }
+        .login-error {
+            background: #fee2e2;
+            color: #991b1b;
+            border: 1px solid #fca5a5;
+            border-radius: 6px;
+            padding: 10px 14px;
+            font-size: 13px;
+            margin-bottom: 16px;
+        }
+        .login-submit {
+            width: 100%;
+            padding: 11px;
+            font-size: 15px;
+            font-weight: 600;
+            margin-top: 8px;
+        }
+    </style>
+</head>
+<body>
+<div class="login-wrap">
+    <div class="login-card">
+        <div class="login-header">
+            <h1>&#127925; Sendspin Bluetooth Bridge</h1>
+            <p>Sign in to continue</p>
+        </div>
+
+        {% if error %}
+        <div class="login-error">{{ error }}</div>
+        {% endif %}
+
+        <form method="post" autocomplete="on">
+            {% if ha_mode %}
+            <div class="form-group">
+                <label>Home Assistant username</label>
+                <input type="text" name="username" autocomplete="username" required autofocus>
+            </div>
+            {% endif %}
+            <div class="form-group">
+                <label>Password</label>
+                <input type="password" name="password" autocomplete="current-password"
+                    required {% if not ha_mode %}autofocus{% endif %}>
+            </div>
+            <button type="submit" class="btn login-submit">Sign in</button>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/web_interface.py
+++ b/web_interface.py
@@ -11,9 +11,11 @@ routes/api.py and routes/views.py; shared helpers live in config.py and state.py
 import logging
 import os
 
-from flask import Flask
+from flask import Flask, jsonify, redirect, request, session, url_for
 from flask_cors import CORS
 from waitress import serve
+
+from config import ensure_secret_key, load_config
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -21,6 +23,11 @@ logger = logging.getLogger(__name__)
 
 app = Flask(__name__, template_folder='templates', static_folder='static')
 CORS(app)
+
+# Set secret key (generated once and persisted to config.json so sessions
+# survive container restarts).
+_startup_config = load_config()
+app.secret_key = ensure_secret_key(_startup_config)
 
 
 class _IngressMiddleware:
@@ -41,9 +48,41 @@ app.wsgi_app = _IngressMiddleware(app.wsgi_app)
 # Register blueprints (imported after app is created to avoid circular imports)
 from routes.views import views_bp  # noqa: E402
 from routes.api import api_bp      # noqa: E402
+from routes.auth import auth_bp    # noqa: E402
 
 app.register_blueprint(views_bp)
 app.register_blueprint(api_bp)
+app.register_blueprint(auth_bp)
+
+# Public paths that never require authentication
+_PUBLIC_PATHS = {'/login', '/logout', '/api/status'}
+
+
+@app.before_request
+def _check_auth():
+    """Enforce authentication when AUTH_ENABLED is True."""
+    config = load_config()
+    if not config.get('AUTH_ENABLED', False):
+        return  # auth disabled — allow all
+
+    # HA Ingress: the proxy already authenticated the user
+    if request.headers.get('X-Ingress-Path'):
+        return
+
+    # Static assets and public API endpoints are always reachable
+    if request.path.startswith('/static/'):
+        return
+    if request.path in _PUBLIC_PATHS:
+        return
+
+    # Active session
+    if session.get('authenticated'):
+        return
+
+    # Unauthenticated — return 401 for API calls, redirect to login for pages
+    if request.path.startswith('/api/'):
+        return jsonify({'error': 'Unauthorized'}), 401
+    return redirect(url_for('auth.login', next=request.path))
 
 
 def main():
@@ -55,3 +94,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
## Web UI Authentication

Adds optional password protection to the web interface, fully backward compatible.

### What's new
- **`AUTH_ENABLED`** setting (default `false`) — opt-in, zero impact on existing deployments
- **Standalone mode**: PBKDF2-SHA256 password hash stored in `config.json` (stdlib only, no extra deps)
- **HA Ingress bypass**: when `X-Ingress-Path` header is present, local auth is skipped (HA already authenticated)
- **HA Supervisor auth**: when running as addon with `AUTH_ENABLED=true`, credentials are validated against the HA user database via the Supervisor auth API
- **Set/change password** form in Configuration panel (standalone mode only)
- **Sign out** button in page header (only when auth is enabled)
- **`SECRET_KEY`** generated once and persisted to `config.json` so sessions survive container restarts
- `/api/status` always public (Docker HEALTHCHECK)

### Security
- `AUTH_PASSWORD_HASH` and `SECRET_KEY` are filtered from `/api/config` GET response
- Both are preserved across config saves (like `LAST_VOLUMES`)

### Bug fixes
- `BT_CHECK_INTERVAL` and `BT_MAX_RECONNECT_FAILS` were missing from `allowed_keys` in `load_config()` — saved values were silently ignored on startup

### New files
- `routes/auth.py` — `auth_bp` Blueprint: `/login` (GET/POST), `/logout`
- `templates/login.html` — minimal dark-theme login page