### PR TITLE
docs: refresh README capabilities and add prerequisites section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/trudenboy/sendspin-bt-bridge?style=flat&logo=github)](https://github.com/trudenboy/sendspin-bt-bridge/stargazers)
 [![Try Demo](https://img.shields.io/badge/Try_Demo-Live-brightgreen?style=flat&logo=render)](https://sendspin-demo.onrender.com)
 
-[Read in Russian](README.ru.md) · [Documentation](https://trudenboy.github.io/sendspin-bt-bridge/) · [Live Demo](https://sendspin-demo.onrender.com) · [Changelog](CHANGELOG.md)
+[Read in Russian](README.ru.md) · [Documentation](https://trudenboy.github.io/sendspin-bt-bridge/) · [Roadmap](ROADMAP.md) · [Live Demo](https://sendspin-demo.onrender.com) · [Changelog](CHANGELOG.md)
 
 Turn Bluetooth speakers and headphones into native [Music Assistant](https://www.music-assistant.io/) [Sendspin](https://www.music-assistant.io/player-support/sendspin/) players.
 
@@ -62,6 +62,17 @@ Full Home Assistant guide: <https://trudenboy.github.io/sendspin-bt-bridge/insta
 - **Multi-room ready** — run one bridge per room or one bridge with many speakers. Multiple bridges share the same Music Assistant server for whole-home audio.
 - **Five deployment options** — Home Assistant addon, Docker, Raspberry Pi, Proxmox VE LXC, and OpenWrt LXC — same bridge, same web UI, same features everywhere.
 - **REST API and live updates** — 60+ automation-friendly endpoints with real-time SSE status stream for custom dashboards and integrations.
+
+## Roadmap at a glance
+
+The roadmap is now aligned with the **current runtime**, not an older refactor wishlist.
+
+- **Now:** finish the v2 runtime foundation already in progress — snapshot-first reads, clearer device registry ownership, and less `state.py` coupling.
+- **Next:** formalize contracts, diagnostics, event history, telemetry, and config migrations so the bridge is easier to evolve and easier to operate.
+- **Then:** deepen onboarding, recovery UX, latency guidance, and capability-aware UI/API behavior.
+- **Later:** introduce backend abstraction for v3 only after the Bluetooth core is explicit and stable, then selectively add adjacent backends such as local sinks or ALSA outputs.
+
+See [`ROADMAP.md`](ROADMAP.md) for the full phased plan, epics, PR sequence, and guardrails.
 
 ## Documentation map
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -6,7 +6,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/trudenboy/sendspin-bt-bridge?style=flat&logo=github)](https://github.com/trudenboy/sendspin-bt-bridge/stargazers)
 [![Try Demo](https://img.shields.io/badge/Try_Demo-Live-brightgreen?style=flat&logo=render)](https://sendspin-demo.onrender.com)
 
-[Read in English](README.md) · [Документация](https://trudenboy.github.io/sendspin-bt-bridge/ru/) · [Демо](https://sendspin-demo.onrender.com) · [История проекта](HISTORY.ru.md)
+[Read in English](README.md) · [Документация](https://trudenboy.github.io/sendspin-bt-bridge/ru/) · [Дорожная карта](ROADMAP.ru.md) · [Демо](https://sendspin-demo.onrender.com) · [История проекта](HISTORY.ru.md)
 
 Превратите Bluetooth-колонки и наушники в нативные плееры [Music Assistant](https://www.music-assistant.io/) на протоколе [Sendspin](https://www.music-assistant.io/player-support/sendspin/).
 
@@ -63,6 +63,17 @@ Sendspin Bluetooth Bridge — это local-first мост для headless-сце
 - **Пять вариантов развёртывания** — Home Assistant addon, Docker, Raspberry Pi, Proxmox VE LXC и OpenWrt LXC — один и тот же bridge, один веб-интерфейс, одни и те же функции везде.
 - **REST API и live-обновления** — 60+ эндпоинтов для автоматизации и поток статусов в реальном времени через SSE для кастомных дашбордов и интеграций.
 
+## Коротко о roadmap
+
+Дорожная карта теперь синхронизирована с **реальным состоянием кода**, а не со старым списком планируемых рефакторингов.
+
+- **Сейчас:** довести до конца уже начатый v2 refactor — snapshot-first чтение, явное владение реестром устройств и уменьшение роли `state.py`.
+- **Дальше:** формализовать IPC-контракты, event history, диагностику, telemetry и lifecycle конфигурации.
+- **Потом:** усилить onboarding, recovery UX, подсказки по latency и capability-aware поведение UI/API.
+- **После этого:** переходить к backend abstraction для v3 и только затем аккуратно добавлять соседние backend'ы вроде local sink или ALSA.
+
+Полная англоязычная версия находится в [`ROADMAP.md`](ROADMAP.md), а краткая русская — в [`ROADMAP.ru.md`](ROADMAP.ru.md).
+
 ## Карта документации
 
 Полные инструкции и справка живут на docs site:
@@ -86,7 +97,8 @@ Sendspin Bluetooth Bridge — это local-first мост для headless-сце
 ## Ссылки по проекту
 
 - [Участие в разработке](CONTRIBUTING.md)
-- [Дорожная карта](ROADMAP.md)
+- [Дорожная карта (RU)](ROADMAP.ru.md)
+- [Roadmap (EN)](ROADMAP.md)
 - [Лицензия](LICENSE)
 - [История изменений](CHANGELOG.md)
 - [История проекта](HISTORY.ru.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,100 +2,78 @@
 
 ## Purpose
 
-This roadmap translates the current architecture analysis into an implementation plan for evolving `sendspin-bt-bridge` without losing its strongest properties:
+This roadmap defines the next development stages for `sendspin-bt-bridge` based on the **current codebase**, not on an older architectural snapshot.
 
-- Bluetooth-first operational reliability
-- per-device subprocess isolation
-- strong Music Assistant integration
-- practical diagnostics and web UX
+The project is no longer at the stage where `BridgeOrchestrator`, startup progress, snapshot models, onboarding guidance, and protocol-versioned IPC are merely ideas. Important parts of that work already exist in the live runtime. The roadmap therefore focuses on:
 
-The goal is not to turn the project into a generic audio platform immediately. The goal is to make the current Bluetooth bridge easier to reason about, easier to test, easier to extend, and easier to operate.
+- finishing partially completed architectural migration
+- reducing remaining shared-state coupling
+- strengthening contracts, diagnostics, and config lifecycle safety
+- improving onboarding and recovery UX
+- preparing for selective backend expansion only after the Bluetooth core is stable
 
-## Current Position
+The goal remains the same: keep the bridge **Bluetooth-first**, operationally reliable, and practical for real Home Assistant, Docker, Raspberry Pi, and LXC deployments.
 
-The project already has a strong runtime model for the Bluetooth problem space:
+## Current Status
 
-- a main process owns the web API, configuration, Music Assistant integration, and Bluetooth lifecycle
-- each Bluetooth speaker runs in its own subprocess with a dedicated `PULSE_SINK`
-- the bridge already handles reconnects, sink rediscovery, MA state sync, and real-time UI updates
+The current runtime already includes major structural improvements:
 
-The main architectural limitations are:
+- `BridgeOrchestrator` owns bridge-wide bootstrap sequencing and runtime assembly
+- `BridgeLifecycleState` publishes startup progress and runtime metadata
+- typed read-side models already exist (`DeviceSnapshot`, `BridgeSnapshot`, `StartupProgressSnapshot`, `DeviceHealthSummary`)
+- `SendspinClient` already delegates subprocess concerns to focused services
+- protocol-versioned IPC helpers already exist (`protocol_version`)
+- onboarding guidance and config upload validation already exist in operator-facing APIs
 
-- orchestration logic is spread across multiple modules
-- `state.py` acts as a wide shared mutable state surface
-- routes still know too much about runtime internals
-- parent/subprocess IPC is useful but not explicitly versioned
-- diagnostics explain symptoms well, but not always causes or recovery history
-- critical flows are still difficult to test without real Bluetooth hardware
+The main architectural gaps are now narrower and more specific:
+
+- `state.py` still remains the main mutable coordination surface
+- device registry is still closer to a snapshot helper than a full ownership service
+- route and service code still contains some direct runtime/internal lookups
+- event history, diagnostics, and health explanations need deeper normalization
+- config validation exists, but config migrations and config/runtime separation are not complete
+- backend abstraction should not start until the current runtime contracts are cleaner
 
 ## Guiding Principles
 
 ### 1. Stay Bluetooth-first
 
-Every architectural change must preserve the reality of A2DP devices:
+Every phase must preserve the core realities of A2DP output:
 
 - unstable connectivity
-- changing PulseAudio/PipeWire sink identity and routing
-- delayed availability after reconnect
-- device-specific latency and buffering behavior
+- sink identity churn
+- delayed post-reconnect availability
+- hardware-specific latency behavior
 
-### 2. Move orchestration into explicit services
+### 2. Finish started refactors before starting new abstractions
 
-The system should be centered around a small set of runtime services rather than implicit shared state and route-driven coordination.
+The repository already contains partial solutions for orchestration, read-side models, startup progress, events, and IPC contracts. The next step is to **complete and normalize** those efforts instead of restarting them under new names.
 
-### 3. Normalize read models
+### 3. Keep migrations incremental
 
-UI and API consumers should read stable, typed snapshots instead of reaching into live runtime objects directly.
+Avoid broad rewrites. Add new services and compatibility layers, migrate callers, validate behavior, then remove legacy access paths only after stability is proven.
 
-### 4. Version internal contracts
+### 4. Prefer operational clarity over theoretical purity
 
-Parent/subprocess IPC, event payloads, and high-value internal models should have explicit schemas and backward-compatible evolution rules.
+This bridge runs in hardware-heavy, failure-prone environments. Diagnostics, contract safety, and recovery visibility are more important than abstract elegance.
 
-### 5. Make runtime behavior observable
+### 5. Expand only after the core becomes boring
 
-Reconnects, re-anchors, sink routing corrections, MA sync gaps, and startup phases should be visible as structured operational data.
+Backend abstraction, local audio outputs, and broader ecosystem expansion are valid directions, but only after the Bluetooth bridge runtime is explicit, observable, and migration-safe.
 
-### 6. Prefer incremental migration
+## Current Architecture Baseline
 
-Do not attempt a full rewrite. Introduce new structures in parallel, migrate callers, and only remove legacy paths once new paths are stable.
-
-## Target Architecture
-
-The desired architecture is still a Bluetooth bridge, but with clearer layers.
+The live codebase already points to the near-term target architecture:
 
 ### Runtime layer
 
 - `BridgeOrchestrator`
-  - owns startup sequencing
-  - owns shutdown and restart semantics
-  - coordinates bridge-wide services
-
-- `DeviceRegistryService`
-  - canonical source of truth for active, disabled, and released devices
-  - publishes immutable device snapshots
-
-- `BluetoothLifecycleService`
-  - pairing, reconnect, release/reclaim, sink acquisition
-
-- `DaemonProcessService`
-  - parent/subprocess lifecycle
-  - command dispatch
-  - subprocess status ingestion
-
-- `PlaybackHealthService`
-  - zombie detection
-  - re-anchor tracking
-  - playback degradation classification
-
-- `MaIntegrationService`
-  - MA auth
-  - MA now-playing and group state sync
-  - control command routing
-
-- `DiagnosticsService`
-  - bridge-wide health summary
-  - per-device event history
-  - structured export and bugreport surfaces
+- `BridgeLifecycleState`
+- `SendspinClient`
+- `BluetoothManager`
+- `BridgeMaIntegrationService`
+- subprocess command / IPC / stderr / stop services
+- playback health and status event builders
 
 ### Read layer
 
@@ -103,649 +81,423 @@ The desired architecture is still a Bluetooth bridge, but with clearer layers.
 - `BridgeSnapshot`
 - `StartupProgressSnapshot`
 - `DeviceHealthSummary`
-- `DeviceEventRecord`
+- onboarding assistant snapshots
 
-Routes and UI should primarily read from these models.
+### Contract layer
 
-### Event layer
+- `protocol_version` for parent/subprocess messages
+- structured status/log/error envelopes in practice, but not yet fully formalized as a finished contract surface
 
-Introduce a small internal event model for important lifecycle changes, for example:
+### Remaining gap
 
-- `device_connected`
-- `device_disconnected`
-- `sink_acquired`
-- `sink_lost`
-- `playback_started`
-- `playback_stalled`
-- `playback_reanchored`
-- `ma_group_changed`
-- `config_changed`
+The architecture is improved, but the center of gravity still sits partly in `state.py`. The roadmap below is about moving from **partially modernized runtime** to **fully explicit runtime ownership**.
 
-This does not need a complex framework. A simple in-process event publisher is enough.
-
-### IPC layer
-
-Parent/subprocess IPC should evolve into an explicit contract:
-
-- `protocol_version`
-- command envelope
-- status envelope
-- event envelope
-- structured error payloads
-- feature/capability flags
-
-## Phase 1: Foundation and Quick Wins
+## Phase 1: Complete the v2 Runtime Foundation
 
 ### Goal
 
-Create a stable foundation for future refactoring without changing the core runtime model.
+Finish the runtime/service/read-model migration that is already underway.
 
-### Workstreams
+### Why this phase exists
 
-#### A. Typed read models
+This phase is not about inventing `BridgeOrchestrator`, snapshots, or startup progress. Those already exist. It is about making them the **canonical path** instead of parallel infrastructure sitting beside older shared-state flows.
 
-Add normalized bridge/device snapshot models and make routes consume them instead of live internal fields wherever practical.
+### Epics
 
-Deliverables:
+#### Epic 1. Complete read-side migration
 
-- `DeviceSnapshot`
-- `BridgeSnapshot`
-- snapshot-building helpers
-- route migration for status/diagnostics/config read paths
+Outcome:
 
-#### B. Event history and health summaries
+- routes and UI rely on snapshot builders and normalized read models consistently
 
-Track operational history per device:
+Backlog:
 
-- reconnect attempts
-- disconnect reasons
-- sink rediscovery attempts
-- sink routing corrections
-- re-anchor timestamps and counts
-- zombie restart counts
-- MA sync failures
+1. Finish migrating status, diagnostics, and config-adjacent read paths to snapshot builders
+2. Remove remaining route assumptions about `SendspinClient` internals where practical
+3. Normalize cross-route status enrichment logic behind snapshot builders
+4. Add targeted tests for snapshot completeness and compatibility behavior
 
-Expose a compact health summary:
+Suggested PRs:
 
-- status severity
-- current degraded mode
-- recent recovery actions
-- active fallback mode, if any
+- PR 1: finish snapshot coverage for status and diagnostics
+- PR 2: snapshot-first route cleanup and compatibility tests
 
-#### C. Startup progress model
+#### Epic 2. Turn device registry into a real ownership service
 
-Expose startup phases so the UI and diagnostics can show where the bridge is blocked:
+Outcome:
 
-- config loaded
-- adapters enumerated
-- BT managers ready
-- MA integration initialized
-- devices restored
-- sinks resolved
-- subprocesses online
+- active, disabled, and released device lookup rules become explicit
 
-#### D. Mock runtime mode
+Backlog:
 
-Introduce a simulation mode for API/UI and integration tests:
+1. Evolve `device_registry` from snapshot helper to canonical device registry service
+2. Move registration and lookup rules out of ad-hoc state access
+3. Centralize disabled/released device handling behind registry APIs
+4. Keep immutable snapshots as the read-side product of the registry
 
-- fake adapters
-- fake BT devices
-- fake subprocess statuses
-- fake MA groups and metadata
+Suggested PRs:
 
-This can start as a code-only debug/test mode before it becomes a user-facing feature.
+- PR 3: registry service introduction with compatibility wrapper
+- PR 4: route and service migration to registry lookups
+
+#### Epic 3. Close orchestration boundaries
+
+Outcome:
+
+- bridge-wide lifecycle ownership becomes explicit and testable
+
+Backlog:
+
+1. Finish centralizing startup/shutdown/restart semantics around `BridgeOrchestrator`
+2. Clarify service ownership boundaries between orchestrator, MA bootstrap, registry, and per-device runtime
+3. Reduce hidden startup coordination through `state.py`
+4. Add integration tests for startup ordering, shutdown ordering, and restart-sensitive flows
+
+Suggested PRs:
+
+- PR 5: orchestrator lifecycle completion
+- PR 6: startup/shutdown integration tests and compat cleanup
 
 ### Exit Criteria
 
-- API responses are built from normalized snapshot models
-- diagnostics can explain why a device is unhealthy
-- startup progress is visible
-- key API/UI flows can be tested without real Bluetooth hardware
+- snapshots are the default read path
+- registry owns device lookup and inventory semantics
+- orchestrator owns bridge lifecycle semantics
+- `state.py` is no longer the primary architectural center
 
-### Out of Scope
-
-- no large orchestration rewrite yet
-- no new backend abstraction yet
-- no major UI redesign
-
-## Phase 2: Orchestration Refactor
+## Phase 2: Contracts, Diagnostics, and Config Lifecycle
 
 ### Goal
 
-Move the core lifecycle out of global shared state and into explicit services.
+Make the bridge easier to evolve safely and easier to operate in production.
 
-### Workstreams
+### Why this phase exists
 
-#### A. Introduce `BridgeOrchestrator`
+The codebase already has the beginnings of versioned IPC, structured diagnostics, health summaries, and config validation. This phase turns those into a finished operational contract.
 
-Responsibilities:
+### Epics
 
-- startup sequencing
-- dependency ordering
-- shutdown behavior
-- restart boundaries
-- bridge-wide error containment
+#### Epic 4. Finish the IPC contract
 
-#### B. Introduce `DeviceRegistryService`
+Outcome:
 
-Responsibilities:
+- parent/subprocess communication can evolve without accidental breakage
 
-- register active devices
-- store disabled/released devices
-- publish immutable snapshots
-- mediate device lookup for routes and services
+Backlog:
 
-#### C. Separate lifecycle services
+1. Formalize command, status, log, and error envelopes around the existing `protocol_version`
+2. Define compatibility behavior for missing/legacy fields
+3. Add explicit contract tests for parent/child parsing behavior
+4. Document supported message guarantees
 
-Split current responsibilities into explicit services:
+Suggested PRs:
 
-- `BluetoothLifecycleService`
-- `DaemonProcessService`
-- `PlaybackHealthService`
-- `MaIntegrationService`
+- PR 7: explicit IPC envelope contract
+- PR 8: IPC compatibility and contract tests
 
-#### D. Reduce `state.py`
+#### Epic 5. Normalize event history and health explanations
 
-Convert `state.py` from a broad state owner into a compatibility layer or remove most of its current responsibilities.
+Outcome:
+
+- diagnostics can explain why a device is degraded, not just that it is degraded
+
+Backlog:
+
+1. Standardize per-device event records for reconnects, sink loss, sink recovery, re-anchor, subprocess failure, and MA sync failures
+2. Build health summaries from event history plus current state
+3. Normalize retention, ordering, and severity classification
+4. Expose richer cause/recovery history in diagnostics and bugreport surfaces
+
+Suggested PRs:
+
+- PR 9: event history normalization
+- PR 10: health explanation and diagnostics enrichment
+
+#### Epic 6. Finish config lifecycle safety
+
+Outcome:
+
+- config changes become migration-ready and safer to reason about
+
+Backlog:
+
+1. Extend validation beyond upload paths to the broader load/save/import lifecycle
+2. Add migration functions keyed by `CONFIG_SCHEMA_VERSION`
+3. Improve validation reporting for import/export flows
+4. Separate user-owned config from runtime-derived state where practical
+
+Suggested PRs:
+
+- PR 11: config lifecycle validation expansion
+- PR 12: config migration framework and runtime/user-state separation
+
+#### Epic 7. Add resource telemetry and hook surfaces
+
+Outcome:
+
+- operators can understand bridge resource usage and external systems can react to lifecycle events
+
+Backlog:
+
+1. Add bridge and subprocess resource telemetry surfaces
+2. Surface startup timings and resource summaries in diagnostics APIs
+3. Formalize hook/webhook events for key lifecycle actions
+4. Add test coverage and failure reporting for hook execution
+
+Suggested PRs:
+
+- PR 13: resource telemetry surfaces
+- PR 14: hook/webhook framework
 
 ### Exit Criteria
 
-- routes no longer rely on runtime object internals for most reads
-- orchestration lives in explicit services
-- device ownership and lookup rules are centralized
-- `state.py` is no longer the architectural center of the application
+- IPC is explicit, versioned, and tested
+- diagnostics explain recent failure and recovery paths
+- config lifecycle is migration-ready
+- the bridge exposes structured operational data, not just logs
 
-### Main Risk
-
-This is the phase most likely to introduce runtime regressions. Migrate incrementally and preserve compatibility wrappers until new code paths are fully validated.
-
-## Phase 3: Contracts, Events, and Operability
+## Phase 3: Onboarding, Recovery UX, and Capability Clarity
 
 ### Goal
 
-Make the system easier to evolve and easier to operate.
+Reduce setup friction and make recovery actions understandable to operators.
 
-### Workstreams
+### Why this phase exists
 
-#### A. Versioned parent/subprocess IPC
+The project already has onboarding assistant logic, startup progress, diagnostics, and runtime explainability. The next step is not to invent onboarding, but to turn the current guidance surfaces into more actionable flows.
 
-Define explicit IPC models and contract tests.
+### Epics
 
-Add:
+#### Epic 8. Expand onboarding assistant into guided setup flows
 
-- protocol version field
-- explicit status schema
-- explicit command schema
-- structured subprocess errors
-- capability negotiation for optional features
+Outcome:
 
-#### B. Internal event bus
+- the path from install to first successful playback becomes shorter and clearer
 
-Introduce a lightweight event system for key lifecycle events.
+Backlog:
 
-Use it for:
+1. Turn current onboarding checks into guided flows for adapters, devices, sinks, and MA auth
+2. Add more actionable remediation text and direct UI entry points
+3. Align onboarding state with live diagnostics and startup progress
+4. Reuse the same guidance model across dashboard, diagnostics, and bugreport outputs
 
-- diagnostics history
-- UI updates
-- startup progress
-- optional hooks/webhooks
+Suggested PRs:
 
-#### C. Hook and webhook model
+- PR 15: guided onboarding backend surfaces
+- PR 16: onboarding UI integration and remediation actions
 
-Formalize operational hooks for:
+#### Epic 9. Introduce an explicit capability model
 
-- stream start
-- stream stop
-- reconnect start
-- reconnect success
-- reconnect failure
-- device released/reclaimed
-- update available
+Outcome:
 
-#### D. Config lifecycle improvements
+- device differences become first-class, not implied
 
-Add:
+Backlog:
 
-- configuration validation report
-- explicit migration path for stored config
-- import/export validation messages
-- safer separation between runtime state and user config
+1. Model bridge/device capabilities explicitly
+2. Distinguish battery support, release/reclaim support, volume routing modes, sink presence, and format-related capabilities
+3. Expose capabilities in API payloads and diagnostics
+4. Let UI render capability-aware controls and messaging
+
+Suggested PRs:
+
+- PR 17: capability model and API exposure
+- PR 18: capability-aware UI and diagnostics
+
+#### Epic 10. Improve latency and recovery tooling
+
+Outcome:
+
+- multi-device deployments become easier to tune and debug
+
+Backlog:
+
+1. Add latency guidance workflow for multi-device setups
+2. Improve sink verification and sink recovery explainability
+3. Add richer structured exports for event timelines, health summaries, and recovery history
+4. Expose sync-related operator hints in diagnostics and onboarding
+
+Suggested PRs:
+
+- PR 19: latency and sink recovery guidance
+- PR 20: richer diagnostics exports and recovery tooling
 
 ### Exit Criteria
 
-- IPC is versioned and tested
-- high-value lifecycle changes are modeled as events
-- hooks have a consistent contract
-- config changes are validated and migration-ready
+- new users can identify setup blockers with less guesswork
+- operators can understand available recovery actions
+- capability differences are explicit in the UI and API
 
-## Phase 4: Product and UX Enhancements
+## Phase 4: Backend Abstraction for v3
 
 ### Goal
 
-Use the stronger architecture to improve usability, onboarding, and diagnostics depth.
+Prepare the bridge for selective non-Bluetooth expansion without destabilizing the current runtime.
 
-### Workstreams
+### Why this phase exists
 
-#### A. Guided onboarding
+The v3 direction is reasonable only after the current Bluetooth runtime is explicit and stable. Backend abstraction should emerge from a stable core, not be used as a substitute for finishing current refactors.
 
-Add guided flows for:
+### Epics
 
-- adapter selection
-- device assignment
-- sink verification
-- MA auth validation
-- latency calibration support
+#### Epic 11. Introduce backend abstraction layer
 
-#### B. Capability model
+Outcome:
 
-Model device/bridge capabilities explicitly, for example:
+- the current Bluetooth implementation becomes one backend under a common contract
 
-- battery-capable
-- release/reclaim-capable
-- preferred-format-capable
-- MA-volume-capable
-- hardware-volume-capable
+Backlog:
 
-#### C. Richer diagnostics exports
+1. Define `AudioBackend` abstraction and capability/status contracts
+2. Wrap the existing Bluetooth runtime in `BluetoothA2DPBackend`
+3. Keep subprocess behavior backend-agnostic where possible
+4. Preserve current behavior while introducing abstraction seams
 
-Add structured exports for:
+Suggested PRs:
 
-- event timeline
-- health summary
-- sync behavior history
-- adapter and sink recovery logs
+- PR 21: backend abstraction contract
+- PR 22: Bluetooth backend wrapper and compatibility path
+
+#### Epic 12. Introduce backend-oriented config schema
+
+Outcome:
+
+- the config model is ready for multiple backend types
+
+Backlog:
+
+1. Define config schema v2 around player/backend configuration
+2. Add migration tooling from the current Bluetooth-device model
+3. Preserve compatibility loading during transition
+4. Document migration behavior and downgrade assumptions
+
+Suggested PRs:
+
+- PR 23: config schema v2
+- PR 24: migration tool and compatibility loading
+
+#### Epic 13. Add the first non-Bluetooth backends
+
+Outcome:
+
+- backend abstraction is proven on realistic adjacent use cases
+
+Backlog:
+
+1. Add `LocalSinkBackend` for PulseAudio/PipeWire
+2. Add `ALSADirectBackend` for stripped or minimal environments
+3. Validate capability reporting and subprocess startup behavior across backend types
+4. Ensure diagnostics and config UX remain coherent across backends
+
+Suggested PRs:
+
+- PR 25: Local sink backend
+- PR 26: ALSA direct backend
 
 ### Exit Criteria
 
-- a new user can understand setup failures with less guesswork
-- diagnostics are useful for both users and maintainers
-- device differences are explicit in the UI and API
+- Bluetooth remains the primary and most stable backend
+- backend abstraction is proven without regressing the current bridge
+- config and diagnostics remain coherent across backend types
 
-## Phase 5: Broader Sendspin Alignment
+## Phase 5: Selective Expansion After Core Stability
 
 ### Goal
 
-Borrow selectively from the broader Sendspin ecosystem once the bridge core is stable.
+Expand only where the project gains clear product value without diluting its focus.
 
-### Opportunities
+### Candidate Areas
 
-#### A. Sync telemetry
+#### Epic 14. High-value adjacent expansion
 
-Use ideas from `time-filter` and `sync-test`:
+Possible backlog:
 
-- drift trend reporting
-- measured sync error surfaces
-- structured re-anchor analysis
-- optional calibration or export tooling
+1. USB audio auto-discovery
+2. virtual sink/testing-oriented backend
+3. richer sync telemetry and drift reporting
+4. stronger Sendspin-aligned capability reporting
 
-#### B. Role-aware evolution
+Suggested PRs:
 
-Move closer to the wider Sendspin model where useful:
+- PR 27: one adjacent backend or USB-discovery feature
+- PR 28: sync telemetry and diagnostics integration
 
-- richer metadata handling
-- improved artwork handling
-- stronger controller semantics around MA groups
-- capability reporting aligned with protocol concepts
+#### Epic 15. Strategic optional work
 
-#### C. Future backend abstraction
+Only pursue if core phases are stable and justified by demand:
 
-Prepare for additional endpoint backends only after Bluetooth lifecycle contracts are stable.
+1. Snapcast client backend
+2. VBAN backend
+3. multi-bridge federation
+4. HACS/custom component strategy
+5. plugin SDK or platform extension surface
+6. OpenHome or similar ecosystem alignment
 
-Possible future backends:
+Suggested PRs:
 
-- Bluetooth output backend
-- local audio output backend
-- web/cast companion endpoint
+- PR 29+: only as separate strategy tracks, not as default roadmap assumptions
 
 ### Exit Criteria
 
-- the bridge remains Bluetooth-first
-- sync quality is observable, not inferred only from symptoms
-- the architecture does not block future endpoint expansion
-
-## Phase 6: Strategic Platform Work
-
-This phase is optional and should only start if the project deliberately evolves beyond a focused Bluetooth bridge.
-
-Potential areas:
-
-- multiple bridge federation
-- aggregated cross-bridge diagnostics
-- unified control plane
-- plugin or extension surfaces
-- deployment-profile specialization
-
-## What to Borrow from Other Projects
-
-### From `Multi-SendSpin-Player-Container`
-
-Adopt:
-
-- explicit startup orchestrator
-- startup progress tracking
-- mock hardware/runtime strategy
-- richer diagnostics surface
-- cleaner service registration mindset
-
-Do not copy blindly:
-
-- a generic local-audio-first domain model
-- heavy DI patterns without clear value
-- service sprawl for simple flows
-
-### From the Sendspin ecosystem
-
-Adopt:
-
-- clearer role and capability thinking
-- explicit sync telemetry
-- versioned contracts
-- stronger separation between protocol core and platform-specific output logic
-
-Do not adopt too early:
-
-- broad backend abstraction before Bluetooth lifecycle refactor
-- protocol-expansion work that distracts from BT reliability
-
-## Execution Backlog
-
-The backlog below is ordered by implementation value and dependency safety, not by estimated duration.
-
-### Epic 1: Typed Read Models and Snapshot Builders
-
-Outcome:
-
-- routes and UI consume stable, normalized models
-
-Backlog:
-
-1. Add `DeviceSnapshot` dataclass/model
-2. Add `BridgeSnapshot` dataclass/model
-3. Add snapshot builders around current runtime objects
-4. Migrate `/api/status*` and diagnostics routes to snapshots
-5. Migrate config read enrichment to snapshot-based lookup
-6. Add tests for snapshot serialization and missing-field behavior
-
-Suggested PRs:
-
-- PR 1: snapshot models and builders
-- PR 2: route migration for status and diagnostics
-
-### Epic 2: Device Health and Event History
-
-Outcome:
-
-- the bridge can explain current and recent device problems
-
-Backlog:
-
-1. Add `DeviceEventRecord`
-2. Add per-device event ring buffer
-3. Record reconnect, re-anchor, sink recovery, zombie restart, and MA sync failures
-4. Add `DeviceHealthSummary`
-5. Expose health and recent history in diagnostics API
-6. Add tests for event retention and severity classification
-
-Suggested PRs:
-
-- PR 3: event history infrastructure
-- PR 4: health summary and diagnostics exposure
-
-### Epic 3: Startup Progress and Bridge Readiness
-
-Outcome:
-
-- startup issues become visible and debuggable
-
-Backlog:
-
-1. Add `StartupProgressSnapshot`
-2. Model startup phases and current blocking step
-3. Surface progress through API
-4. Add simple UI hooks for progress display
-5. Add tests for success and failure paths
-
-Suggested PR:
-
-- PR 5: startup progress model and API surface
-
-### Epic 4: Mock Runtime / Simulator Mode
-
-Outcome:
-
-- critical flows are testable without real hardware
-
-Backlog:
-
-1. Add a mock adapter/device provider
-2. Add fake subprocess state source
-3. Add fake MA state provider
-4. Allow routes and snapshot builders to run against mock runtime
-5. Add integration tests for common UI/API scenarios
-
-Suggested PRs:
-
-- PR 6: mock runtime core
-- PR 7: integration tests and developer documentation
-
-### Epic 5: Bridge Orchestrator
-
-Outcome:
-
-- startup and shutdown logic is centralized
-
-Backlog:
-
-1. Introduce `BridgeOrchestrator`
-2. Move bootstrap sequencing into the orchestrator
-3. Move shutdown and cleanup semantics into the orchestrator
-4. Keep compatibility wrapper paths until stable
-5. Add integration tests for startup and shutdown ordering
-
-Suggested PR:
-
-- PR 8: orchestrator introduction with compatibility layer
-
-### Epic 6: Device Registry Service
-
-Outcome:
-
-- device ownership and lookup become explicit
-
-Backlog:
-
-1. Introduce `DeviceRegistryService`
-2. Move active client registration into the registry
-3. Move disabled/released device metadata into the registry
-4. Expose immutable registry snapshots
-5. Migrate routes away from direct `state.py` lookups
-
-Suggested PRs:
-
-- PR 9: registry service
-- PR 10: route and service migration to registry
-
-### Epic 7: Lifecycle Service Split
-
-Outcome:
-
-- runtime responsibilities are easier to reason about and test
-
-Backlog:
-
-1. Extract `BluetoothLifecycleService`
-2. Extract `DaemonProcessService`
-3. Extract `PlaybackHealthService`
-4. Extract `MaIntegrationService`
-5. Reduce `SendspinClient` to a thinner per-device runtime component
-
-Suggested PRs:
-
-- PR 11: extract daemon and playback health service
-- PR 12: extract Bluetooth lifecycle and MA integration service
-
-### Epic 8: Versioned IPC Contracts
-
-Outcome:
-
-- subprocess communication can evolve safely
-
-Backlog:
-
-1. Define command envelope
-2. Define status envelope
-3. Add protocol version
-4. Add structured subprocess error payloads
-5. Add IPC contract tests
-6. Add compatibility behavior for older payload assumptions if needed
-
-Suggested PR:
-
-- PR 13: versioned IPC contract
-
-### Epic 9: Internal Event Model
-
-Outcome:
-
-- lifecycle changes become first-class runtime signals
-
-Backlog:
-
-1. Add lightweight event publisher
-2. Publish high-value device and bridge events
-3. Route diagnostics history through the event publisher
-4. Integrate startup progress and optional hook triggers
-
-Suggested PR:
-
-- PR 14: event publisher and event migration
-
-### Epic 10: Hook/Webhook Framework
-
-Outcome:
-
-- external integrations become predictable and extensible
-
-Backlog:
-
-1. Define hook event contract
-2. Add start/stop/reconnect hook support
-3. Add error and update-related hook support
-4. Add validation and logging around hook execution
-5. Add tests for payloads and failure reporting
-
-Suggested PR:
-
-- PR 15: formal hook framework
-
-### Epic 11: Config Validation and Migration
-
-Outcome:
-
-- config changes are safer and more maintainable
-
-Backlog:
-
-1. Add explicit config schema validation
-2. Add migration functions for persisted config versions
-3. Improve import/export validation reporting
-4. Separate runtime state from user-owned config where practical
-
-Suggested PR:
-
-- PR 16: config validation and migrations
-
-### Epic 12: Onboarding and UX Improvements
-
-Outcome:
-
-- setup becomes easier for new users
-
-Backlog:
-
-1. Adapter assignment assistant
-2. Sink verification helper
-3. MA auth diagnostics assistant
-4. Latency calibration guidance
-5. UI exposure for health and startup progress
-
-Suggested PRs:
-
-- PR 17: backend support for onboarding flows
-- PR 18: UI integration for onboarding and diagnostics
-
-### Epic 13: Sync Telemetry and Sendspin Alignment
-
-Outcome:
-
-- sync quality becomes measurable and future extension becomes easier
-
-Backlog:
-
-1. Add richer sync telemetry model
-2. Track drift and re-anchor patterns over time
-3. Expose metrics through diagnostics exports
-4. Improve capability reporting in a way that aligns with broader Sendspin concepts
-
-Suggested PR:
-
-- PR 19: sync telemetry and capability model
+- expansion does not weaken Bluetooth reliability
+- the architecture stays understandable
+- new backends or platforms prove practical value, not just conceptual neatness
 
 ## Recommended PR Sequence
 
-The safest order is:
+The safest implementation order is:
 
-1. snapshot models
-2. event history
-3. health summary
-4. startup progress
-5. mock runtime
-6. orchestrator
-7. registry
-8. lifecycle service extraction
-9. versioned IPC
-10. internal events
-11. hooks
-12. config validation and migrations
-13. onboarding improvements
-14. sync telemetry
+1. finish snapshot/read-side migration
+2. formalize registry ownership
+3. close orchestrator lifecycle boundaries
+4. finish IPC contracts
+5. normalize event history and health explanations
+6. finish config lifecycle and migrations
+7. add resource telemetry and hooks
+8. expand onboarding into guided flows
+9. introduce capability model
+10. improve latency and recovery tooling
+11. add backend abstraction
+12. add backend-oriented config schema
+13. add the first non-Bluetooth backends
+14. only then consider broader expansion
 
 ## Dependency Summary
 
-- snapshot models should come before broad route migration
-- event history should come before health summary
-- startup progress can land before the orchestration rewrite
-- mock runtime should land before heavy lifecycle refactors
-- orchestrator should land before major service extraction
-- registry should land before route de-coupling from runtime internals
-- versioned IPC should land before adding many subprocess features
-- capability model should come after snapshots and registry exist
+- route cleanup should follow snapshot-first read paths
+- registry ownership should precede full `state.py` de-centering
+- explicit IPC contracts should land before substantial backend expansion
+- config schema v2 should come after the current config lifecycle is migration-ready
+- backend abstraction should come after runtime ownership is explicit
+- adjacent backends should come before speculative platform work
 
-## Definition of Done for the Roadmap
+## Definition of Done
 
-The roadmap can be considered successfully executed when:
+This roadmap is successfully executed when:
 
 - runtime ownership is explicit
-- API and UI read from normalized models
-- subprocess contracts are versioned
-- Bluetooth failure and recovery paths are observable
-- critical flows are testable without real hardware
-- configuration is validated and migration-ready
-- the architecture is ready for selective Sendspin ecosystem alignment without compromising Bluetooth reliability
+- routes and UI read from normalized models by default
+- device inventory and lookup rules are centralized
+- subprocess contracts are explicit and versioned
+- diagnostics explain both symptoms and recent recovery history
+- config changes are validated and migration-ready
+- onboarding and recovery flows reduce setup friction
+- the project can expand selectively without compromising Bluetooth reliability
 
 ## Guardrails
 
 Do not:
 
-- rewrite the bridge into a generic audio platform too early
-- expand backend abstraction before lifecycle contracts are stable
+- restart already completed refactors as if they do not exist
+- treat demo/mock infrastructure as the main roadmap instead of a supporting tool
+- begin generic platform expansion before finishing current runtime ownership work
 - move multiple critical lifecycle responsibilities in one PR
-- let diagnostics and mock mode lag behind refactors
-- over-engineer the event layer when a small in-process publisher is enough
+- turn backend abstraction into a pretext for rewriting the bridge
 
 Do:
 
 - migrate incrementally
-- preserve compatibility shims while changing runtime ownership
-- validate behavior after each structural change
-- keep Bluetooth recovery paths as the top priority
+- keep compatibility layers while callers are being moved
+- test real runtime behavior after each structural change
+- keep diagnostics, docs, and contract surfaces aligned with runtime changes
+- preserve Bluetooth recovery reliability as the highest priority

--- a/ROADMAP.ru.md
+++ b/ROADMAP.ru.md
@@ -1,0 +1,88 @@
+# Дорожная карта (краткая версия)
+
+Эта страница — краткое русское резюме актуального roadmap. Полная версия и основной source of truth находятся в [`ROADMAP.md`](ROADMAP.md).
+
+## Зачем обновлён roadmap
+
+Проект уже прошёл часть большого внутреннего рефакторинга. В кодовой базе **уже есть**:
+
+- `BridgeOrchestrator`
+- startup progress и runtime metadata
+- snapshot/read-side модели для status и diagnostics
+- protocol-versioned IPC helpers
+- onboarding assistant и базовая config validation
+
+Поэтому roadmap больше не должен описывать эти вещи как «будущие». Его задача теперь — довести начатую архитектуру до завершённого состояния и только потом идти в v3-расширение.
+
+## Куда проект движется
+
+### Фаза 1. Завершить foundation текущего v2 runtime
+
+Главная цель — сделать уже добавленные архитектурные слои каноническими:
+
+- довести migration routes на snapshots
+- превратить `device_registry` в полноценный ownership service
+- окончательно вынести lifecycle semantics в `BridgeOrchestrator`
+- уменьшить центральную роль `state.py`
+
+### Фаза 2. Контракты, диагностика и lifecycle конфигурации
+
+Цель — сделать bridge безопаснее для развития и понятнее в эксплуатации:
+
+- формализовать IPC envelopes вокруг `protocol_version`
+- унифицировать event history и health explanations
+- довести config lifecycle до migration-ready состояния
+- добавить resource telemetry и hook/webhook surfaces
+
+### Фаза 3. Onboarding, recovery UX и capability model
+
+Цель — уменьшить количество guesswork у пользователей и операторов:
+
+- превратить текущий onboarding assistant в более guided setup flow
+- сделать recovery actions понятнее
+- добавить явную capability model для устройств и bridge-функций
+- улучшить latency guidance и structured diagnostics exports
+
+### Фаза 4. Backend abstraction для v3
+
+Эта фаза начинается только после стабилизации Bluetooth core:
+
+- ввести `AudioBackend` abstraction
+- завернуть текущий runtime в `BluetoothA2DPBackend`
+- подготовить config schema v2
+- добавить первые соседние backend'ы: `LocalSinkBackend` и `ALSADirectBackend`
+
+### Фаза 5. Выборочное расширение
+
+Только после выполнения предыдущих фаз:
+
+- USB audio auto-discovery
+- virtual sink / test-oriented backend
+- richer sync telemetry
+- при наличии спроса — Snapcast, VBAN, federation, HACS, plugin surfaces
+
+## Рекомендуемый порядок работ
+
+1. Закончить snapshot/read-side migration.
+2. Формализовать registry ownership.
+3. Довести lifecycle boundaries orchestrator'а.
+4. Завершить IPC contracts и event/diagnostics model.
+5. Сделать config lifecycle migration-ready.
+6. Усилить onboarding, capability model и recovery UX.
+7. Только потом переходить к backend abstraction и v3.
+
+## Важные ограничения
+
+Не стоит:
+
+- начинать новый «большой рефакторинг» с нуля
+- превращать mock/demo в отдельную главную фазу развития
+- идти в generic audio platform раньше стабилизации Bluetooth runtime
+- тащить backend abstraction как оправдание полного rewrite
+
+Стоит:
+
+- мигрировать инкрементально
+- сохранять compatibility layers во время переходов
+- проверять поведение на реальном runtime после structural changes
+- держать Bluetooth reliability главным приоритетом


### PR DESCRIPTION
Rewrite Key Capabilities in both README.md and README.ru.md to emphasize user-facing value over internal architecture:

- **Synchronized streaming** via the Sendspin protocol with lossless audio
- **No-console setup**: scan, pair, and configure entirely from the web UI
- **Deep Music Assistant integration** (now playing, transport, groups, WebSocket)
- **Home Assistant automations**: BT speakers as MA player entities for scripts, scenes, dashboards, and voice assistants
- **Multi-room ready** with multi-bridge support
- **Five deployment options** with concrete 60+ endpoint count

Also adds:
- `What you need` / `Что потребуется` prerequisites section before Quick Start
- ROADMAP.md link in Project links

Both EN and RU READMEs updated symmetrically (34 insertions, 16 deletions each).