### PR TITLE
fix: replace null-sink/loopback with move-sink-input routing

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ Provides the config file path, a process-wide lock for atomic writes,
 and helpers for loading/persisting configuration.
 """
 
-VERSION = "2.2.1"
+VERSION = "2.2.2"
 BUILD_DATE = "2026-03-02"
 
 DEFAULT_CONFIG = {

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "2.2.1"
+version: "2.2.2"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -94,8 +94,6 @@ class SendspinClient:
         self._bridge_daemon = None  # BridgeDaemon instance (in-process sendspin)
         self._monitor_task: Optional[asyncio.Task] = None
         self._status_lock = threading.Lock()  # protects concurrent reads/writes of self.status
-        self._null_sink_name: Optional[str] = None  # virtual PA sink name (set by main())
-        self._loopback_module_id: Optional[int] = None  # PA loopback module index
 
     def update_status(self, **kwargs) -> None:
         """Thread-safe update of one or more status fields."""
@@ -212,29 +210,14 @@ class SendspinClient:
             else:
                 logger.info(f"Starting Sendspin player '{self.player_name}' with auto-discovery (port {self.listen_port})")
 
-            # --- Null-sink + loopback routing ---
-            # If we have a null-sink, create a loopback to forward audio to BT sink
-            # and resolve the audio device to the null-sink (not the BT sink).
-            resolve_target = self.bluetooth_sink_name  # fallback: try BT sink directly
-            if self._null_sink_name and self.bluetooth_sink_name:
-                from services.pulse import load_loopback
-                self._loopback_module_id = load_loopback(
-                    f"{self._null_sink_name}.monitor",
-                    self.bluetooth_sink_name,
-                )
-                if self._loopback_module_id is not None:
-                    logger.info(
-                        f"[{self.player_name}] Loopback: {self._null_sink_name} → {self.bluetooth_sink_name}"
-                    )
-                    resolve_target = self._null_sink_name
-                else:
-                    logger.warning(
-                        f"[{self.player_name}] Loopback creation failed — falling back to default device"
-                    )
+            # Snapshot current sink-inputs so BridgeDaemon can identify
+            # the new one it creates (for move-sink-input routing).
+            from services.pulse import get_sink_input_ids
+            pre_sink_inputs = get_sink_input_ids()
 
-            audio_device = await resolve_audio_device_for_sink(resolve_target)
+            audio_device = await resolve_audio_device_for_sink(self.bluetooth_sink_name)
             if audio_device:
-                logger.info(f"[{self.player_name}] Audio device resolved: {audio_device.name!r} (index {audio_device.index}) for sink {resolve_target!r}")
+                logger.info(f"[{self.player_name}] Audio device resolved: {audio_device.name!r} (index {audio_device.index}) for sink {self.bluetooth_sink_name!r}")
             else:
                 logger.error("No audio output device found — cannot start daemon")
                 self.status['last_error'] = 'No audio output device found'
@@ -270,6 +253,7 @@ class SendspinClient:
                 status=self.status,
                 bluetooth_sink_name=self.bluetooth_sink_name,
                 on_volume_save=_on_volume_save,
+                pre_start_sink_input_ids=pre_sink_inputs,
             )
             self.status['playing'] = False
 
@@ -288,7 +272,7 @@ class SendspinClient:
             self.status['server_connected'] = False
 
     async def stop_sendspin(self) -> None:
-        """Stop the in-process sendspin daemon task and clean up loopback."""
+        """Stop the in-process sendspin daemon task."""
         if self._daemon_task and not self._daemon_task.done():
             self._daemon_task.cancel()
             try:
@@ -297,11 +281,6 @@ class SendspinClient:
                 pass
         self._daemon_task = None
         self._bridge_daemon = None
-        # Unload loopback module (null-sink persists for reuse)
-        if self._loopback_module_id is not None and self._loopback_module_id >= 0:
-            from services.pulse import unload_module
-            unload_module(self._loopback_module_id)
-            self._loopback_module_id = None
         self.status['server_connected'] = False
         self.status['connected'] = False
         self.status['group_name'] = None
@@ -453,17 +432,6 @@ async def main():
         or f"Sendspin-{socket.gethostname()}"
     )
 
-    # Pre-create virtual null-sinks for each BT device so PortAudio sees them
-    # on first Pa_Initialize() (triggered by query_devices() in daemon startup).
-    from services.pulse import load_null_sink
-    for device in bt_devices:
-        mac = device.get('mac', '')
-        if mac:
-            mac_under = mac.replace(':', '_')
-            ns_name = f"bridge_{mac_under}"
-            _pname = device.get('player_name') or _default_player_name
-            load_null_sink(ns_name, f"Bridge: {_pname}")
-
     base_listen_port = 8928
     clients = []
     for i, device in enumerate(bt_devices):
@@ -483,7 +451,6 @@ async def main():
                                 listen_port=listen_port, static_delay_ms=static_delay_ms,
                                 listen_host=listen_host, effective_bridge=effective_bridge)
         if mac:
-            client._null_sink_name = f"bridge_{mac.replace(':', '_')}"
             bt_mgr = BluetoothManager(mac, adapter=adapter, device_name=player_name, client=client,
                                        prefer_sbc=prefer_sbc,
                                        check_interval=bt_check_interval,

--- a/services/bridge_daemon.py
+++ b/services/bridge_daemon.py
@@ -22,7 +22,7 @@ from aiosendspin.models.core import (
 )
 from aiosendspin.models.types import PlayerCommand, UndefinedField
 from sendspin.daemon.daemon import DaemonArgs, SendspinDaemon
-from services.pulse import aset_sink_volume, aget_sink_description
+from services.pulse import aset_sink_volume, aget_sink_description, alist_sink_input_ids, amove_sink_input
 
 from config import VERSION as _BRIDGE_VERSION
 
@@ -40,17 +40,23 @@ class BridgeDaemon(SendspinDaemon):
                         to persist the value to config.
     """
 
+    # Class-level lock to serialize sink-input routing across daemon instances
+    _routing_lock = asyncio.Lock()
+
     def __init__(
         self,
         args: DaemonArgs,
         status: dict,
         bluetooth_sink_name: str | None,
         on_volume_save: Callable[[int], None] | None = None,
+        pre_start_sink_input_ids: set[int] | None = None,
     ) -> None:
         super().__init__(args)
         self._bridge_status = status
         self._bluetooth_sink_name = bluetooth_sink_name
         self._on_volume_save = on_volume_save
+        self._pre_start_sink_input_ids = pre_start_sink_input_ids or set()
+        self._routed = False  # True after sink-input has been moved to target
 
     # ── Client creation ──────────────────────────────────────────────────────
 
@@ -147,6 +153,39 @@ class BridgeDaemon(SendspinDaemon):
         self._bridge_status['audio_format'] = (
             f"{codec or 'PCM'} {sample_rate}Hz/{bit_depth}-bit/{channels}ch"
         )
+        # PA stream (sink-input) was just created by set_format() → sounddevice.
+        # Schedule routing to the correct BT sink.
+        if self._bluetooth_sink_name and not self._routed:
+            asyncio.ensure_future(self._route_stream_to_sink())
+
+    async def _route_stream_to_sink(self) -> None:
+        """Find the newly created sink-input and move it to the target BT sink.
+
+        Uses *pre_start_sink_input_ids* to identify the new sink-input (any ID
+        that didn't exist before this daemon started).  An asyncio lock serializes
+        routing across daemon instances to prevent two daemons from claiming the
+        same sink-input.
+        """
+        async with BridgeDaemon._routing_lock:
+            # Small delay for PA/PipeWire to register the new sink-input
+            await asyncio.sleep(0.3)
+            current_ids = await alist_sink_input_ids()
+            new_ids = current_ids - self._pre_start_sink_input_ids
+            player = self._bridge_status.get('player_name', '?')
+            if not new_ids:
+                logger.warning("[%s] No new sink-input found for routing "
+                               "(pre=%s, cur=%s)", player,
+                               self._pre_start_sink_input_ids, current_ids)
+                return
+            target_id = max(new_ids)  # highest (newest) ID
+            ok = await amove_sink_input(target_id, self._bluetooth_sink_name)
+            if ok:
+                self._routed = True
+                logger.info("[%s] ✓ Routed sink-input %d → %s",
+                            player, target_id, self._bluetooth_sink_name)
+            else:
+                logger.warning("[%s] Failed to route sink-input %d → %s",
+                               player, target_id, self._bluetooth_sink_name)
 
     def _on_stream_event(self, event: str) -> None:
         super()._on_stream_event(event)

--- a/services/pulse.py
+++ b/services/pulse.py
@@ -362,105 +362,31 @@ def _fallback_move_sink_input(sink_input_idx: int, sink_name: str) -> bool:
             ['pactl', 'move-sink-input', str(sink_input_idx), sink_name],
             capture_output=True, text=True, timeout=3,
         )
+        if r.returncode == 0:
+            logger.info("Moved sink-input %d → %s", sink_input_idx, sink_name)
+        else:
+            logger.warning("move_sink_input(%d → %s) failed (rc=%d): %s",
+                            sink_input_idx, sink_name, r.returncode, r.stderr.strip())
         return r.returncode == 0
     except Exception:
         return False
 
 
-# ---------------------------------------------------------------------------
-# PA module management (null-sink / loopback)
-# ---------------------------------------------------------------------------
-
-def check_sink_exists(sink_name: str) -> bool:
-    """Return True if a PA sink with *sink_name* already exists."""
+def get_sink_input_ids() -> set[int]:
+    """Return the set of currently active sink-input IDs (sync, subprocess)."""
+    ids: set[int] = set()
     try:
         r = subprocess.run(
-            ['pactl', 'list', 'short', 'sinks'],
+            ['pactl', 'list', 'short', 'sink-inputs'],
             capture_output=True, text=True, timeout=5,
         )
         for line in r.stdout.splitlines():
             parts = line.split('\t')
-            if len(parts) >= 2 and parts[1] == sink_name:
-                return True
+            if parts:
+                try:
+                    ids.add(int(parts[0]))
+                except ValueError:
+                    pass
     except Exception as exc:
-        logger.debug("check_sink_exists(%s) error: %s", sink_name, exc)
-    return False
-
-
-def load_null_sink(sink_name: str, description: str) -> int | None:
-    """Load a ``module-null-sink`` and return the module index, or None on error.
-
-    Idempotent: if a sink with *sink_name* already exists, returns -1 (skip).
-    """
-    if check_sink_exists(sink_name):
-        logger.info("Null-sink %s already exists — skipping", sink_name)
-        return -1
-    try:
-        # Use shell=True so bash handles quoting of description with spaces
-        import shlex
-        desc_arg = shlex.quote(f'sink_properties=device.description={description}')
-        cmd = f'pactl load-module module-null-sink sink_name={sink_name} {desc_arg}'
-        logger.info("Creating null-sink: %s", cmd)
-        r = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=5)
-        if r.returncode == 0 and r.stdout.strip():
-            module_id = int(r.stdout.strip())
-            logger.info("Loaded module-null-sink %s (module %d)", sink_name, module_id)
-            return module_id
-        logger.warning("load_null_sink(%s) failed (rc=%d): %s", sink_name, r.returncode, r.stderr.strip())
-    except Exception as exc:
-        logger.warning("load_null_sink(%s) error: %s", sink_name, exc)
-    return None
-
-
-def load_loopback(source: str, sink: str, latency_msec: int = 50) -> int | None:
-    """Load a ``module-loopback`` from *source* to *sink*. Returns module index or None."""
-    try:
-        r = subprocess.run(
-            ['pactl', 'load-module', 'module-loopback',
-             f'source={source}', f'sink={sink}', f'latency_msec={latency_msec}'],
-            capture_output=True, text=True, timeout=5,
-        )
-        if r.returncode == 0 and r.stdout.strip():
-            module_id = int(r.stdout.strip())
-            logger.info("Loaded module-loopback %s → %s (module %d)", source, sink, module_id)
-            return module_id
-        logger.warning("load_loopback(%s → %s) failed (rc=%d): %s",
-                        source, sink, r.returncode, r.stderr.strip())
-    except Exception as exc:
-        logger.warning("load_loopback(%s → %s) error: %s", source, sink, exc)
-    return None
-
-
-def unload_module(module_id: int) -> bool:
-    """Unload a PA module by index. Returns True on success."""
-    if module_id is None or module_id < 0:
-        return False
-    try:
-        r = subprocess.run(
-            ['pactl', 'unload-module', str(module_id)],
-            capture_output=True, text=True, timeout=5,
-        )
-        if r.returncode == 0:
-            logger.debug("Unloaded PA module %d", module_id)
-            return True
-        logger.debug("unload_module(%d) failed: %s", module_id, r.stderr.strip())
-    except Exception as exc:
-        logger.debug("unload_module(%d) error: %s", module_id, exc)
-    return False
-
-
-# Async wrappers (run subprocess in executor to avoid blocking event loop)
-
-async def aload_null_sink(sink_name: str, description: str) -> int | None:
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, load_null_sink, sink_name, description)
-
-
-async def aload_loopback(source: str, sink: str, latency_msec: int = 50) -> int | None:
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, load_loopback, source, sink, latency_msec)
-
-
-async def aunload_module(module_id: int) -> bool:
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, unload_module, module_id)
+        logger.debug("get_sink_input_ids error: %s", exc)
+    return ids


### PR DESCRIPTION
## Problem
PipeWire (HAOS audio system) does not support `pactl load-module`. The null-sink + loopback approach failed with `Module initialization failed` on every device.

## Solution
Use `pactl move-sink-input` instead — supported by both PipeWire and PulseAudio.

After each daemon's PA stream is created (on first audio chunk / format change):
1. Diff current sink-input IDs against a pre-start snapshot to identify the new one
2. `pactl move-sink-input {new_id} {target_bt_sink}`
3. `asyncio.Lock` serializes routing to prevent two daemons from claiming the same sink-input

## Changes
- Removed: `load_null_sink`, `load_loopback`, `unload_module` from pulse.py
- Added: `get_sink_input_ids()` sync helper, `_route_stream_to_sink()` in BridgeDaemon
- Removed: null-sink creation from main(), loopback from `_start_sendspin_inner()`
- Version: 2.2.2