### PR TITLE
ui: compact connection column with BT/MA labeled rows

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -148,20 +148,22 @@ function buildDeviceCard(i) {
         '</div>' +
         '<div class="device-rows">' +
           // Connection column (BT + MA server merged)
-          '<div>' +
+          '<div class="conn-col">' +
             '<div class="status-label">Connection</div>' +
-            '<div class="status-value">' +
+            '<div class="conn-row">' +
+              '<span class="conn-tag">BT</span>' +
               '<span class="status-indicator" id="dbt-ind-' + i + '"></span>' +
               '<span id="dbt-txt-' + i + '">-</span>' +
+              '<span class="conn-detail" id="dbt-adapter-' + i + '"></span>' +
+              '<span class="conn-since" id="dbt-since-' + i + '"></span>' +
             '</div>' +
-            '<div class="ts" id="dbt-since-' + i + '"></div>' +
-            '<div class="ts-sub" id="dbt-adapter-' + i + '"></div>' +
-            '<div class="status-value" style="margin-top:6px;">' +
+            '<div class="conn-row">' +
+              '<span class="conn-tag">MA</span>' +
               '<span class="status-indicator" id="dsrv-ind-' + i + '"></span>' +
               '<span id="dsrv-txt-' + i + '">-</span>' +
+              '<span class="conn-detail" id="dsrv-uri-' + i + '"></span>' +
+              '<span class="conn-since" id="dsrv-since-' + i + '"></span>' +
             '</div>' +
-            '<div class="ts-sub" id="dsrv-uri-' + i + '"></div>' +
-            '<div class="ts" id="dsrv-since-' + i + '"></div>' +
           '</div>' +
           // Playback column (with inline track)
           '<div>' +

--- a/static/style.css
+++ b/static/style.css
@@ -429,6 +429,29 @@
         }
         .card-icon-btn:hover { background: var(--secondary-background-color); }
 
+        /* Connection column compact rows */
+        .conn-row {
+            display: flex; align-items: center; gap: 4px;
+            font-size: 12px; margin-top: 5px;
+            overflow: hidden;
+        }
+        .conn-tag {
+            font-size: 10px; font-weight: 700; text-transform: uppercase;
+            color: var(--secondary-text-color); width: 18px; flex-shrink: 0;
+        }
+        .conn-detail {
+            font-size: 11px; color: var(--secondary-text-color);
+            overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+            flex: 1; min-width: 0;
+        }
+        .conn-since {
+            font-size: 11px; color: var(--secondary-text-color);
+            flex-shrink: 0; margin-left: auto; padding-left: 4px;
+            white-space: nowrap;
+        }
+        .conn-row .status-indicator { margin-right: 3px; }
+        .conn-row > span:nth-child(3) { font-size: 13px; font-weight: 600; flex-shrink: 0; }
+
         /* Volume column — sink name hidden, revealed on hover */
         .volume-col .dsink-value { display: none; font-size: 11px; }
         .volume-col:hover .dsink-value,


### PR DESCRIPTION
## Summary

- Restructures the device card connection column to show BT and MA status as separate labeled rows (`BT` / `MA` tags)
- Each row uses a flex `conn-row` layout with inline status indicator, text, detail, and since fields
- Replaces the previous stacked `ts`/`ts-sub` divs with cleaner, overflow-safe CSS classes (`conn-tag`, `conn-detail`, `conn-since`)

## Test plan

- [ ] Verify BT and MA rows display correctly in device cards
- [ ] Check that detail (adapter, URI) and since fields render inline with proper truncation
- [ ] Confirm layout holds on narrow/wide screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)