### PR TITLE
feat: GitHub issue templates, labels, and discussions setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bluetooth_audio.yml
+++ b/.github/ISSUE_TEMPLATE/bluetooth_audio.yml
@@ -1,0 +1,123 @@
+name: 🔊 Bluetooth & Audio Issue
+description: Report Bluetooth connection or audio playback problems
+labels: ["bug", "bluetooth"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for Bluetooth and audio-specific issues:
+        pairing failures, no sound, intermittent disconnects, codec problems, audio artifacts.
+
+        For general bugs (web UI, config, API) use the **[Bug Report](https://github.com/trudenboy/sendspin-bt-bridge/issues/new?template=bug_report.yml)** template.
+
+  - type: dropdown
+    id: problem_type
+    validations:
+      required: true
+    attributes:
+      label: Problem Type
+      options:
+        - Cannot pair / device not found
+        - Pairs but no audio output
+        - Intermittent disconnects
+        - Wrong codec / poor audio quality
+        - Silence during playback (connected but no sound)
+        - Audio artifacts / crackling / stuttering
+
+  - type: input
+    id: speaker_model
+    validations:
+      required: true
+    attributes:
+      label: Bluetooth Speaker Model
+      placeholder: "JBL Flip 6 / Sony SRS-XB43 / Marshall Stanmore II"
+
+  - type: input
+    id: bt_adapter
+    validations:
+      required: true
+    attributes:
+      label: Bluetooth Adapter
+      description: Model, chipset, or "built-in"
+      placeholder: "Intel AX200 / TP-Link UB500 / built-in RPi 4"
+
+  - type: input
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: Bridge Version
+      placeholder: "2.7.4"
+
+  - type: dropdown
+    id: deployment
+    validations:
+      required: true
+    attributes:
+      label: Deployment Method
+      options:
+        - Home Assistant Addon
+        - Docker Compose
+        - Proxmox LXC
+        - OpenWrt LXC
+        - Bare Metal (pip install)
+
+  - type: dropdown
+    id: audio_system
+    validations:
+      required: true
+    attributes:
+      label: Audio System
+      options:
+        - PipeWire
+        - PulseAudio
+        - Not sure
+
+  - type: input
+    id: host_os
+    validations:
+      required: true
+    attributes:
+      label: Host OS
+      placeholder: "HAOS 14.1 / Debian 12 / Ubuntu 24.04"
+
+  - type: textarea
+    id: bluetoothctl_info
+    attributes:
+      label: "Output of `bluetoothctl info <MAC>`"
+      description: |
+        Run inside the container:
+        - Docker: `docker exec sendspin-client bluetoothctl info AA:BB:CC:DD:EE:FF`
+        - LXC: `bluetoothctl info AA:BB:CC:DD:EE:FF`
+      render: shell
+
+  - type: textarea
+    id: pactl_sinks
+    attributes:
+      label: "Output of `pactl list sinks short`"
+      description: |
+        Run inside the container:
+        - Docker: `docker exec sendspin-client pactl list sinks short`
+        - LXC: `pactl list sinks short`
+      render: shell
+
+  - type: textarea
+    id: logs
+    validations:
+      required: true
+    attributes:
+      label: Logs
+      description: |
+        Paste relevant log output. Include lines around the connection/audio event.
+        - Docker: `docker logs sendspin-client --tail 100`
+        - HA Addon: Addon → Log tab
+        - LXC: `journalctl -u sendspin-client --no-pager -n 100`
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: |
+        Any other relevant details: distance to speaker, number of connected devices,
+        whether the speaker works with other apps on the same host, etc.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,135 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the form below so we can reproduce and fix the issue.
+
+        **Before submitting:** check [existing issues](https://github.com/trudenboy/sendspin-bt-bridge/issues) and [Q&A discussions](https://github.com/trudenboy/sendspin-bt-bridge/discussions/categories/q-a).
+
+        For Bluetooth/Audio specific problems (no sound, pairing failures, codec issues) use the **[Bluetooth & Audio Issue](https://github.com/trudenboy/sendspin-bt-bridge/issues/new?template=bluetooth_audio.yml)** template instead.
+
+  - type: textarea
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: Description
+      description: A clear description of the bug. What happened? What did you expect?
+      placeholder: |
+        When I try to ... the bridge does ... instead of ...
+
+  - type: input
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: Bridge Version
+      description: Shown in the web UI header or `docker logs` at startup
+      placeholder: "2.7.4"
+
+  - type: dropdown
+    id: deployment
+    validations:
+      required: true
+    attributes:
+      label: Deployment Method
+      options:
+        - Home Assistant Addon
+        - Docker Compose
+        - Proxmox LXC
+        - OpenWrt LXC
+        - Bare Metal (pip install)
+
+  - type: input
+    id: host_os
+    validations:
+      required: true
+    attributes:
+      label: Host OS
+      description: Operating system and version
+      placeholder: "HAOS 14.1 / Debian 12 / Ubuntu 24.04 / Proxmox 8.3"
+
+  - type: dropdown
+    id: audio_system
+    validations:
+      required: true
+    attributes:
+      label: Audio System
+      options:
+        - PipeWire
+        - PulseAudio
+        - Not sure
+
+  - type: dropdown
+    id: device_count
+    attributes:
+      label: Number of Bluetooth Devices
+      options:
+        - "1"
+        - "2-3"
+        - "4+"
+
+  - type: input
+    id: bt_adapter
+    attributes:
+      label: Bluetooth Adapter
+      description: Model or chipset (optional)
+      placeholder: "Intel AX200 / TP-Link UB500 / built-in RPi"
+
+  - type: textarea
+    id: steps
+    validations:
+      required: true
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior
+      placeholder: |
+        1. Start the bridge with config ...
+        2. Open the web UI
+        3. Click on ...
+        4. See error ...
+
+  - type: textarea
+    id: expected
+    validations:
+      required: true
+    attributes:
+      label: Expected Behavior
+      description: What should have happened instead?
+
+  - type: textarea
+    id: logs
+    validations:
+      required: true
+    attributes:
+      label: Logs
+      description: |
+        Paste relevant log output. Get logs with:
+        - Docker: `docker logs sendspin-client --tail 100`
+        - HA Addon: Addon → Log tab
+        - LXC: `journalctl -u sendspin-client --no-pager -n 100`
+      render: shell
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: |
+        Paste your `config.json` (remove passwords/tokens).
+        Docker: `docker exec sendspin-client cat /config/config.json`
+      render: json
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots of the web UI or error messages.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other relevant information.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Question or Setup Help
+    url: https://github.com/trudenboy/sendspin-bt-bridge/discussions/categories/q-a
+    about: For setup questions and troubleshooting — use GitHub Discussions Q&A
+  - name: 🔊 Bluetooth & Audio Help
+    url: https://github.com/trudenboy/sendspin-bt-bridge/discussions
+    about: Questions about speaker compatibility, audio routing, codecs — ask in Discussions
+  - name: 🏗️ Deployment Help
+    url: https://github.com/trudenboy/sendspin-bt-bridge/discussions
+    about: Help with Docker, HA Addon, Proxmox LXC, or OpenWrt setup
+  - name: 💬 Music Assistant Discussion
+    url: https://github.com/orgs/music-assistant/discussions/5061
+    about: Discuss the project in the Music Assistant community
+  - name: 📖 Documentation
+    url: https://trudenboy.github.io/sendspin-bt-bridge/
+    about: Check the docs — your answer might already be there

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,75 @@
+name: 💡 Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a new feature? We'd love to hear it!
+
+        **Tip:** For early-stage ideas or brainstorming, consider starting a [Discussion in Ideas](https://github.com/trudenboy/sendspin-bt-bridge/discussions/categories/ideas) first.
+
+  - type: textarea
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: Feature Description
+      description: A clear description of the feature you'd like to see.
+      placeholder: |
+        I'd like the bridge to support ...
+
+  - type: textarea
+    id: motivation
+    validations:
+      required: true
+    attributes:
+      label: Motivation / Use Case
+      description: What problem does this solve? Why do you need it?
+      placeholder: |
+        Currently I have to ... which is inconvenient because ...
+
+  - type: checkboxes
+    id: deployment_modes
+    attributes:
+      label: Affected Deployment Modes
+      options:
+        - label: Home Assistant Addon
+        - label: Docker Compose
+        - label: Proxmox LXC
+        - label: OpenWrt LXC
+        - label: All / Not deployment-specific
+
+  - type: checkboxes
+    id: components
+    attributes:
+      label: Affected Components
+      options:
+        - label: Web UI
+        - label: Bluetooth connectivity
+        - label: Audio / PulseAudio
+        - label: REST API
+        - label: Configuration
+        - label: Multiroom sync
+        - label: Music Assistant integration
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any workarounds or alternative approaches?
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Willingness to Contribute
+      options:
+        - I can submit a PR
+        - I can help with testing
+        - Just an idea
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Mockups, screenshots, links to related projects or discussions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,14 +60,37 @@ For HA addon changes, additionally test via the HA Addon Store dev workflow (loc
 
 ---
 
-## Reporting Bugs
+## Reporting Bugs & Requesting Features
 
-Open an issue at [GitHub Issues](https://github.com/trudenboy/sendspin-bt-bridge/issues). Include:
+We use **GitHub Issues** for actionable bug reports and feature requests, and **GitHub Discussions** for questions, ideas, and community help.
 
-- Deployment method (Docker / HA Addon / Proxmox LXC)
-- Relevant log output (`docker logs sendspin-client` or `journalctl -u sendspin-client`)
-- Host OS, audio system (PipeWire or PulseAudio), Bluetooth adapter model
-- Steps to reproduce
+### Issues (bugs & features)
+
+Open a new issue using one of the structured templates:
+
+| Template | When to use |
+|----------|-------------|
+| [🐛 Bug Report](https://github.com/trudenboy/sendspin-bt-bridge/issues/new?template=bug_report.yml) | Something is broken — reproducible unexpected behavior |
+| [🔊 Bluetooth & Audio](https://github.com/trudenboy/sendspin-bt-bridge/issues/new?template=bluetooth_audio.yml) | BT pairing failures, no sound, disconnects, codec issues |
+| [💡 Feature Request](https://github.com/trudenboy/sendspin-bt-bridge/issues/new?template=feature_request.yml) | Suggest a new feature or enhancement |
+
+**Tips for good bug reports:**
+- Include your deployment method (Docker / HA Addon / Proxmox LXC / OpenWrt LXC)
+- Paste log output: `docker logs sendspin-client --tail 100` or `journalctl -u sendspin-client`
+- For BT/audio issues: include `bluetoothctl info <MAC>` and `pactl list sinks short` output
+- Mention your host OS, audio system (PipeWire/PulseAudio), and BT adapter model
+
+### Discussions (questions & ideas)
+
+For questions, setup help, and early-stage ideas — use [GitHub Discussions](https://github.com/trudenboy/sendspin-bt-bridge/discussions):
+
+| Category | When to use |
+|----------|-------------|
+| 🙏 Q&A | General usage questions and troubleshooting |
+| 🔊 Bluetooth & Audio | Speaker compatibility, audio routing, codec questions |
+| 🏗️ Deployment | Help with Docker, HA Addon, Proxmox LXC, OpenWrt setup |
+| 💡 Ideas | Early-stage feature ideas and brainstorming |
+| 🛠️ Show and Tell | Share your setup, config, or creative use case |
 
 ---
 

--- a/community_engagement.md
+++ b/community_engagement.md
@@ -66,3 +66,31 @@
 - Если в проект добавлен значительный оригинальный код — обсуди с Loryan Strant
   добавление себя как соавтора копирайта
 - MA использует Apache 2.0, но для companion-проектов MIT допустим
+
+---
+
+## Шаг 7 — Reddit (r/homeassistant)
+
+- Сабреддит: [r/homeassistant](https://www.reddit.com/r/homeassistant/)
+- Flair: `I Made This!`
+- Формат: Gallery post (инфографика + скриншоты) + развёрнутый комментарий от автора
+- Лучшее время: вторник–четверг, 14:00–17:00 UTC
+- Требования перед публикацией:
+  - Активный аккаунт с полезными комментариями в сабреддите
+  - Соблюдение правила 90/10 (не более 10% промоушн)
+- Изображения для gallery:
+  1. `sbb_infographic_en.png` — инфографика (первое изображение, главный hook)
+  2. `screenshot-dashboard-full.png` — полный дашборд
+  3. `screenshot-device-card-playing.png` — карточка устройства
+  4. `ma-players.png` — вид плееров в Music Assistant
+  5. `screenshot-diagnostics.png` — панель диагностики
+  6. `multiroom-floorplan.png` — мультирум схема (опционально)
+- Заголовок: `I built a Bluetooth Bridge for Music Assistant — multi-device multiroom audio from any BT speaker (HA Addon / Docker / Proxmox LXC)`
+- Содержание поста:
+  - Проблема: MA не поддерживает BT-колонки нативно
+  - Решение: мост, превращающий любую BT-колонку в полноценный MA-плеер
+  - Ключевые фичи: multi-device, multiroom sync, auto-reconnect, web UI, REST API
+  - 4 варианта развёртывания
+  - Ссылки: GitHub, документация, MA Discussion (#5061)
+  - Призыв к обратной связи и feature requests
+- После публикации: активно отвечать на комментарии в первые 24 часа

--- a/scripts/setup-discussions.sh
+++ b/scripts/setup-discussions.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Setup GitHub Discussions categories and welcome post for sendspin-bt-bridge
+# Usage: ./scripts/setup-discussions.sh [owner/repo]
+#
+# Requires: gh CLI authenticated
+# Note: GitHub GraphQL API is used because REST API doesn't support discussion categories
+
+set -euo pipefail
+
+REPO="${1:-trudenboy/sendspin-bt-bridge}"
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+
+echo "Setting up Discussions for $REPO"
+echo ""
+
+# Get repository ID
+REPO_ID=$(gh api graphql -f query="
+  { repository(owner: \"$OWNER\", name: \"$REPO_NAME\") { id } }
+" --jq '.data.repository.id')
+
+echo "Repository ID: $REPO_ID"
+
+# Get existing category slugs
+echo ""
+echo "📂 Existing categories:"
+EXISTING=$(gh api graphql -f query="
+  { repository(owner: \"$OWNER\", name: \"$REPO_NAME\") {
+    discussionCategories(first: 20) {
+      nodes { id name slug isAnswerable }
+    }
+  } }
+" --jq '.data.repository.discussionCategories.nodes[] | "\(.slug)|\(.id)|\(.name)|\(.isAnswerable)"')
+
+while IFS='|' read -r slug id name answerable; do
+  echo "  $name ($slug) [answerable=$answerable] id=$id"
+done <<< "$EXISTING"
+
+# Helper: check if category exists
+category_exists() {
+  echo "$EXISTING" | grep -q "^$1|"
+}
+
+# Helper: get category ID by slug
+category_id() {
+  echo "$EXISTING" | grep "^$1|" | cut -d'|' -f2
+}
+
+echo ""
+echo "🔧 Creating new categories..."
+echo ""
+echo "  ⚠️  GitHub API does not support creating/deleting Discussion categories."
+echo "  Please create these manually in repository Settings → Discussions:"
+echo ""
+echo "  1. ➕ Create 'Bluetooth & Audio' (emoji: 🔊, format: Question/Answer)"
+echo "     Description: Speaker compatibility, pairing, codecs, audio routing, BT adapter questions"
+echo ""
+echo "  2. ➕ Create 'Deployment' (emoji: 🏗️, format: Question/Answer)"
+echo "     Description: HA Addon, Docker Compose, Proxmox LXC, OpenWrt LXC setup and configuration"
+echo ""
+echo "  3. 🗑️  Delete 'Polls' category (if not needed)"
+echo ""
+
+# Create Welcome post in General
+echo ""
+echo "📝 Creating Welcome post..."
+
+GENERAL_ID=$(category_id "general")
+
+if [ -z "$GENERAL_ID" ]; then
+  echo "  ⚠️  General category not found, skipping welcome post"
+else
+  WELCOME_BODY='## 👋 Welcome to Sendspin BT Bridge Discussions!
+
+This is the place to ask questions, share ideas, and show off your setup.
+
+### Where to post
+
+| Your question | Where to go |
+|---------------|-------------|
+| 🐛 Something is broken (reproducible bug) | [New Issue → Bug Report](https://github.com/trudenboy/sendspin-bt-bridge/issues/new?template=bug_report.yml) |
+| 🔊 Bluetooth won'\''t pair / no audio / crackling | **Bluetooth & Audio** category |
+| 🏗️ Can'\''t set up Docker / HA Addon / LXC | **Deployment** category |
+| 🙏 General usage question | **Q&A** category |
+| 💡 New feature idea | **Ideas** category |
+| 🛠️ Want to show your setup | **Show and Tell** category |
+
+### Guidelines
+
+1. **Search first** — check [documentation](https://trudenboy.github.io/sendspin-bt-bridge/) and existing discussions before posting
+2. **Be specific** — include your deployment method, bridge version, OS, and BT adapter model
+3. **Include logs** — attach `docker logs` or `journalctl` output for troubleshooting questions
+4. **For ideas** — describe your use case (why you need it), not just what you want
+5. **Language** — English preferred, Russian accepted
+6. **Be kind** — this is a community project, help each other out 🤝
+
+### Useful links
+
+- 📖 [Documentation](https://trudenboy.github.io/sendspin-bt-bridge/)
+- 🐙 [GitHub Repository](https://github.com/trudenboy/sendspin-bt-bridge)
+- 🎵 [Music Assistant Discussion](https://github.com/orgs/music-assistant/discussions/5061)
+- 🐛 [Report a Bug](https://github.com/trudenboy/sendspin-bt-bridge/issues/new/choose)'
+
+  gh api graphql -f query="
+    mutation {
+      createDiscussion(input: {
+        repositoryId: \"$REPO_ID\"
+        categoryId: \"$GENERAL_ID\"
+        title: \"👋 Welcome — Read this before posting\"
+        body: $(echo "$WELCOME_BODY" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
+      }) { discussion { url } }
+    }
+  " --jq '.data.createDiscussion.discussion.url' && echo "  ✅ Welcome post created" || echo "  ⚠️  Could not create welcome post (may already exist)"
+fi
+
+echo ""
+echo "Done! 🎉"
+echo ""
+echo "Manual steps remaining:"
+echo "  1. Pin the Welcome post in Discussions"
+echo "  2. Review category order in Settings → Discussions"

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Setup GitHub issue labels for sendspin-bt-bridge
+# Usage: ./scripts/setup-labels.sh [owner/repo]
+#
+# Requires: gh CLI authenticated
+
+set -euo pipefail
+
+REPO="${1:-trudenboy/sendspin-bt-bridge}"
+
+create_or_update_label() {
+  local name="$1" color="$2" description="$3"
+  gh label create "$name" --repo "$REPO" --color "$color" --description "$description" --force 2>/dev/null \
+    && echo "  ✅ $name" \
+    || echo "  ❌ Failed: $name"
+}
+
+echo "Setting up labels for $REPO"
+echo ""
+
+echo "📂 Category labels:"
+create_or_update_label "bluetooth"    "1E90FF" "Bluetooth connection and pairing"
+create_or_update_label "audio"        "9B59B6" "PulseAudio / PipeWire / codecs"
+create_or_update_label "web-ui"       "2ECC71" "Web interface"
+create_or_update_label "api"          "3498DB" "REST API"
+create_or_update_label "config"       "F39C12" "Configuration"
+create_or_update_label "multiroom"    "E74C3C" "Multiroom sync"
+create_or_update_label "ha-addon"     "00BCD4" "Home Assistant addon"
+create_or_update_label "docker"       "2496ED" "Docker deployment"
+create_or_update_label "lxc"          "FF9800" "Proxmox / OpenWrt LXC"
+echo ""
+
+echo "🔴 Priority labels:"
+create_or_update_label "priority: critical" "B60205" "Service down / data loss"
+create_or_update_label "priority: high"     "D93F0B" "Major feature broken"
+create_or_update_label "priority: low"      "0E8A16" "Cosmetic / minor"
+echo ""
+
+echo "📋 Status labels:"
+create_or_update_label "needs-info" "FBCA04" "Waiting for more information from reporter"
+create_or_update_label "confirmed"  "0075CA" "Reproduced by maintainer"
+create_or_update_label "wontfix"    "FFFFFF" "Not planned"
+create_or_update_label "duplicate"  "CFD3D7" "Duplicate of another issue"
+echo ""
+
+echo "Done! 🎉"


### PR DESCRIPTION
## Summary

Add structured GitHub Issues management and Discussions setup for the project.

### Issue Templates (YAML forms)

- **🐛 Bug Report** — deployment dropdown, audio system, version, host OS, BT adapter, required logs/steps
- **🔊 Bluetooth & Audio** — specialized: 6 problem types, speaker model, `bluetoothctl info`/`pactl` output
- **💡 Feature Request** — motivation, component checkboxes, contribution willingness
- **config.yml** — `blank_issues_enabled: false`, links to Discussions and docs

### Labels (`scripts/setup-labels.sh`)

16 custom labels already applied:
- 9 category: bluetooth, audio, web-ui, api, config, multiroom, ha-addon, docker, lxc
- 3 priority: critical, high, low
- 4 status: needs-info, confirmed, wontfix, duplicate

### Discussions (`scripts/setup-discussions.sh`)

- Welcome post published: #59
- Script prints manual instructions for creating categories (GitHub API limitation)

### Updated docs

- **CONTRIBUTING.md** — Issues vs Discussions routing guide with tables
- **community_engagement.md** — added Reddit (r/homeassistant) engagement step

### Manual steps after merge

1. Create Discussion category **🔊 Bluetooth & Audio** (Q&A format)
2. Create Discussion category **🏗️ Deployment** (Q&A format)
3. Delete **🗳 Polls** category
4. Pin Welcome post in Discussions