### PR TITLE
fix: track re-anchor count and sync status in device card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.4] - 2026-03-04
+
+### Fixed
+- **Sync status empty in device card (re-anchor count, reanchoring flag)**: The subprocess
+  status dict was missing `reanchor_count`, `reanchoring`, and `last_sync_error_ms` fields.
+  Added tracking via `_JsonLineHandler` — re-anchor log messages from `sendspin/audio.py`
+  (`"Sync error … re-anchoring"`) are intercepted and update the status dict in real time.
+  `reanchoring` flag is cleared when the stream restarts successfully. Counter resets on
+  new stream (`_handle_format_change`).
+
 ## [2.5.3] - 2026-03-03
 
 ### Fixed

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ import threading
 import uuid as _uuid
 from pathlib import Path
 
-VERSION = "2.5.3"
+VERSION = "2.5.4"
 BUILD_DATE = "2026-03-03"
 
 DEFAULT_CONFIG = {

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.4] - 2026-03-04
+
+### Fixed
+- **Sync status empty in device card**: re-anchor count and reanchoring flag were not
+  tracked in subprocess mode. Now intercepted from log messages in real time.
+
 ## [2.5.3] - 2026-03-03
 
 ### Fixed

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "2.5.3"
+version: "2.5.4"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"

--- a/services/bridge_daemon.py
+++ b/services/bridge_daemon.py
@@ -164,6 +164,8 @@ class BridgeDaemon(SendspinDaemon):
     def _handle_format_change(self, codec: str | None, sample_rate: int, bit_depth: int, channels: int) -> None:
         super()._handle_format_change(codec, sample_rate, bit_depth, channels)
         self._bridge_status["audio_format"] = f"{codec or 'PCM'} {sample_rate}Hz/{bit_depth}-bit/{channels}ch"
+        self._bridge_status["reanchor_count"] = 0  # reset per-stream re-anchor counter
+        self._bridge_status["reanchoring"] = False
         self._sink_routed = False  # new stream — allow one routing correction
         self._notify()
 
@@ -173,6 +175,10 @@ class BridgeDaemon(SendspinDaemon):
         if self._bridge_status.get("playing") != is_playing:
             self._bridge_status["playing"] = is_playing
             self._bridge_status["state_changed_at"] = datetime.now().isoformat()
+            self._notify()
+        # Clear reanchoring flag once the stream has restarted successfully
+        if event == "start" and self._bridge_status.get("reanchoring"):
+            self._bridge_status["reanchoring"] = False
             self._notify()
         if event == "start" and self._bluetooth_sink_name and not self._sink_routed:
             # Correct any stream PA module-rescue-streams moved to the default sink.

--- a/services/daemon_process.py
+++ b/services/daemon_process.py
@@ -33,18 +33,49 @@ import sys
 
 _LOG_LEVELS = {"DEBUG": 10, "INFO": 20, "WARNING": 30, "ERROR": 40, "CRITICAL": 50}
 
+# Pattern that audio.py logs when re-anchoring is triggered
+_REANCHOR_MSG = "re-anchoring"
+_SYNC_ERROR_PREFIX = "Sync error "
+
 
 class _JsonLineHandler(logging.Handler):
     """Emit log records as {"type":"log", ...} JSON lines on stdout."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._status: dict | None = None
+        self._on_status_change: object = None
+
+    def set_status(self, status: dict, on_status_change) -> None:
+        """Attach the shared status dict so re-anchor events update it."""
+        self._status = status
+        self._on_status_change = on_status_change
+
     def emit(self, record: logging.LogRecord) -> None:
         try:
+            msg = self.format(record)
+            # Detect re-anchor log message from sendspin/audio.py
+            if self._status is not None and _REANCHOR_MSG in msg:
+                self._status["reanchor_count"] = self._status.get("reanchor_count", 0) + 1
+                self._status["reanchoring"] = True
+                # Extract sync error value if present: "Sync error 123.4 ms too large; re-anchoring"
+                if _SYNC_ERROR_PREFIX in msg:
+                    try:
+                        after = msg.split(_SYNC_ERROR_PREFIX, 1)[1]
+                        self._status["last_sync_error_ms"] = float(after.split()[0])
+                    except (IndexError, ValueError):
+                        pass
+                if callable(self._on_status_change):
+                    try:
+                        self._on_status_change()
+                    except Exception:
+                        pass
             line = json.dumps(
                 {
                     "type": "log",
                     "level": record.levelname.lower(),
                     "name": record.name,
-                    "msg": self.format(record),
+                    "msg": msg,
                 }
             )
             print(line, flush=True)
@@ -52,11 +83,14 @@ class _JsonLineHandler(logging.Handler):
             pass
 
 
+_json_handler = _JsonLineHandler()
+
+
 def _setup_logging() -> None:
     root = logging.getLogger()
     root.setLevel(logging.INFO)
     root.handlers.clear()
-    root.addHandler(_JsonLineHandler())
+    root.addHandler(_json_handler)
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +215,9 @@ async def _run(params: dict) -> None:
         "group_id": None,
         "connected_server_url": None,
         "last_error": None,
+        "reanchor_count": 0,
+        "reanchoring": False,
+        "last_sync_error_ms": None,
     }
 
     # Emit initial status so parent knows subprocess is alive
@@ -191,6 +228,9 @@ async def _run(params: dict) -> None:
 
     def _on_status_change() -> None:
         _emit_status(status)
+
+    # Wire the log handler so re-anchor log messages update status
+    _json_handler.set_status(status, _on_status_change)
 
     daemon = BridgeDaemon(
         args=args,


### PR DESCRIPTION
## Problem

The **Sync** row in device cards was always empty — re-anchor count, `reanchoring` flag, and `last_sync_error_ms` were never set.

## Root Cause

The subprocess status dict (`daemon_process.py`) didn't include `reanchor_count`, `reanchoring`, or `last_sync_error_ms` fields. These fields exist in the parent `sendspin_client.py` status init but were never populated from the subprocess.

Re-anchoring is an internal `sendspin/audio.py` mechanism — there's no callback, only a log message: `"Sync error 123.4 ms too large; re-anchoring"`.

## Fix

`_JsonLineHandler` now intercepts log records containing `"re-anchoring"`:
- Increments `status['reanchor_count']`
- Sets `status['reanchoring'] = True`  
- Parses sync error value from `"Sync error X.X ms…"` into `status['last_sync_error_ms']`
- Calls `_on_status_change()` to immediately emit updated status to parent

`BridgeDaemon._on_stream_event` clears `reanchoring = False` on stream restart.  
`_handle_format_change` resets counter to 0 on each new stream.

Bumps version to v2.5.4.