### PR TITLE
fix: missing closing }); in _updateGroupFilter breaks entire UI

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -702,6 +702,7 @@ function _updateGroupFilter() {
     lastDevices.forEach(function(dev) {
         var g = dev.group_name || dev.group_id || '';
         if (g && groups.indexOf(g) === -1) groups.push(g);
+    });
     // Rebuild options, preserving current selection
     var cur = sel.value;
     sel.innerHTML = '<option value="">All groups</option>';


### PR DESCRIPTION
## Problem

The `_updateGroupFilter()` function in `static/app.js` had a missing `});` to close its `forEach` callback. This caused a JS `SyntaxError: missing ) after argument list` that prevented the entire `app.js` from parsing, resulting in a completely blank UI — no device cards rendered at all.

## Fix

Added the missing `});` closing the `forEach` on line 704.

## Reproduce

Load `http://<host>:8080/` — only the header and collapsed sections (Configuration, Diagnostics, Logs) are visible; no device cards appear.