### PR TITLE
fix(lxc): fix PulseAudio boot failures on Ubuntu 24.04

### DIFF
--- a/lxc/install.sh
+++ b/lxc/install.sh
@@ -131,6 +131,12 @@ usermod -aG audio    pulse 2>/dev/null || true
 mkdir -p /var/run/pulse
 chown pulse:pulse /var/run/pulse
 chmod 755 /var/run/pulse
+
+# Ensure /var/run/pulse is recreated on boot (tmpfs)
+cat > /etc/tmpfiles.d/pulse.conf <<'EOF'
+d /var/run/pulse 0755 pulse pulse -
+EOF
+
 ok "pulse user configured (bluetooth + audio groups)"
 
 # ─── 7. PulseAudio system configuration ──────────────────────────────────────

--- a/lxc/pulse-daemon.conf
+++ b/lxc/pulse-daemon.conf
@@ -8,4 +8,5 @@ default-sample-rate = 48000     # Match MA output rate → zero resampling
 high-priority = yes              # PA gets elevated priority when available
 realtime-scheduling = yes        # SCHED_RR for audio threads
 flat-volumes = no                # No per-stream volume rescaling
-enable-lfe-remixing = no         # Skip LFE (subwoofer) channel processing
+remixing-produce-lfe = no        # Skip LFE (subwoofer) channel processing
+remixing-consume-lfe = no        # Skip LFE (subwoofer) channel processing

--- a/lxc/pulseaudio-system.service
+++ b/lxc/pulseaudio-system.service
@@ -6,8 +6,6 @@ Before=sendspin-client.service
 
 [Service]
 Type=notify
-User=pulse
-Group=pulse
 Environment=PULSE_RUNTIME_PATH=/var/run/pulse
 # Use the host's D-Bus socket (bind-mounted at /bt-dbus) for Bluetooth A2DP
 Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/bt-dbus/system_bus_socket


### PR DESCRIPTION
## Problem

Three issues discovered during real LXC deployment on Proxmox PVE 8.4:

1. **PulseAudio refuses to start as `pulse` user** — `--system` mode requires starting as root (PA drops privileges internally). Error: `System mode refused for non-root user`.

2. **Deprecated `enable-lfe-remixing` option** — Ubuntu 24.04 ships PulseAudio 17+ which removed this option. Causes error on startup. Replaced with `remixing-produce-lfe` and `remixing-consume-lfe`.

3. **`/var/run/pulse` not recreated on reboot** — Since `/var/run` is tmpfs, the pulse runtime directory disappears on reboot. Added `tmpfiles.d` entry to recreate it automatically.

## Changes

- `pulseaudio-system.service`: Remove `User=pulse` and `Group=pulse`
- `pulse-daemon.conf`: Replace deprecated option with new equivalents
- `install.sh`: Add `/etc/tmpfiles.d/pulse.conf` for boot persistence