### PR TITLE
ui: UX polish pass — hover actions, sort, eq-bars inline, form reorder (v2.6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.5] - 2026-03-04
+
+### Improved
+- **Web UI — Action buttons on hover**: Reconnect / Re-pair / Release buttons are hidden by default and revealed on card hover (always visible on mobile), reducing visual clutter
+- **Web UI — MAC and URL on hover**: device MAC address and WebSocket URL in the identity column are hidden by default and revealed on hover
+- **Web UI — Sort disconnected to bottom**: device cards sorted by activity — Playing first, then BT connected, then disconnected
+- **Web UI — EQ bars inline**: animated EQ bars moved inside the volume row (before the slider), visible only during active audio streaming
+- **Web UI — Audio format in Volume column**: stream format moved from Playback column to Volume column, shown in secondary text color
+- **Web UI — Adapter tooltip**: BT adapter shown as `hciN` only; full controller MAC visible in tooltip on hover
+- **Web UI — Delay color**: `delay: Xms` badge uses secondary text color; amber only when `|delay| > 1000 ms`
+- **Web UI — Secondary text colors**: audio format, ws:// URL, and delay badge use `--secondary-text-color` instead of the accent blue
+- **Web UI — Pause button hidden on No Sink**: pause/play button hidden when BT is connected but audio sink is not yet configured
+- **Web UI — Inactive devices deselected**: group-control checkbox auto-unchecked for disconnected/inactive devices
+- **Configuration form order**: Bridge Name and Timezone promoted to top; MA server/port moved into Advanced settings (alongside latency, BT intervals, codec)
+
 ## [2.6.3] - 2026-03-04
 
 ### Fixed

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ import threading
 import uuid as _uuid
 from pathlib import Path
 
-VERSION = "2.6.4"
+VERSION = "2.6.5"
 BUILD_DATE = "2026-03-04"
 
 DEFAULT_CONFIG = {

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Sendspin Bluetooth Bridge"
-version: "2.6.4"
+version: "2.6.5"
 slug: "sendspin_bt_bridge"
 description: "Bridge Music Assistant Sendspin protocol to Bluetooth speakers"
 url: "https://github.com/trudenboy/sendspin-bt-bridge"

--- a/static/app.js
+++ b/static/app.js
@@ -98,18 +98,22 @@ async function updateStatus() {
         if (sysEl) sysEl.textContent = info.join(' \u00b7 ');
 
         var devices = status.devices || [status];
+        var sorted = devices.slice().sort(function(a, b) {
+            var score = function(d) { return d.playing ? 2 : (d.bluetooth_connected ? 1 : 0); };
+            return score(b) - score(a);
+        });
         // Reset index-keyed state if device list changes (avoids stale mappings)
-        if (lastDevices.length !== devices.length ||
-            !lastDevices.every(function(d, idx) { return d.player_name === devices[idx].player_name; })) {
+        if (lastDevices.length !== sorted.length ||
+            !lastDevices.every(function(d, idx) { return d.player_name === sorted[idx].player_name; })) {
             _groupSelected = {};
             lastReanchorCount = {};
             reanchorShownAt = {};
             lastReanchorAt = {};
         }
-        lastDevices = devices;
+        lastDevices = sorted;
         var grid = document.getElementById('status-grid');
 
-        devices.forEach(function(dev, i) {
+        sorted.forEach(function(dev, i) {
             var card = document.getElementById('device-card-' + i);
             if (!card) {
                 card = buildDeviceCard(i);
@@ -120,11 +124,11 @@ async function updateStatus() {
 
         // Remove stale cards
         Array.from(grid.querySelectorAll('.device-card'))
-            .slice(devices.length)
+            .slice(sorted.length)
             .forEach(function(c) { c.remove(); });
 
         _updateGroupPanel();
-        updateHealthIndicator(devices);
+        updateHealthIndicator(sorted);
 
     } catch (err) {
         console.error('Status update failed:', err);
@@ -143,8 +147,8 @@ function buildDeviceCard(i) {
             '<div class="device-card-title" id="dname-' + i + '">Device ' + (i+1) + '</div>' +
           '</div>' +
           '<div class="group-badge" id="dgroup-' + i + '" style="display:none"></div>' +
-          '<div class="device-mac" id="dmac-' + i + '"></div>' +
-          '<div class="ts-sub" id="durl-' + i + '"></div>' +
+          '<div class="device-mac identity-detail" id="dmac-' + i + '"></div>' +
+          '<div class="ts-sub identity-detail" id="durl-' + i + '"></div>' +
         '</div>' +
         '<div class="device-rows">' +
           // Connection column (BT + MA server merged)
@@ -162,7 +166,6 @@ function buildDeviceCard(i) {
               '<span class="status-indicator" id="dsrv-ind-' + i + '"></span>' +
               '<span id="dsrv-txt-' + i + '">-</span>' +
               '<span class="conn-detail" id="dsrv-uri-' + i + '"></span>' +
-              '<span class="conn-since" id="dsrv-since-' + i + '"></span>' +
             '</div>' +
           '</div>' +
           // Playback column (with inline track)
@@ -177,12 +180,15 @@ function buildDeviceCard(i) {
             '</div>' +
             '<div id="dtrack-' + i + '" class="device-track-inline"></div>' +
             '<div class="ts" id="dplay-since-' + i + '"></div>' +
-            '<div class="ts-sub" id="daudiofmt-' + i + '"></div>' +
           '</div>' +
           // Volume column
           '<div class="volume-col">' +
             '<div class="status-label">Volume</div>' +
             '<div class="volume-row">' +
+              '<div class="eq-bars" id="deq-' + i + '">' +
+                '<div class="eq-bar"></div><div class="eq-bar"></div>' +
+                '<div class="eq-bar"></div><div class="eq-bar"></div>' +
+              '</div>' +
               '<input type="range" min="0" max="100" value="100" ' +
                 'class="volume-slider" id="vslider-' + i + '" ' +
                 'oninput="onVolumeInput(' + i + ', this.value)">' +
@@ -192,17 +198,14 @@ function buildDeviceCard(i) {
                 'title="Mute/Unmute">&#128264;</button>' +
             '</div>' +
             '<div class="dsink-value ts-sub" id="dsink-' + i + '" style="margin-top:3px;"></div>' +
-            '<div class="eq-bars" id="deq-' + i + '">' +
-              '<div class="eq-bar"></div><div class="eq-bar"></div>' +
-              '<div class="eq-bar"></div><div class="eq-bar"></div>' +
-            '</div>' +
+            '<div class="ts" id="daudiofmt-' + i + '"></div>' +
           '</div>' +
           // Sync column
           '<div>' +
             '<div class="status-label">Sync</div>' +
             '<div class="status-value" id="dsync-' + i + '">&#8212;</div>' +
             '<div class="ts" id="dsync-detail-' + i + '"></div>' +
-            '<div class="ts" id="ddelay-' + i + '" style="display:none;color:#f59e0b;"></div>' +
+            '<div class="ts" id="ddelay-' + i + '" style="display:none;"></div>' +
           '</div>' +
         '</div>' +
         '<div class="device-card-actions">' +
@@ -230,6 +233,13 @@ function populateDeviceCard(i, dev) {
         var isActive = dev.bluetooth_connected || dev.playing;
         card.classList.toggle('inactive', !isActive);
         card.classList.toggle('playing', !!dev.playing);
+        if (!isActive) {
+            var selCb = document.getElementById('dsel-' + i);
+            if (selCb && selCb.checked) {
+                selCb.checked = false;
+                _groupSelected[i] = false;
+            }
+        }
     }
 
     var groupBadge = document.getElementById('dgroup-' + i);
@@ -245,10 +255,8 @@ function populateDeviceCard(i, dev) {
 
     var btAdapterEl = document.getElementById('dbt-adapter-' + i);
     if (btAdapterEl) {
-        var parts = [];
-        if (dev.bluetooth_adapter_hci) parts.push(dev.bluetooth_adapter_hci);
-        if (dev.bluetooth_adapter) parts.push(dev.bluetooth_adapter);
-        btAdapterEl.textContent = parts.join(' ');
+        btAdapterEl.textContent = dev.bluetooth_adapter_hci || '';
+        if (dev.bluetooth_adapter) btAdapterEl.title = (dev.bluetooth_adapter_hci ? dev.bluetooth_adapter_hci + ' ' : '') + dev.bluetooth_adapter;
     }
 
     var urlEl = document.getElementById('durl-' + i);
@@ -281,9 +289,8 @@ function populateDeviceCard(i, dev) {
     if (btSince) btSince.textContent = formatSince(dev.bluetooth_connected_at);
 
     // Server
-    var srvInd   = document.getElementById('dsrv-ind-' + i);
-    var srvTxt   = document.getElementById('dsrv-txt-' + i);
-    var srvSince = document.getElementById('dsrv-since-' + i);
+    var srvInd = document.getElementById('dsrv-ind-' + i);
+    var srvTxt = document.getElementById('dsrv-txt-' + i);
     if (dev.server_connected) {
         srvInd.className = 'status-indicator active';
         srvTxt.textContent = 'Connected';
@@ -291,7 +298,6 @@ function populateDeviceCard(i, dev) {
         srvInd.className = 'status-indicator inactive';
         srvTxt.textContent = dev.error || 'Disconnected';
     }
-    if (srvSince) srvSince.textContent = formatSince(dev.server_connected_at);
     var srvUri = document.getElementById('dsrv-uri-' + i);
     if (srvUri) {
         var srvLabel = '';
@@ -351,6 +357,7 @@ function populateDeviceCard(i, dev) {
             pauseBtn.classList.add('paused');
             pauseBtn.title = 'Unpause';
         }
+        pauseBtn.style.display = (!dev.has_sink && dev.bluetooth_mac) ? 'none' : '';
     }
 
     var trackEl = document.getElementById('dtrack-' + i);
@@ -373,7 +380,7 @@ function populateDeviceCard(i, dev) {
         if (dev.playing && delay !== undefined && delay !== null && delay !== 0) {
             delayEl.textContent = 'delay: ' + (delay > 0 ? '+' : '') + delay + 'ms';
             delayEl.style.display = '';
-            delayEl.style.color = '#f59e0b';
+            delayEl.style.color = Math.abs(delay) > 1000 ? '#f59e0b' : 'var(--secondary-text-color)';
         } else {
             delayEl.style.display = 'none';
         }

--- a/static/style.css
+++ b/static/style.css
@@ -97,7 +97,15 @@
         .device-card-actions {
             grid-column: 1 / -1; grid-row: 2;
             display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
-            padding-top: 10px; margin-top: 10px; border-top: 1px solid var(--divider-color);
+            max-height: 0; overflow: hidden; opacity: 0;
+            padding-top: 0; margin-top: 0; border-top: none;
+            transition: max-height 0.2s, opacity 0.15s, padding-top 0.2s, margin-top 0.2s;
+        }
+        .device-card:hover .device-card-actions,
+        .device-card:focus-within .device-card-actions {
+            max-height: 60px; opacity: 1;
+            padding-top: 10px; margin-top: 10px;
+            border-top: 1px solid var(--divider-color);
         }
         .device-track-inline {
             font-size: 12px; color: var(--secondary-text-color);
@@ -166,6 +174,13 @@
         .device-mac {
             font-size: 11px; color: var(--secondary-text-color); font-family: 'Courier New', monospace;
         }
+        .device-card-identity .identity-detail {
+            max-height: 0; overflow: hidden; opacity: 0;
+            transition: max-height 0.15s, opacity 0.15s;
+        }
+        .device-card:hover .identity-detail, .device-card:focus-within .identity-detail {
+            max-height: 30px; opacity: 1;
+        }
         .group-badge {
             font-size: 11px; color: var(--secondary-text-color); margin-top: 3px;
             padding: 2px 6px; background: var(--divider-color, rgba(0,0,0,0.08));
@@ -209,9 +224,10 @@
             align-items: flex-end;
             gap: 2px;
             height: 14px;
-            margin-top: 5px;
         }
         .eq-bars.active { display: flex; }
+        .volume-row .eq-bars { display: none; flex-shrink: 0; margin-right: 4px; }
+        .volume-row .eq-bars.active { display: flex; }
         .eq-bar {
             width: 3px;
             border-radius: 1px;
@@ -385,7 +401,7 @@
         .filter-btn:hover { color: var(--primary-text-color); }
         .filter-btn.active { background: var(--primary-color); color: white; }
         .ts     { font-size: 11px; color: var(--secondary-text-color); margin-top: 3px; }
-        .ts-sub { font-size: 11px; color: var(--primary-color); margin-top: 3px; word-break: break-all; }
+        .ts-sub { font-size: 11px; color: var(--secondary-text-color); margin-top: 3px; word-break: break-all; }
 
         /* Diagnostics section */
         .diag-section {
@@ -538,6 +554,9 @@
             /* Sync (5th cell) spans full width */
             .device-rows > div:nth-child(5) { grid-column: 1 / -1; }
             .device-card-actions {
+                max-height: 100px; opacity: 1;
+                padding-top: 10px; margin-top: 10px;
+                border-top: 1px solid var(--divider-color);
                 flex-direction: column; align-items: flex-start;
             }
             .device-track-inline { white-space: normal; word-break: break-word; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,47 +81,9 @@
         <summary>&#9881;&#65039; Configuration</summary>
         <form id="config-form">
             <div class="form-group">
-                <label>Music Assistant server &mdash; IP/hostname, or <code>auto</code> to discover via mDNS</label>
-                <input type="text" name="SENDSPIN_SERVER" placeholder="auto" required>
-            </div>
-
-            <div class="form-group">
-                <label>Music Assistant WebSocket port</label>
-                <input type="number" name="SENDSPIN_PORT" placeholder="9000" min="1024" max="65535">
-            </div>
-
-            <div class="form-group">
                 <label>Bridge name — appended to every player name in MA as <em>Player @ Name</em> (empty = off)</label>
                 <input type="text" name="BRIDGE_NAME" placeholder="e.g. Living Room">
             </div>
-
-            <button type="button" class="config-advanced-toggle" id="adv-toggle"
-                    onclick="toggleAdvanced()">Advanced settings</button>
-            <div class="config-advanced-body" id="adv-body">
-
-            <div class="form-group">
-                <label>PulseAudio latency (ms) — larger value reduces audio dropouts on slow hardware (default 200)</label>
-                <input type="number" name="PULSE_LATENCY_MSEC" placeholder="200" min="50" max="2000">
-            </div>
-
-            <div class="form-group">
-                <label>BT check interval (s) — how often to probe each device connection (default 10)</label>
-                <input type="number" name="BT_CHECK_INTERVAL" placeholder="10" min="5" max="300">
-            </div>
-
-            <div class="form-group">
-                <label>Auto-disable after N failed reconnects — set Enabled=Off after this many consecutive failures (0 = never)</label>
-                <input type="number" name="BT_MAX_RECONNECT_FAILS" placeholder="0" min="0" max="100">
-            </div>
-
-            <div class="form-group">
-                <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
-                    <input type="checkbox" name="PREFER_SBC_CODEC" id="prefer-sbc-codec" style="width:auto;margin:0;">
-                    Prefer SBC codec — forces the simplest A2DP codec after each BT connect, reducing encoder CPU load on slow hardware (requires PulseAudio 15+)
-                </label>
-            </div>
-
-            </div><!-- /adv-body -->
 
             <div class="form-group">
                 <label>Timezone</label>
@@ -207,6 +169,44 @@
                 </div>
             </div>
             {% endif %}
+
+            <button type="button" class="config-advanced-toggle" id="adv-toggle"
+                    onclick="toggleAdvanced()">Advanced settings</button>
+            <div class="config-advanced-body" id="adv-body">
+
+            <div class="form-group">
+                <label>Music Assistant server &mdash; IP/hostname, or <code>auto</code> to discover via mDNS</label>
+                <input type="text" name="SENDSPIN_SERVER" placeholder="auto" required>
+            </div>
+
+            <div class="form-group">
+                <label>Music Assistant WebSocket port</label>
+                <input type="number" name="SENDSPIN_PORT" placeholder="9000" min="1024" max="65535">
+            </div>
+
+            <div class="form-group">
+                <label>PulseAudio latency (ms) — larger value reduces audio dropouts on slow hardware (default 200)</label>
+                <input type="number" name="PULSE_LATENCY_MSEC" placeholder="200" min="50" max="2000">
+            </div>
+
+            <div class="form-group">
+                <label>BT check interval (s) — how often to probe each device connection (default 10)</label>
+                <input type="number" name="BT_CHECK_INTERVAL" placeholder="10" min="5" max="300">
+            </div>
+
+            <div class="form-group">
+                <label>Auto-disable after N failed reconnects — set Enabled=Off after this many consecutive failures (0 = never)</label>
+                <input type="number" name="BT_MAX_RECONNECT_FAILS" placeholder="0" min="0" max="100">
+            </div>
+
+            <div class="form-group">
+                <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+                    <input type="checkbox" name="PREFER_SBC_CODEC" id="prefer-sbc-codec" style="width:auto;margin:0;">
+                    Prefer SBC codec — forces the simplest A2DP codec after each BT connect, reducing encoder CPU load on slow hardware (requires PulseAudio 15+)
+                </label>
+            </div>
+
+            </div><!-- /adv-body -->
         </form>
     </details>
 


### PR DESCRIPTION
## Summary

- Action buttons (Reconnect/Re-pair/Release) hidden until card hover; always visible on mobile
- MAC address and ws:// URL in identity column hidden until hover (`identity-detail`)
- Device cards sorted: playing > BT connected > disconnected
- EQ bars moved inline before volume slider; visible only during audio streaming
- Audio format moved from Playback → Volume column; secondary text color
- BT adapter shows `hciN` only; full MAC in hover tooltip
- Delay badge uses secondary color; amber only when `|delay| > 1000 ms`
- Pause button hidden when no audio sink configured
- Inactive devices auto-deselected in group controls
- Config form reordered: Bridge Name + TZ first; MA server/port moved into Advanced

## Test plan

- [ ] Hover over a device card → MAC, ws:// URL appear; action buttons appear with border
- [ ] Mobile viewport → action buttons always visible
- [ ] Disconnect a device → card moves to bottom of list
- [ ] Audio streaming → EQ bars appear inline before slider
- [ ] Device with `static_delay_ms = -500` → delay shown in secondary color
- [ ] Device with `static_delay_ms = -1500` → delay shown in amber
- [ ] BT adapter column shows `hci0` only; hover shows full MAC tooltip
- [ ] No-sink device → pause button hidden
- [ ] Config section → Bridge Name first, Advanced toggle at bottom with MA server/port inside

🤖 Generated with [Claude Code](https://claude.com/claude-code)