### PR TITLE
fix: sync column delay badge and re-anchor warning duration

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -314,6 +314,8 @@ function populateDeviceCard(i, dev) {
         if (delay !== undefined && delay !== null && delay !== 0) {
             delayEl.textContent = 'delay: ' + (delay > 0 ? '+' : '') + delay + 'ms';
             delayEl.style.display = '';
+            // Orange only when active; gray for offline/idle devices
+            delayEl.style.color = dev.playing ? '#f59e0b' : '#9ca3af';
         } else {
             delayEl.style.display = 'none';
         }
@@ -336,7 +338,7 @@ function populateDeviceCard(i, dev) {
                 ? 'Error: ' + dev.last_sync_error_ms.toFixed(1) + ' ms' : '';
         } else {
             // After reanchoring=False: keep showing the warning for abs(static_delay_ms) ms
-            var warningDuration = Math.abs(dev.static_delay_ms || 0) || 3000;
+            var warningDuration = Math.max(Math.abs(dev.static_delay_ms || 0), 3000);
             var shownAt = reanchorShownAt[i];
             if (shownAt && (Date.now() - shownAt) < warningDuration) {
                 syncEl.innerHTML = '<span style="color:#f59e0b;">&#9888; Re-anchoring</span>';


### PR DESCRIPTION
## Summary

- **Delay badge color**: `delay: -600ms` badge is now gray for non-playing/offline devices and orange only when device is actively playing. Previously all devices with a non-zero `static_delay_ms` showed an orange badge, making offline devices look like they had a warning condition.
- **Re-anchor warning duration**: Changed `Math.abs(delay) || 3000` → `Math.max(Math.abs(delay), 3000)` — for devices with `-600ms` delay, the old 600ms window was shorter than a typical SSE update interval (~1–2 s), so the post-re-anchor transition banner was invisible in practice. Now minimum 3 s.

## Test plan

- [ ] Playing device with `static_delay_ms ≠ 0` → delay badge is orange
- [ ] Disconnected/non-playing device with `static_delay_ms ≠ 0` → delay badge is gray
- [ ] After re-anchor completes (`reanchoring` flips to `false`), warning stays visible ≥ 3 s before switching to "✓ In sync"

🤖 Generated with [Claude Code](https://claude.com/claude-code)