### PR TITLE
fix: correct pactl argument quoting for null-sink and loopback creation

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ Provides the config file path, a process-wide lock for atomic writes,
 and helpers for loading/persisting configuration.
 """
 
-VERSION = "2.2.0"
+VERSION = "2.2.1"
 BUILD_DATE = "2026-03-02"
 
 DEFAULT_CONFIG = {

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "2.2.0"
+version: "2.2.1"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"

--- a/services/pulse.py
+++ b/services/pulse.py
@@ -393,22 +393,20 @@ def load_null_sink(sink_name: str, description: str) -> int | None:
     Idempotent: if a sink with *sink_name* already exists, returns -1 (skip).
     """
     if check_sink_exists(sink_name):
-        logger.debug("Null-sink %s already exists — skipping", sink_name)
+        logger.info("Null-sink %s already exists — skipping", sink_name)
         return -1
     try:
-        args = (
-            f'sink_name={sink_name} '
-            f'sink_properties=device.description="{description}"'
-        )
-        r = subprocess.run(
-            ['pactl', 'load-module', 'module-null-sink', args],
-            capture_output=True, text=True, timeout=5,
-        )
-        if r.returncode == 0:
+        # Use shell=True so bash handles quoting of description with spaces
+        import shlex
+        desc_arg = shlex.quote(f'sink_properties=device.description={description}')
+        cmd = f'pactl load-module module-null-sink sink_name={sink_name} {desc_arg}'
+        logger.info("Creating null-sink: %s", cmd)
+        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=5)
+        if r.returncode == 0 and r.stdout.strip():
             module_id = int(r.stdout.strip())
             logger.info("Loaded module-null-sink %s (module %d)", sink_name, module_id)
             return module_id
-        logger.warning("load_null_sink(%s) failed: %s", sink_name, r.stderr.strip())
+        logger.warning("load_null_sink(%s) failed (rc=%d): %s", sink_name, r.returncode, r.stderr.strip())
     except Exception as exc:
         logger.warning("load_null_sink(%s) error: %s", sink_name, exc)
     return None
@@ -417,16 +415,17 @@ def load_null_sink(sink_name: str, description: str) -> int | None:
 def load_loopback(source: str, sink: str, latency_msec: int = 50) -> int | None:
     """Load a ``module-loopback`` from *source* to *sink*. Returns module index or None."""
     try:
-        args = f'source={source} sink={sink} latency_msec={latency_msec}'
         r = subprocess.run(
-            ['pactl', 'load-module', 'module-loopback', args],
+            ['pactl', 'load-module', 'module-loopback',
+             f'source={source}', f'sink={sink}', f'latency_msec={latency_msec}'],
             capture_output=True, text=True, timeout=5,
         )
-        if r.returncode == 0:
+        if r.returncode == 0 and r.stdout.strip():
             module_id = int(r.stdout.strip())
             logger.info("Loaded module-loopback %s → %s (module %d)", source, sink, module_id)
             return module_id
-        logger.warning("load_loopback(%s → %s) failed: %s", source, sink, r.stderr.strip())
+        logger.warning("load_loopback(%s → %s) failed (rc=%d): %s",
+                        source, sink, r.returncode, r.stderr.strip())
     except Exception as exc:
         logger.warning("load_loopback(%s → %s) error: %s", source, sink, exc)
     return None


### PR DESCRIPTION
## Problem

`module-null-sink` and `module-loopback` creation failed silently in v2.2.0 because:

1. **Null-sink**: Description with spaces (e.g. `Bridge: ENEBY20`) was passed as a single string arg with embedded quotes — PulseAudio's modargs parser couldn't handle it
2. **Loopback**: All args passed as single concatenated string instead of separate argv elements — pactl couldn't parse them

## Fix

- Use `shell=True` with `shlex.quote()` for null-sink to properly handle descriptions with spaces
- Split loopback args into separate list elements for subprocess
- Add explicit command logging for debugging
- Validate stdout is non-empty before parsing module ID

## Version

Bumped to v2.2.1