### PR TITLE
feat: MA API integration for correct group resume (v2.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] - 2026-03-05
+
+### Added
+- **Music Assistant API integration** (`MA_API_URL` + `MA_API_TOKEN` config options): when configured, the bridge connects to the MA WebSocket API at startup to discover persistent MA syncgroup players.
+- **`GET /api/ma/groups`** — returns all MA syncgroup players with full member info (id, name, playback state, volume, availability) from the MA API.
+- **Correct group resume**: `POST /api/group/pause` with `action=play` now sends play to the **persistent MA syncgroup player** (`syncgroup_*`) via MA API instead of the transient Sendspin session group. This correctly restores all group members in sync, matching the behaviour of the MA UI resume button. Falls back to Sendspin session group command if MA API is not configured.
+- `music-assistant-client` dependency added.
+
+### Changed
+- MA group names in bridge UI now reflect the persistent MA group name (e.g. "Sendspin BT") when MA API is configured.
+
 ## [2.8.2] - 2026-03-05
 
 ### Fixed

--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ import threading
 import uuid as _uuid
 from pathlib import Path
 
-VERSION = "2.8.2"
+VERSION = "2.9.0"
 BUILD_DATE = "2026-03-05"
 
 __all__ = [
@@ -49,6 +49,8 @@ DEFAULT_CONFIG = {
     "AUTH_PASSWORD_HASH": "",
     "SECRET_KEY": "",
     "LOG_LEVEL": "INFO",
+    "MA_API_URL": "",
+    "MA_API_TOKEN": "",
 }
 
 logger = logging.getLogger(__name__)

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] - 2026-03-05
+
+### Added
+- New optional options `ma_api_url` and `ma_api_token`: connect to the Music Assistant WebSocket API to enable correct group resume and group name display.
+- `GET /api/ma/groups` endpoint: returns all MA syncgroup players with member details.
+- Group resume now uses the persistent MA syncgroup player via MA API (when configured), restoring all members in sync — identical to pressing resume in the MA UI.
+
 ## [2.8.2] - 2026-03-05
 
 ### Fixed

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -38,6 +38,8 @@ options:
   bt_max_reconnect_fails: 0
   auth_enabled: false
   log_level: "info"
+  ma_api_url: ""
+  ma_api_token: ""
   bluetooth_devices: []
   bluetooth_adapters: []
 
@@ -53,6 +55,8 @@ schema:
   bt_max_reconnect_fails: int?
   auth_enabled: bool?
   log_level: "list(info|debug)?"
+  ma_api_url: str?
+  ma_api_token: str?
   bluetooth_devices:
     - mac: "match(([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2})"
       player_name: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ waitress>=2.1.2,<4.0.0
 dbus-python>=1.3.2,<2.0.0
 dbus-fast>=2.22.0,<3.0.0
 pulsectl-asyncio>=1.0.0,<2.0.0
+music-assistant-client>=1.3.0,<2.0.0

--- a/routes/api.py
+++ b/routes/api.py
@@ -413,13 +413,12 @@ def pause_all():
 def api_group_pause():
     """Pause or resume a specific MA sync group by group_id.
 
-    Sends MediaCommand.PAUSE or MediaCommand.PLAY to ONE member of the group.
-    MA propagates the action to all group members — sending to each member
-    individually would break group sync.
+    For action="play": if MA API (MA_API_URL + MA_API_TOKEN) is configured,
+    sends play to the persistent MA syncgroup player so all members resume in sync.
+    Falls back to Sendspin session group command when MA API is not configured.
 
-    Use action="play" to resume a paused group. Note: this is a resume command
-    only. Starting fresh playback with an empty queue must be done from MA UI
-    or HA actions.
+    For action="pause": always uses Sendspin session group command (one member,
+    MA propagates to all).
     """
     data = request.get_json() or {}
     group_id = data.get("group_id")
@@ -439,6 +438,30 @@ def api_group_pause():
     if not target:
         return jsonify({"success": False, "error": "Group not found or no running members"}), 404
 
+    # For play: prefer MA API so the persistent syncgroup resumes all members in sync
+    if action == "play":
+        ma_url, ma_token = state.get_ma_api_credentials()
+        if ma_url and ma_token:
+            ma_group = state.get_ma_group_for_player(target.player_name)
+            if ma_group:
+                try:
+                    from services.ma_client import ma_group_play
+
+                    fut = asyncio.run_coroutine_threadsafe(ma_group_play(ma_url, ma_token, ma_group["id"]), loop)
+                    ok = fut.result(timeout=10.0)
+                    if ok:
+                        return jsonify(
+                            {
+                                "success": True,
+                                "action": action,
+                                "group_id": group_id,
+                                "ma_syncgroup_id": ma_group["id"],
+                                "ma_syncgroup_name": ma_group["name"],
+                            }
+                        )
+                except Exception as exc:
+                    logger.warning("MA API group play failed, falling back: %s", exc)
+
     try:
         fut = asyncio.run_coroutine_threadsafe(target._send_subprocess_command({"cmd": action}), loop)
         fut.result(timeout=2.0)
@@ -446,6 +469,16 @@ def api_group_pause():
         return jsonify({"success": True, "action": action, "group_id": group_id, "group_name": group_name})
     except Exception as exc:
         return jsonify({"success": False, "error": str(exc)}), 500
+
+
+@api_bp.route("/api/ma/groups", methods=["GET"])
+def api_ma_groups():
+    """Return all MA syncgroup players discovered from the MA API.
+
+    Each group includes id, name, and members with id/name/state/volume/available.
+    Returns empty list if MA API is not configured or discovery has not run yet.
+    """
+    return jsonify(state.get_ma_groups())
 
 
 @api_bp.route("/api/pause", methods=["POST"])

--- a/scripts/translate_ha_config.py
+++ b/scripts/translate_ha_config.py
@@ -108,6 +108,8 @@ def main() -> None:
         "BT_MAX_RECONNECT_FAILS": int(opts.get("bt_max_reconnect_fails") or 0),
         "AUTH_ENABLED": bool(opts.get("auth_enabled", False)),
         "LOG_LEVEL": (opts.get("log_level") or "info").upper(),
+        "MA_API_URL": opts.get("ma_api_url") or "",
+        "MA_API_TOKEN": opts.get("ma_api_token") or "",
     }
 
     # Normalize: devices without explicit 'enabled' field default to True

--- a/sendspin_client.py
+++ b/sendspin_client.py
@@ -791,6 +791,39 @@ async def main():
     # Expose the running loop so Flask/WSGI threads can schedule coroutines
     _state.set_main_loop(asyncio.get_running_loop())
 
+    # Discover MA syncgroups via MA API.
+    # In HA addon mode (SUPERVISOR_TOKEN present): auto-detect URL and try supervisor token.
+    # Otherwise: use explicit MA_API_URL + MA_API_TOKEN from config.
+    ma_api_url = config.get("MA_API_URL", "").strip()
+    ma_api_token = config.get("MA_API_TOKEN", "").strip()
+
+    supervisor_token = os.environ.get("SUPERVISOR_TOKEN", "")
+    if supervisor_token:
+        # HA addon mode: auto-detect MA URL if not explicitly configured
+        if not ma_api_url:
+            _resolved = (
+                server_host
+                if (server_host and server_host.lower() not in ("auto", "discover", ""))
+                else "homeassistant.local"
+            )
+            ma_api_url = f"http://{_resolved}:8095"
+            logger.debug("MA API URL auto-detected (addon mode): %s", ma_api_url)
+        # Use supervisor token as MA auth token if no explicit token configured
+        if not ma_api_token:
+            ma_api_token = supervisor_token
+            logger.debug("MA API token: using SUPERVISOR_TOKEN (addon mode)")
+
+    if ma_api_url and ma_api_token:
+        _state.set_ma_api_credentials(ma_api_url, ma_api_token)
+        try:
+            from services.ma_client import discover_ma_groups
+
+            player_names = [c.player_name for c in clients]
+            name_map, all_groups = await discover_ma_groups(ma_api_url, ma_api_token, player_names)
+            _state.set_ma_groups(name_map, all_groups)
+        except Exception as _ma_exc:
+            logger.warning("MA API group discovery error: %s", _ma_exc)
+
     # Run all clients in parallel
     await asyncio.gather(*[c.run() for c in clients])
 

--- a/services/ma_client.py
+++ b/services/ma_client.py
@@ -1,0 +1,104 @@
+"""Music Assistant API helpers for group discovery and playback control."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def _fetch_all_players(ma_url: str, ma_token: str) -> list[dict]:
+    """Connect to MA API and return the full players/all list."""
+    from music_assistant_client import MusicAssistantClient
+
+    async with MusicAssistantClient(ma_url, None, token=ma_token) as client:
+        await client.connect()
+        return await client.send_command("players/all")
+
+
+async def discover_ma_groups(ma_url: str, ma_token: str, bridge_player_names: list[str]) -> tuple[dict, list[dict]]:
+    """Query MA API and return two things:
+
+    1. name_map: dict player_name_lower → {"id", "name"} for bridge players that belong to a syncgroup.
+    2. all_groups: list of all MA syncgroup dicts {"id", "name", "members": [{"id", "name"}]}
+
+    Both are derived from a single players/all call.
+    """
+    try:
+        import music_assistant_client as _mac  # noqa: F401
+    except ImportError:
+        logger.warning("music-assistant-client not installed — MA API group discovery disabled")
+        return {}, []
+
+    try:
+        players = await _fetch_all_players(ma_url, ma_token)
+    except Exception as exc:
+        logger.warning("MA API players/all failed: %s", exc)
+        return {}, []
+
+    # Build MA player_id → display name map
+    id_to_name: dict[str, str] = {p["player_id"]: (p.get("display_name") or p.get("name") or "") for p in players}
+
+    all_groups: list[dict] = []
+    name_map: dict[str, dict] = {}
+
+    for p in players:
+        if p.get("type") != "group" or p.get("provider") != "sync_group":
+            continue
+
+        syncgroup_id = p["player_id"]
+        syncgroup_name = p.get("display_name") or p.get("name") or syncgroup_id
+        raw_members = p.get("group_members") or []
+        # Build rich member info from the full player list
+        member_by_id = {pl["player_id"]: pl for pl in players}
+        members = [
+            {
+                "id": mid,
+                "name": id_to_name.get(mid, mid),
+                "state": member_by_id.get(mid, {}).get("playback_state"),
+                "volume": member_by_id.get(mid, {}).get("volume_level"),
+                "available": member_by_id.get(mid, {}).get("available", True),
+            }
+            for mid in raw_members
+        ]
+        member_names_lower = {id_to_name.get(mid, "").lower() for mid in raw_members}
+
+        all_groups.append({"id": syncgroup_id, "name": syncgroup_name, "members": members})
+
+        # Match bridge players → this syncgroup by name (case-insensitive substring)
+        for bridge_name in bridge_player_names:
+            b = bridge_name.lower()
+            if any(b in mn or mn in b for mn in member_names_lower if mn):
+                name_map[b] = {"id": syncgroup_id, "name": syncgroup_name}
+                logger.debug(
+                    "Mapped bridge player '%s' → MA syncgroup '%s' (%s)",
+                    bridge_name,
+                    syncgroup_name,
+                    syncgroup_id,
+                )
+
+    logger.info(
+        "MA API: found %d syncgroup(s), matched %d bridge player(s)",
+        len(all_groups),
+        len(name_map),
+    )
+    return name_map, all_groups
+
+
+async def ma_group_play(ma_url: str, ma_token: str, syncgroup_id: str) -> bool:
+    """Send play command to a MA persistent syncgroup player. Returns True on success."""
+    try:
+        from music_assistant_client import MusicAssistantClient
+    except ImportError:
+        logger.warning("music-assistant-client not installed — MA API play disabled")
+        return False
+
+    try:
+        async with MusicAssistantClient(ma_url, None, token=ma_token) as client:
+            await client.connect()
+            await client.players.play(syncgroup_id)
+        logger.info("MA group play → %s", syncgroup_id)
+        return True
+    except Exception as exc:
+        logger.warning("MA group play failed for %s: %s", syncgroup_id, exc)
+        return False

--- a/state.py
+++ b/state.py
@@ -19,12 +19,17 @@ __all__ = [
     "create_scan_job",
     "finish_scan_job",
     "get_adapter_name",
+    "get_ma_api_credentials",
+    "get_ma_group_for_player",
+    "get_ma_groups",
     "get_main_loop",
     "get_scan_job",
     "is_scan_running",
     "load_adapter_name_cache",
     "notify_status_changed",
     "set_clients",
+    "set_ma_api_credentials",
+    "set_ma_groups",
     "set_main_loop",
 ]
 
@@ -174,3 +179,50 @@ def get_scan_job(job_id: str) -> "dict | None":
     """Return the job dict or None if not found."""
     with _scan_jobs_lock:
         return _scan_jobs.get(job_id)
+
+
+# ---------------------------------------------------------------------------
+# MA syncgroup cache — player_name_lower → {"id": syncgroup_id, "name": group_name}
+# Populated at startup if MA_API_URL + MA_API_TOKEN are configured.
+# ---------------------------------------------------------------------------
+
+_ma_groups: dict[str, dict] = {}
+_ma_groups_lock = threading.Lock()
+_ma_all_groups: list[dict] = []  # full list: [{id, name, members: [{id, name, state, volume, available}]}]
+_ma_api_url: str = ""
+_ma_api_token: str = ""
+
+
+def set_ma_groups(mapping: "dict[str, dict]", all_groups: "list[dict] | None" = None) -> None:
+    """Store the MA player_name → syncgroup mapping and full group list discovered from MA API."""
+    with _ma_groups_lock:
+        _ma_groups.clear()
+        _ma_groups.update(mapping)
+        if all_groups is not None:
+            _ma_all_groups.clear()
+            _ma_all_groups.extend(all_groups)
+    logger.info("MA syncgroup cache updated: %d mapped, %d total group(s)", len(mapping), len(_ma_all_groups))
+
+
+def set_ma_api_credentials(url: str, token: str) -> None:
+    """Store resolved MA API URL and token for use across modules."""
+    global _ma_api_url, _ma_api_token
+    _ma_api_url = url
+    _ma_api_token = token
+
+
+def get_ma_api_credentials() -> "tuple[str, str]":
+    """Return (ma_api_url, ma_api_token)."""
+    return _ma_api_url, _ma_api_token
+
+
+def get_ma_group_for_player(player_name: str) -> "dict | None":
+    """Return MA syncgroup info {id, name} for the given bridge player name, or None."""
+    with _ma_groups_lock:
+        return _ma_groups.get(player_name.lower())
+
+
+def get_ma_groups() -> "list[dict]":
+    """Return all MA syncgroup players with their members."""
+    with _ma_groups_lock:
+        return list(_ma_all_groups)


### PR DESCRIPTION
## Summary

Fixes group resume by integrating with the Music Assistant WebSocket API.

### Root cause
After pause, Sendspin session group disbands ~5s later. Bridge sending play to one member → only that member resumes.

### Fix
Send play to the **persistent MA syncgroup player** (`syncgroup_*`) via MA API — identical to pressing resume in the MA UI. Falls back to Sendspin session group command if MA API is not configured.

### Changes
- **`services/ma_client.py`** (new): `discover_ma_groups()` + `ma_group_play()` via MA WS API
- **`GET /api/ma/groups`**: returns all MA syncgroup players with member details (id, name, state, volume)
- **HA addon mode auto-setup**: MA URL auto-detected from SENDSPIN_SERVER, `SUPERVISOR_TOKEN` used automatically — no separate token needed when running as HA addon
- **Explicit config** (`MA_API_URL` / `MA_API_TOKEN`) for non-addon deployments
- `music-assistant-client>=1.3.0` added to requirements.txt
- Version bumped to 2.9.0