### PR TITLE
fix: v2.5.2 — prevent move-sink-input re-anchor feedback loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.2] - 2026-03-03
+
+### Fixed
+- **Re-anchoring loop caused by move-sink-input**: `_ensure_sink_routing()` was called
+  on every `Stream STARTED` event, including re-anchor events triggered by PA stream
+  glitches. Moving a sink-input causes a brief PA interruption → sendspin detects sync
+  error → re-anchor → `Stream STARTED` → move again → infinite loop of re-anchors at
+  playback start.
+  Fixed with `_sink_routed` flag: routing correction runs **once per stream** (reset in
+  `_handle_format_change` on new codec/format, set after first move). Re-anchor events
+  no longer trigger redundant `move-sink-input` calls.
+
 ## [2.5.1] - 2026-03-03
 
 ### Fixed

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ import threading
 import uuid as _uuid
 from pathlib import Path
 
-VERSION = "2.5.1"
+VERSION = "2.5.2"
 BUILD_DATE = "2026-03-03"
 
 DEFAULT_CONFIG = {

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.2] - 2026-03-03
+
+### Fixed
+- **Re-anchoring loop at playback start**: `move-sink-input` was firing on every
+  stream re-anchor, causing a feedback loop. Now runs once per stream session only.
+
 ## [2.5.1] - 2026-03-03
 
 ### Fixed

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "2.5.1"
+version: "2.5.2"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"

--- a/services/bridge_daemon.py
+++ b/services/bridge_daemon.py
@@ -66,6 +66,7 @@ class BridgeDaemon(SendspinDaemon):
         self._bluetooth_sink_name = bluetooth_sink_name
         self._on_volume_save = on_volume_save
         self._on_status_change = on_status_change
+        self._sink_routed = False  # True after first move-sink-input for current stream
 
     def _notify(self) -> None:
         """Notify subscriber that status has changed (no-op if no callback)."""
@@ -169,6 +170,7 @@ class BridgeDaemon(SendspinDaemon):
     def _handle_format_change(self, codec: str | None, sample_rate: int, bit_depth: int, channels: int) -> None:
         super()._handle_format_change(codec, sample_rate, bit_depth, channels)
         self._bridge_status["audio_format"] = f"{codec or 'PCM'} {sample_rate}Hz/{bit_depth}-bit/{channels}ch"
+        self._sink_routed = False  # new stream — allow one routing correction
         self._notify()
 
     def _on_stream_event(self, event: str) -> None:
@@ -178,9 +180,11 @@ class BridgeDaemon(SendspinDaemon):
             self._bridge_status["playing"] = is_playing
             self._bridge_status["state_changed_at"] = datetime.now().isoformat()
             self._notify()
-        if event == "start" and self._bluetooth_sink_name:
-            # Correct any stream that PulseAudio's module-rescue-streams may have
-            # moved to the default sink when a BT sink disappeared temporarily.
+        if event == "start" and self._bluetooth_sink_name and not self._sink_routed:
+            # Correct any stream PA module-rescue-streams moved to the default sink.
+            # Guard with _sink_routed so we only move once per stream — moving a
+            # sink-input causes a PA glitch that triggers re-anchoring, creating a loop.
+            self._sink_routed = True
             asyncio.ensure_future(self._ensure_sink_routing())
         logger.debug("[%s] stream event: %s", self._bridge_status.get("player_name", "?"), event)
 


### PR DESCRIPTION
## Root cause

`_ensure_sink_routing()` was called on **every** `Stream STARTED` event, including re-anchor events triggered by sendspin's sync algorithm.

Moving a sink-input causes a brief PA stream interruption → sendspin detects sync error → re-anchors → new `Stream STARTED` → move again → loop.

This explains the 1-2 second silence at every playback start and the log pattern:
```
Stream STARTED → Corrected 1 sink-input → Sync error 600ms → Stream STARTED → Sync error → ...
```

## Fix

Added `_sink_routed` flag in `BridgeDaemon`:
- Reset to `False` in `_handle_format_change` (new codec = genuinely new stream)
- Set to `True` after first `_ensure_sink_routing()` call
- Re-anchor events skip the move entirely