### PR TITLE
fix: add Format column header and grid for preferred_format in config UI

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -507,6 +507,7 @@ async function refreshLogs() {
 // ---- Group Controls ----
 
 var _groupSelected = {};   // index → true/false
+var _groupFilter = '';     // current group filter value ('' = all groups)
 
 function _getSelectedNames() {
     var names = [];
@@ -518,6 +519,48 @@ function _getSelectedNames() {
     return names;
 }
 
+function _updateGroupFilter() {
+    var sel = document.getElementById('group-filter-sel');
+    if (!sel || !lastDevices) return;
+    // Collect unique group names from current devices
+    var groups = [];
+    lastDevices.forEach(function(dev) {
+        var g = dev.group_name || (dev.group_id ? dev.group_id.split('-').pop() : '');
+        if (g && groups.indexOf(g) === -1) groups.push(g);
+    });
+    // Rebuild options, preserving current selection
+    var cur = sel.value;
+    sel.innerHTML = '<option value="">All groups</option>';
+    groups.sort().forEach(function(g) {
+        var opt = document.createElement('option');
+        opt.value = g;
+        opt.textContent = '\uD83D\uDD17 ' + g;
+        sel.appendChild(opt);
+    });
+    // Hide/show based on whether any groups exist
+    sel.style.display = groups.length ? '' : 'none';
+    // Restore selection if group still exists
+    if (cur && groups.indexOf(cur) !== -1) {
+        sel.value = cur;
+    } else if (cur && groups.indexOf(cur) === -1) {
+        sel.value = '';
+        _groupFilter = '';
+    }
+}
+
+function onGroupFilterChange(val) {
+    _groupFilter = val;
+    if (!lastDevices) return;
+    lastDevices.forEach(function(dev, i) {
+        var g = dev.group_name || (dev.group_id ? dev.group_id.split('-').pop() : '');
+        var inGroup = !val || g === val;
+        _groupSelected[i] = inGroup;
+        var cb = document.getElementById('dsel-' + i);
+        if (cb) cb.checked = inGroup;
+    });
+    _updateGroupPanel();
+}
+
 function _updateGroupPanel() {
     var total = lastDevices ? lastDevices.length : 0;
     if (total < 2) {
@@ -525,6 +568,7 @@ function _updateGroupPanel() {
         return;
     }
     document.getElementById('group-controls').style.display = 'flex';
+    _updateGroupFilter();
     var sel = _getSelectedNames().length;
     var info = document.getElementById('group-select-info');
     if (info) info.textContent = sel === total ? 'All ' + total + ' players' : sel + ' of ' + total + ' selected';
@@ -589,11 +633,10 @@ function onPauseAll() {
     var btn = document.getElementById('group-pause-btn');
     var isPaused = btn && btn.classList.contains('paused');
     var action = isPaused ? 'play' : 'pause';
-    fetch(API_BASE + '/api/pause_all', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({action: action})
-    }).then(function(r) { return r.json(); }).then(function() {
+    var names = _getSelectedNames();
+    var total = lastDevices ? lastDevices.length : 0;
+
+    var afterPause = function() {
         if (btn) {
             if (action === 'pause') {
                 btn.textContent = '\u25b6 Unpause All';
@@ -603,7 +646,26 @@ function onPauseAll() {
                 btn.classList.remove('paused');
             }
         }
-    });
+    };
+
+    if (names.length === total) {
+        // All players — use bulk MPRIS pause
+        fetch(API_BASE + '/api/pause_all', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({action: action})
+        }).then(function(r) { return r.json(); }).then(afterPause);
+    } else {
+        // Filtered selection — call individual pause per player
+        var calls = names.map(function(name) {
+            return fetch(API_BASE + '/api/pause', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({action: action, player_name: name})
+            });
+        });
+        Promise.all(calls).then(afterPause);
+    }
 }
 
 function onDevicePause(i) {

--- a/static/style.css
+++ b/static/style.css
@@ -119,6 +119,12 @@
             text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap;
         }
         .group-select-info { font-size: 12px; color: var(--secondary-text-color); white-space: nowrap; }
+        .group-filter-sel {
+            padding: 3px 8px; font-size: 12px; border: 1px solid var(--divider-color);
+            border-radius: 5px; background: var(--card-background-color);
+            color: var(--primary-text-color); cursor: pointer; max-width: 160px;
+        }
+        .group-filter-sel:focus { outline: none; border-color: var(--primary-color); }
         .group-vol-row { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 180px; }
         .group-vol-slider { flex: 1; height: 4px; accent-color: var(--primary-color); cursor: pointer; }
         .group-vol-pct { min-width: 36px; font-size: 13px; color: var(--secondary-text-color); text-align: right; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,6 +50,9 @@
     <!-- Group Controls -->
     <div class="group-controls" id="group-controls" style="display:none;">
         <span class="group-controls-label">&#127922; Group</span>
+        <select id="group-filter-sel" class="group-filter-sel" onchange="onGroupFilterChange(this.value)" title="Filter by MA sync group">
+            <option value="">All groups</option>
+        </select>
         <span class="group-select-info" id="group-select-info">All players</span>
         <label style="display:flex;align-items:center;gap:5px;font-size:12px;color:#6b7280;cursor:pointer;">
             <input type="checkbox" id="group-select-all" checked onchange="onGroupSelectAll(this)">


### PR DESCRIPTION
Fixes layout regression: bt-device-row grid had 7 columns but preferred_format added an 8th input without updating the template.

- Add 'Format' header span to bt-header in index.html
- Update grid-template-columns from 7 to 8 columns in .bt-header and .bt-device-row
- Bump mobile min-width from 560px to 700px to accommodate new column