### PR TITLE
fix: always register METADATA and CONTROLLER roles for track info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.3] - 2026-03-03
+
+### Fixed
+- **Track title and artist not displayed in device cards**: The bridge was only
+  registering the `PLAYER` role with the MA server (not `METADATA` or `CONTROLLER`).
+  The server only sends metadata (title/artist) to clients with the `METADATA` role.
+  Fixed by always including `METADATA` and `CONTROLLER` roles regardless of MPRIS
+  availability — MPRIS is a D-Bus feature irrelevant to metadata role assignment.
+
 ## [2.5.2] - 2026-03-03
 
 ### Fixed

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ import threading
 import uuid as _uuid
 from pathlib import Path
 
-VERSION = "2.5.2"
+VERSION = "2.5.3"
 BUILD_DATE = "2026-03-03"
 
 DEFAULT_CONFIG = {

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.3] - 2026-03-03
+
+### Fixed
+- **Track title and artist not shown in device cards**: METADATA role was not registered
+  with the server — only PLAYER role was used. Server requires METADATA role to send track info.
+
 ## [2.5.2] - 2026-03-03
 
 ### Fixed

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "2.5.2"
+version: "2.5.3"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"

--- a/services/bridge_daemon.py
+++ b/services/bridge_daemon.py
@@ -87,11 +87,6 @@ class BridgeDaemon(SendspinDaemon):
         from sendspin.audio import detect_supported_audio_formats
 
         try:
-            from aiosendspin_mpris import MPRIS_AVAILABLE
-        except ImportError:
-            MPRIS_AVAILABLE = False
-
-        try:
             sw_ver = f"aiosendspin {_pkg_version('aiosendspin')}"
         except Exception:
             sw_ver = "aiosendspin"
@@ -103,9 +98,8 @@ class BridgeDaemon(SendspinDaemon):
         )
 
         assert self._audio_handler is not None
-        client_roles = [Roles.PLAYER]
-        if MPRIS_AVAILABLE and self._args.use_mpris:
-            client_roles.extend([Roles.METADATA, Roles.CONTROLLER])
+        client_roles = [Roles.PLAYER, Roles.METADATA, Roles.CONTROLLER]
+        # MPRIS is handled separately (requires D-Bus session bus, not available in subprocesses)
 
         supported_formats = detect_supported_audio_formats(self._args.audio_device.index)
         if self._args.preferred_format is not None:


### PR DESCRIPTION
## Problem

Device cards showed no track title/artist during playback since v2.5.0.

## Root Cause

In subprocess isolation mode, `use_mpris=False` is always set (subprocesses don't have a D-Bus session bus for MPRIS). The role registration code was:

```python
client_roles = [Roles.PLAYER]
if MPRIS_AVAILABLE and self._args.use_mpris:
    client_roles.extend([Roles.METADATA, Roles.CONTROLLER])
```

Since `use_mpris=False`, only `Roles.PLAYER` was registered. The MA server only sends metadata (title/artist) to clients with the `METADATA` role — so no metadata was ever delivered.

## Fix

`METADATA` and `CONTROLLER` roles are independent of MPRIS. MPRIS is a D-Bus desktop integration feature; `METADATA` just means "I want to receive track info from the server". Always include both roles:

```python
client_roles = [Roles.PLAYER, Roles.METADATA, Roles.CONTROLLER]
# MPRIS is handled separately (requires D-Bus session bus, not available in subprocesses)
```

Bumps version to v2.5.3.