### PR TITLE
fix: emit status update after set_volume in daemon subprocess

### DIFF
--- a/services/daemon_process.py
+++ b/services/daemon_process.py
@@ -143,6 +143,7 @@ async def _read_commands(daemon_ref: list, stop_event: asyncio.Event) -> None:
                 vol = int(cmd["value"])
                 daemon._bridge_status["volume"] = vol
                 daemon._sync_bt_sink_volume(vol)
+                daemon._notify()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem\n\nWhen the parent sends a `set_volume` command to the daemon subprocess, `_read_commands` was updating `_bridge_status['volume']` and calling `_sync_bt_sink_volume()` but never calling `_notify()` to emit the updated status back to the parent.\n\nThis meant the web UI would not reflect volume changes triggered via this code path, unlike the `_handle_server_command` path which does call `_notify()`.\n\n## Fix\n\nAdd `daemon._notify()` call after the mutation, consistent with all other state-change handlers.