### PR TITLE
chore: bump version to 2.6.4

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ import threading
 import uuid as _uuid
 from pathlib import Path
 
-VERSION = "2.6.3"
+VERSION = "2.6.4"
 BUILD_DATE = "2026-03-04"
 
 DEFAULT_CONFIG = {

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "2.6.3"
+version: "2.6.4"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"


### PR DESCRIPTION
## Summary

- Bumps `VERSION` in `config.py` to `2.6.4`
- Bumps `version` in `ha-addon/config.yaml` to `2.6.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)