### PR TITLE
fix: sync enabled toggle between bridge UI and HA addon config page (v2.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.5] - 2026-03-03
+
+### Fixed
+- **Enabled toggle sync**: bridge UI `enabled` toggle and HA addon config page now stay in sync
+  - `persist_device_enabled()` now writes to both `config.json` and `/data/options.json`, so toggling
+    in the bridge UI is immediately reflected on the HA config page
+  - On startup, each device's actual `enabled` state is synced to `options.json` (fixes devices showing
+    as disabled in HA config page when they are enabled in the bridge)
+  - `entrypoint.sh` no longer overrides `enabled` from old `config.json` on restart — `options.json`
+    is now the authoritative source; devices without explicit `enabled` in `options.json` default to `true`
+
 ## [2.1.4] - 2026-03-03
 
 ### Added

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ Provides the config file path, a process-wide lock for atomic writes,
 and helpers for loading/persisting configuration.
 """
 
-VERSION = "2.1.4"
+VERSION = "2.1.5"
 BUILD_DATE = "2026-03-02"
 
 DEFAULT_CONFIG = {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,6 +72,10 @@ config = {
     'BT_MAX_RECONNECT_FAILS': opts.get('bt_max_reconnect_fails', 0),
 }
 
+# Normalize: devices without explicit 'enabled' field default to True
+for dev in config.get('BLUETOOTH_DEVICES', []):
+    dev.setdefault('enabled', True)
+
 # Preserve runtime state (volumes, release/reclaim flags) from previous config
 try:
     with open('/data/config.json') as f:
@@ -80,12 +84,6 @@ try:
         config['LAST_VOLUMES'] = existing['LAST_VOLUMES']
     elif 'LAST_VOLUME' in existing:
         config['LAST_VOLUME'] = existing['LAST_VOLUME']
-    # Preserve enabled flags (release/reclaim) per device, matched by MAC
-    ex_by_mac = {d.get('mac', ''): d for d in existing.get('BLUETOOTH_DEVICES', []) if d.get('mac')}
-    for dev in config.get('BLUETOOTH_DEVICES', []):
-        mac = dev.get('mac', '')
-        if mac in ex_by_mac and 'enabled' in ex_by_mac[mac]:
-            dev['enabled'] = ex_by_mac[mac]['enabled']
 except (FileNotFoundError, json.JSONDecodeError):
     pass
 

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.5] - 2026-03-03
+
+### Fixed
+- Enabled toggle in bridge UI now syncs to `options.json` so HA config page stays in sync
+- Startup sync: device enabled state written to `options.json` on boot (fixes "disabled" display for active devices)
+- `entrypoint.sh`: `options.json` is now authoritative for `enabled`; absent field defaults to `true`
+
 ## [2.1.4] - 2026-03-03
 
 ### Added

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "2.1.4"
+version: "2.1.5"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -510,6 +510,14 @@ async def main():
 
     logger.info("Client instance(s) registered")
 
+    # Sync enabled state to options.json so HA addon config page reflects current state
+    try:
+        from services.bluetooth import persist_device_enabled as _persist_enabled
+        for _c in clients:
+            _persist_enabled(_c.player_name, _c.bt_management_enabled)
+    except Exception as _e:
+        logger.debug(f"Could not sync enabled state to options.json: {_e}")
+
     # Register MPRIS Identity services on the session bus (one per player)
     if _DBUS_MPRIS_AVAILABLE:
         try:

--- a/services/bluetooth.py
+++ b/services/bluetooth.py
@@ -16,6 +16,7 @@ from config import _config_lock
 logger = logging.getLogger(__name__)
 
 _CONFIG_FILE = Path(os.getenv('CONFIG_DIR', '/config')) / 'config.json'
+_OPTIONS_FILE = Path('/data/options.json')
 
 _AUDIO_UUIDS = {
     '0000110b',  # A2DP Sink
@@ -44,7 +45,7 @@ def bt_remove_device(mac: str, adapter_mac: str = '') -> None:
 
 
 def persist_device_enabled(player_name: str, enabled: bool) -> None:
-    """Persist the enabled flag for a device in config.json."""
+    """Persist the enabled flag to config.json and (in HA mode) to options.json."""
     if not _CONFIG_FILE.exists():
         return
     try:
@@ -61,6 +62,23 @@ def persist_device_enabled(player_name: str, enabled: bool) -> None:
             os.replace(tmp, str(_CONFIG_FILE))
     except Exception as e:
         logger.warning(f"Could not persist enabled flag for '{player_name}': {e}")
+
+    # Sync to options.json so the HA addon config page reflects the change
+    if _OPTIONS_FILE.exists():
+        try:
+            with open(_OPTIONS_FILE, 'r') as f:
+                opts = json.load(f)
+            for dev in opts.get('bluetooth_devices', []):
+                if dev.get('player_name') == player_name:
+                    dev['enabled'] = enabled
+                    break
+            tmp = str(_OPTIONS_FILE) + '.tmp'
+            with open(tmp, 'w') as f:
+                json.dump(opts, f, indent=2)
+            os.replace(tmp, str(_OPTIONS_FILE))
+            logger.debug(f"Synced enabled={enabled} for '{player_name}' to options.json")
+        except Exception as e:
+            logger.debug(f"Could not sync enabled flag to options.json: {e}")
 
 
 def is_audio_device(mac: str) -> bool:


### PR DESCRIPTION
## Problem

The `enabled` toggle in the HA addon config page and the bridge UI were out of sync:
- ENEBY20 and Yandex showed as **disabled** (OFF) in the HA config page but were **enabled** in the bridge
- Root cause: `options.json` stores the `enabled` field as absent for these devices; HA's optional `bool?` form shows absent as OFF

## Changes

### `services/bluetooth.py`
- `persist_device_enabled()` now writes to **both** `config.json` and `/data/options.json`
- Toggling in the bridge UI is immediately reflected in the HA addon config page

### `sendspin_client.py`
- On startup, sync each device's actual `bt_management_enabled` state to `options.json`
- Fixes devices showing as disabled in HA config page when they are actively running in the bridge

### `entrypoint.sh`
- Added `dev.setdefault('enabled', True)` — devices without explicit `enabled` in `options.json` now get `enabled: true` in `config.json` (fixes optional `bool?` defaulting to OFF)
- Removed legacy preservation of `enabled` from old `config.json` on restart — `options.json` is now the authoritative source