### PR TITLE
chore: release 2.42.2-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.42.2-rc.1] - 2026-03-20
+
+### Changed
+- The compact UI system is now much more consistent across the live app: primary/secondary/icon actions, media transport controls, table-like rows, and empty states now follow a shared visual language instead of mixing several older styles.
+- Configuration, diagnostics, discovery, and device list surfaces now use denser data-row and placeholder treatments, keeping the current information architecture while making the interface feel more coherent and Home Assistant-aligned.
+- The login screen now follows the same refreshed compact styling as the main application, reducing the visual jump between authentication and the dashboard.
+
+### Fixed
+- Demo mode regains compatibility with the refreshed UI preview workflow, so local demo validation continues to work against the current Bluetooth manager behavior.
+
 ## [2.42.1] - 2026-03-20
 
 ### Added

--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-VERSION = "2.42.1"
+VERSION = "2.42.2-rc.1"
 BUILD_DATE = "2026-03-20"
 CONFIG_SCHEMA_VERSION = 1
 UPDATE_CHANNELS = ("stable", "rc", "beta")


### PR DESCRIPTION
## Summary
- bump the runtime version to 2.42.2-rc.1
- add the RC changelog entry for the compact UI system refresh

## Validation
- python3 -m pytest -q
- python3 -m ruff check .
- node --check static/app.js
- git --no-pager diff --check
