### PR TITLE
Enhance Bluetooth scan modal

### DIFF
--- a/routes/api_bt.py
+++ b/routes/api_bt.py
@@ -485,14 +485,37 @@ def api_bt_scan():
     """Start an async BT device scan; returns a job_id immediately."""
     if is_scan_running():
         return jsonify({"error": "A scan is already in progress"}), 409
+    data = request.get_json(silent=True) or {}
+    raw_adapter = (data.get("adapter") or "").strip()
+    adapter_value = "" if raw_adapter.lower() == "all" else raw_adapter
+    try:
+        adapter = validate_adapter(adapter_value)
+        audio_only = _coerce_scan_audio_only(data.get("audio_only"))
+        adapter_macs = _resolve_scan_adapter_macs(adapter)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     if time.monotonic() - _last_scan_completed < _SCAN_COOLDOWN:
         remaining = int(_SCAN_COOLDOWN - (time.monotonic() - _last_scan_completed)) + 1
         return jsonify({"error": "Scan cooldown active", "retry_after": remaining}), 429
     job_id = str(uuid.uuid4())
-    create_scan_job(job_id)
-    t = threading.Thread(target=_run_bt_scan, args=(job_id,), daemon=True, name=f"bt-scan-{job_id[:8]}")
+    scan_options = _build_scan_options(adapter, audio_only, adapter_macs)
+    expected_duration = _estimate_scan_duration(adapter_macs)
+    create_scan_job(
+        job_id,
+        {
+            "scan_options": scan_options,
+            "expected_duration": expected_duration,
+            "started_at": time.time(),
+        },
+    )
+    t = threading.Thread(
+        target=_run_bt_scan,
+        args=(job_id, adapter, audio_only),
+        daemon=True,
+        name=f"bt-scan-{job_id[:8]}",
+    )
     t.start()
-    return jsonify({"job_id": job_id})
+    return jsonify({"job_id": job_id, "scan_options": scan_options, "expected_duration": expected_duration})
 
 
 @bt_bp.route("/api/bt/scan/result/<job_id>", methods=["GET"])
@@ -502,8 +525,25 @@ def api_bt_scan_result(job_id: str):
     if job is None:
         return jsonify({"error": "Job not found"}), 404
     if job["status"] == "running":
-        return jsonify({"status": "running"})
-    return jsonify({"status": "done", "devices": job.get("devices", []), "error": job.get("error")})
+        return jsonify(
+            {
+                "status": "running",
+                "scan_options": job.get("scan_options", {}),
+                "expected_duration": job.get("expected_duration"),
+                "started_at": job.get("started_at"),
+            }
+        )
+    return jsonify(
+        {
+            "status": "done",
+            "devices": job.get("devices", []),
+            "error": job.get("error"),
+            "scan_options": job.get("scan_options", {}),
+            "expected_duration": job.get("expected_duration"),
+            "started_at": job.get("started_at"),
+            "stats": job.get("stats", {}),
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -514,6 +554,78 @@ _MAX_SCAN_RESULTS = 50
 
 _last_scan_completed: float = 0.0
 _SCAN_COOLDOWN = 10.0  # seconds between scans
+_SCAN_BASE_DURATION = 15
+_SCAN_ADAPTER_OVERHEAD = 2
+
+
+def _coerce_scan_audio_only(value) -> bool:
+    """Return a normalized audio-only flag from request JSON."""
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    raise ValueError("Invalid audio_only flag")
+
+
+def _resolve_scan_adapter_macs(adapter: str) -> "list[str]":
+    """Resolve a selected adapter identifier into bluetoothctl adapter MACs."""
+    adapter_macs = list_bt_adapters()
+    if not adapter:
+        return adapter_macs
+    normalized = adapter.strip()
+    if not normalized:
+        return adapter_macs
+    if normalized.lower() == "all":
+        return adapter_macs
+    if normalized.lower().startswith("hci"):
+        try:
+            idx = int(normalized[3:])
+        except ValueError as exc:
+            raise ValueError("Invalid adapter identifier") from exc
+        if idx < 0 or idx >= len(adapter_macs):
+            raise ValueError("Selected adapter is not available")
+        return [adapter_macs[idx].upper()]
+    normalized = normalized.upper()
+    if normalized not in {mac.upper() for mac in adapter_macs}:
+        raise ValueError("Selected adapter is not available")
+    return [normalized]
+
+
+def _build_scan_options(adapter: str, audio_only: bool, adapter_macs: "list[str]") -> dict:
+    """Build the public scan-options payload returned to the UI."""
+    return {
+        "adapter": adapter,
+        "audio_only": audio_only,
+        "adapter_scope": "all" if not adapter else "selected",
+        "adapter_count": max(len(adapter_macs), 1 if adapter else 0),
+    }
+
+
+def _estimate_scan_duration(adapter_macs: "list[str]") -> int:
+    """Return a client-facing timed-scan duration hint in seconds."""
+    return _SCAN_BASE_DURATION + max(len(adapter_macs) - 1, 0) * _SCAN_ADAPTER_OVERHEAD
+
+
+def _classify_audio_capability(out: str) -> bool:
+    """Return True when bluetoothctl info suggests the device is audio-capable."""
+    out_lower = out.lower()
+    class_m = re.search(r"\bClass:\s+(0x[0-9A-Fa-f]+)", out)
+    if class_m:
+        cls = int(class_m.group(1), 16)
+        return ((cls >> 8) & 0x1F) == 4
+    if any(u in out_lower for u in _AUDIO_UUIDS):
+        return True
+    if "UUID:" in out:
+        return False
+    return True
 
 
 def _run_bluetoothctl_scan(adapter_macs: "list[str]") -> str:
@@ -615,10 +727,10 @@ def _resolve_unnamed_devices(all_macs: "set[str]", names: "dict[str, str]") -> N
                 names[mac] = name
 
 
-def _enrich_audio_device(mac: str, names: "dict[str, str]") -> "dict | None":
-    """Return device info dict if the device is audio-capable, else None."""
+def _enrich_scan_device(mac: str, names: "dict[str, str]", audio_only: bool = True) -> "dict | None":
+    """Return scan device info, optionally filtering out non-audio rows."""
     if not validate_mac(mac):
-        return {"mac": mac, "name": mac}
+        return {"mac": mac, "name": mac, "audio_capable": True}
     try:
         r = subprocess.run(
             ["bluetoothctl", "info", mac],
@@ -627,34 +739,27 @@ def _enrich_audio_device(mac: str, names: "dict[str, str]") -> "dict | None":
             timeout=4,
         )
         out = r.stdout
-        out_lower = out.lower()
     except Exception:
-        return {"mac": mac, "name": names.get(mac, mac)}
+        return {"mac": mac, "name": names.get(mac, mac), "audio_capable": True}
     if mac not in names:
         nm = re.search(r"\bName:\s+(.*)", out)
         if nm:
             n = nm.group(1).strip()
             if n and not re.match(r"^[0-9A-Fa-f]{2}[-:]", n):
                 names[mac] = n
-    class_m = re.search(r"Class:\s+(0x[0-9A-Fa-f]+)", out)
-    if class_m:
-        cls = int(class_m.group(1), 16)
-        if (cls >> 8) & 0x1F != 4:
-            return None
-    elif any(u in out_lower for u in _AUDIO_UUIDS):
-        pass
-    elif "UUID:" in out:
+    audio_capable = _classify_audio_capability(out)
+    if audio_only and not audio_capable:
         return None
-    return {"mac": mac, "name": names.get(mac, mac)}
+    return {"mac": mac, "name": names.get(mac, mac), "audio_capable": audio_capable}
 
 
-def _run_bt_scan(job_id: str) -> None:
+def _run_bt_scan(job_id: str, adapter: str = "", audio_only: bool = True) -> None:
     """Perform BT scan in a background thread and store result in state."""
     global _last_scan_completed
     # Apply cooldown to every scan attempt, even if later enrichment fails.
     _last_scan_completed = time.monotonic()
     try:
-        adapter_macs = list_bt_adapters()
+        adapter_macs = _resolve_scan_adapter_macs(adapter)
 
         result_stdout = _run_bluetoothctl_scan(adapter_macs)
         seen, names, device_adapter, active_macs = _parse_scan_output(result_stdout)
@@ -669,7 +774,7 @@ def _run_bt_scan(job_id: str) -> None:
         devices = []
         if all_macs:
             with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
-                futures = {pool.submit(_enrich_audio_device, mac, names): mac for mac in all_macs}
+                futures = {pool.submit(_enrich_scan_device, mac, names, audio_only): mac for mac in all_macs}
                 for fut in concurrent.futures.as_completed(futures):
                     result = fut.result()
                     if result is not None:
@@ -677,9 +782,22 @@ def _run_bt_scan(job_id: str) -> None:
 
         for d in devices:
             d["adapter"] = device_adapter.get(d["mac"], "")
+            d["supports_import"] = bool(d.get("audio_capable", True))
+            d["kind"] = "audio" if d.get("audio_capable", True) else "other"
 
         devices.sort(key=lambda d: (d["name"] == d["mac"], d["name"]))
-        finish_scan_job(job_id, {"devices": devices})
+        finish_scan_job(
+            job_id,
+            {
+                "devices": devices,
+                "stats": {
+                    "total_candidates": len(all_macs),
+                    "returned_candidates": len(devices),
+                    "audio_candidates": sum(1 for d in devices if d.get("audio_capable", True)),
+                    "audio_only": audio_only,
+                },
+            },
+        )
     except Exception:
         logger.exception("BT scan failed")
         finish_scan_job(job_id, {"devices": [], "error": "Bluetooth scan failed"})

--- a/services/async_job_state.py
+++ b/services/async_job_state.py
@@ -48,11 +48,13 @@ def get_async_job(job_id: str) -> dict[str, Any] | None:
         return dict(job) if job else None
 
 
-def create_scan_job(job_id: str) -> None:
+def create_scan_job(job_id: str, initial_data: dict[str, Any] | None = None) -> None:
     """Register a new in-progress scan job."""
     with _scan_jobs_lock:
         _evict_expired_jobs(_scan_jobs, _SCAN_JOB_TTL)
         _scan_jobs[job_id] = {"status": "running", "created": _time.time()}
+        if initial_data:
+            _scan_jobs[job_id].update(initial_data)
 
 
 def finish_scan_job(job_id: str, result: dict[str, Any]) -> None:

--- a/state.py
+++ b/state.py
@@ -427,9 +427,9 @@ def get_async_job(job_id: str) -> dict | None:
     return _async_job_state.get_async_job(job_id)
 
 
-def create_scan_job(job_id: str) -> None:
+def create_scan_job(job_id: str, initial_data: dict | None = None) -> None:
     """Register a new in-progress scan job."""
-    _async_job_state.create_scan_job(job_id)
+    _async_job_state.create_scan_job(job_id, initial_data)
 
 
 def finish_scan_job(job_id: str, result: dict) -> None:

--- a/static/app.js
+++ b/static/app.js
@@ -4056,6 +4056,8 @@ async function loadBtAdapters() {
     });
     renderAdaptersTable();
     rebuildAdapterDropdowns();
+    _renderBtScanAdapterOptions();
+    _syncBtScanControls();
 }
 
 // ---- Adapter panel ----
@@ -4499,6 +4501,178 @@ function _openBluetoothInventory(options) {
 }
 
 var _btScanModalEscHandler = null;
+var _btScanModalState = {
+    adapter: '',
+    audioOnly: true,
+    activeJobId: '',
+    isRunning: false,
+    expectedDuration: 15,
+    startedAtMs: 0,
+    progressTimer: null,
+    lastDevices: [],
+    lastStats: null,
+    lastError: '',
+};
+var _scanCooldownTimer = null;
+var _scanCooldownRemaining = 0;
+
+function _getBtScanAdapters() {
+    return btAdapters.filter(function(adapter) {
+        return adapter && !adapter.manual && (adapter.id || adapter.mac);
+    });
+}
+
+function _getBtScanAdapterValue(adapter) {
+    return adapter && (adapter.id || adapter.mac) ? (adapter.id || adapter.mac) : '';
+}
+
+function _getBtScanAdapterLabel(adapterValue) {
+    if (!adapterValue) return 'All adapters';
+    var adapter = _findAdapterRecord(adapterValue, adapterValue);
+    if (!adapter) return adapterValue;
+    return adapter.customName || adapter.detectedName || adapter.name || adapter.id || adapter.mac || adapterValue;
+}
+
+function _estimateBtScanDurationForSelection(adapterValue) {
+    var adapterCount = adapterValue ? 1 : _getBtScanAdapters().length;
+    return 15 + Math.max(adapterCount - 1, 0) * 2;
+}
+
+function _renderBtScanAdapterOptions() {
+    var select = document.getElementById('scan-adapter-select');
+    if (!select) return;
+    var adapters = _getBtScanAdapters();
+    var currentValue = _btScanModalState.adapter || '';
+    var options = ['<option value="">All adapters</option>'];
+    adapters.forEach(function(adapter) {
+        var value = _getBtScanAdapterValue(adapter);
+        var label = adapter.customName || adapter.detectedName || adapter.name || value;
+        var meta = [];
+        if (adapter.id && label !== adapter.id) meta.push(adapter.id);
+        if (adapter.mac) meta.push(adapter.mac);
+        options.push(
+            '<option value="' + escHtmlAttr(value) + '">' +
+                escHtml(label + (meta.length ? ' · ' + meta.join(' · ') : '')) +
+            '</option>'
+        );
+    });
+    select.innerHTML = options.join('');
+    var isAvailable = !currentValue || adapters.some(function(adapter) {
+        return _getBtScanAdapterValue(adapter) === currentValue;
+    });
+    _btScanModalState.adapter = isAvailable ? currentValue : '';
+    select.value = _btScanModalState.adapter || '';
+}
+
+function _setBtScanProgressPill(variant, label) {
+    var stateEl = document.getElementById('scan-progress-state');
+    if (!stateEl) return;
+    stateEl.className = 'scan-status-pill' + (variant ? ' ' + variant : '');
+    stateEl.textContent = label;
+}
+
+function _clearBtScanProgressTimer() {
+    if (_btScanModalState.progressTimer) {
+        clearInterval(_btScanModalState.progressTimer);
+        _btScanModalState.progressTimer = null;
+    }
+}
+
+function _renderBtScanProgress() {
+    var progress = document.getElementById('scan-progress');
+    var detail = document.getElementById('scan-progress-detail');
+    var remaining = document.getElementById('scan-progress-remaining');
+    var fill = document.getElementById('scan-progress-bar-fill');
+    if (!progress || !detail || !remaining || !fill) return;
+    if (!_btScanModalState.startedAtMs && !_btScanModalState.isRunning && !_btScanModalState.lastError && !_btScanModalState.lastDevices.length) {
+        progress.hidden = true;
+        return;
+    }
+
+    var ratio = 1;
+    if (_btScanModalState.isRunning) {
+        var totalMs = Math.max(_btScanModalState.expectedDuration, 1) * 1000;
+        var elapsedMs = Math.max(Date.now() - _btScanModalState.startedAtMs, 0);
+        ratio = Math.min(elapsedMs / totalMs, 0.96);
+        _setBtScanProgressPill('is-scanning', 'Scanning nearby devices');
+        detail.textContent = _getBtScanAdapterLabel(_btScanModalState.adapter) + ' · ' +
+            (_btScanModalState.audioOnly ? 'Audio devices only' : 'All Bluetooth devices');
+        remaining.textContent = Math.max(0, Math.ceil((totalMs - elapsedMs) / 1000)) + ' s';
+    } else if (_btScanModalState.lastError) {
+        ratio = 1;
+        _setBtScanProgressPill('is-error', 'Scan failed');
+        detail.textContent = _btScanModalState.lastError;
+        remaining.textContent = 'Error';
+    } else {
+        var foundCount = (_btScanModalState.lastStats && _btScanModalState.lastStats.returned_candidates) || _btScanModalState.lastDevices.length;
+        ratio = 1;
+        _setBtScanProgressPill('is-success', 'Scan complete');
+        detail.textContent = 'Found ' + String(foundCount) + ' ' +
+            (_btScanModalState.audioOnly ? 'device' : 'candidate') +
+            (foundCount === 1 ? '' : 's');
+        remaining.textContent = 'Done';
+    }
+    fill.style.width = Math.max(0, Math.min(ratio, 1)) * 100 + '%';
+    progress.hidden = false;
+}
+
+function _startBtScanProgressTimer(expectedDuration, startedAtMs) {
+    _clearBtScanProgressTimer();
+    _btScanModalState.expectedDuration = expectedDuration || _btScanModalState.expectedDuration || 15;
+    _btScanModalState.startedAtMs = startedAtMs || Date.now();
+    _renderBtScanProgress();
+    _btScanModalState.progressTimer = setInterval(function() {
+        if (!_btScanModalState.isRunning) {
+            _clearBtScanProgressTimer();
+            return;
+        }
+        _renderBtScanProgress();
+    }, 250);
+}
+
+function _syncBtScanControls() {
+    var select = document.getElementById('scan-adapter-select');
+    var audioOnly = document.getElementById('scan-audio-only');
+    var rescanBtn = document.getElementById('scan-rescan-btn');
+    if (select) {
+        select.value = _btScanModalState.adapter || '';
+        select.disabled = _btScanModalState.isRunning;
+    }
+    if (audioOnly) {
+        audioOnly.checked = _btScanModalState.audioOnly !== false;
+        audioOnly.disabled = _btScanModalState.isRunning;
+    }
+    if (rescanBtn) {
+        rescanBtn.disabled = _btScanModalState.isRunning || _scanCooldownRemaining > 0;
+        if (_btScanModalState.isRunning) {
+            rescanBtn.innerHTML = _buttonLabelWithIconHtml('refresh', 'Scanning...');
+        } else if (_scanCooldownRemaining > 0) {
+            rescanBtn.innerHTML = _buttonLabelWithIconHtml('refresh', 'Rescan (' + _scanCooldownRemaining + 's)');
+        } else {
+            rescanBtn.innerHTML = _buttonLabelWithIconHtml('refresh', 'Rescan');
+        }
+    }
+}
+
+function _onBtScanOptionChange() {
+    var select = document.getElementById('scan-adapter-select');
+    var audioOnly = document.getElementById('scan-audio-only');
+    _btScanModalState.adapter = select ? (select.value || '') : '';
+    _btScanModalState.audioOnly = audioOnly ? !!audioOnly.checked : true;
+    if (!_btScanModalState.isRunning) _renderBtScanProgress();
+}
+
+function _applyBtScanCooldownUi() {
+    var btn = document.getElementById('scan-btn');
+    if (btn) {
+        btn.disabled = _scanCooldownRemaining > 0;
+        btn.innerHTML = _buttonLabelWithIconHtml(
+            'search',
+            _scanCooldownRemaining > 0 ? 'Scan nearby (' + _scanCooldownRemaining + 's)' : 'Scan nearby'
+        );
+    }
+    _syncBtScanControls();
+}
 
 function closeBtScanModal() {
     var overlay = document.getElementById('bt-scan-modal-overlay');
@@ -4517,6 +4691,9 @@ function openBtScanModal(options) {
     }
     var opts = options || {};
     _openConfigPanel('bluetooth', 'config-bluetooth-paired-card', 'start');
+    _renderBtScanAdapterOptions();
+    _syncBtScanControls();
+    _renderBtScanProgress();
     var overlay = document.getElementById('bt-scan-modal-overlay');
     if (!overlay) return false;
     overlay.hidden = false;
@@ -4581,123 +4758,210 @@ function openConfigAndAddDevice(options) {
     }
 }
 
+function _renderBtScanResults(devices) {
+    var box = document.getElementById('scan-results-box');
+    var listDiv = document.getElementById('scan-results-list');
+    if (!box || !listDiv) return;
+    listDiv.innerHTML = devices.map(function(d, i) {
+        var addable = d.supports_import !== false && d.audio_capable !== false;
+        var chips = [
+            '<span class="scan-result-chip ' + (d.audio_capable === false ? 'is-other' : 'is-audio') + '">' +
+                (d.audio_capable === false ? 'Other Bluetooth device' : 'Audio device') +
+            '</span>'
+        ];
+        if (d.adapter) {
+            chips.push('<span class="scan-result-chip">' + escHtml(_getBtScanAdapterLabel(d.adapter)) + '</span>');
+        }
+        return '<div class="scan-result-item" data-scan-idx="' + i + '">' +
+            '<span class="scan-result-actions">' +
+                (addable
+                    ? '<button type="button" class="scan-action-btn scan-action-btn--primary scan-add-btn" title="Add to config without pairing now">Add to fleet</button>' +
+                      '<button type="button" class="scan-action-btn scan-action-btn--pair scan-pair-btn" data-pair-idx="' + i + '" title="Pair, trust, and add to config">Add & pair</button>'
+                    : '<span class="scan-result-passive">Audio import unavailable</span>') +
+            '</span>' +
+            '<span class="scan-result-mac">' + escHtml(d.mac) + '</span>' +
+            '<span class="scan-result-name">' + escHtml(d.name) +
+                '<span class="scan-result-meta">' + chips.join('') + '</span>' +
+            '</span>' +
+            '</div>';
+    }).join('');
+
+    listDiv.querySelectorAll('[data-scan-idx]').forEach(function(row) {
+        var scanAddBtn = row.querySelector('.scan-add-btn');
+        if (scanAddBtn) {
+            scanAddBtn.addEventListener('click', function(e) {
+                e.stopPropagation();
+                var d = devices[parseInt(row.dataset.scanIdx, 10)];
+                addFromScan(d.mac, d.name, d.adapter);
+            });
+        }
+    });
+    listDiv.querySelectorAll('.scan-pair-btn').forEach(function(scanPairBtn) {
+        scanPairBtn.addEventListener('click', function(e) {
+            e.stopPropagation();
+            var d = devices[parseInt(this.dataset.pairIdx, 10)];
+            pairAndAdd(d.mac, d.name, d.adapter, this);
+        });
+    });
+    box.hidden = !devices.length;
+}
+
+async function _pollBtScanResult(jobId) {
+    for (var attempt = 0; attempt < 30; attempt++) {
+        await new Promise(function(resolve) { setTimeout(resolve, 2000); });
+        var pollResp = await fetch(API_BASE + '/api/bt/scan/result/' + jobId);
+        var pollData = await pollResp.json();
+        if (!pollResp.ok) {
+            throw new Error(pollData.error || 'Scan polling failed');
+        }
+        if (pollData.scan_options) {
+            _btScanModalState.adapter = pollData.scan_options.adapter || '';
+            _btScanModalState.audioOnly = pollData.scan_options.audio_only !== false;
+        }
+        if (pollData.expected_duration) _btScanModalState.expectedDuration = pollData.expected_duration;
+        if (pollData.started_at) _btScanModalState.startedAtMs = pollData.started_at * 1000;
+        if (pollData.status === 'done') return pollData;
+        _renderBtScanProgress();
+    }
+    throw new Error('Scan timed out');
+}
+
 // ---- BT Scan ----
 
 async function startBtScan() {
-    var btn     = document.getElementById('scan-btn');
-    var status  = document.getElementById('scan-status');
-    var box     = document.getElementById('scan-results-box');
+    var btn = document.getElementById('scan-btn');
+    var status = document.getElementById('scan-status');
+    var box = document.getElementById('scan-results-box');
     var listDiv = document.getElementById('scan-results-list');
+    if (_btScanModalState.isRunning) return false;
+    _onBtScanOptionChange();
 
-    btn.disabled = true;
-    status.innerHTML = '<span class="scan-status-pill is-scanning">' +
-        '<span class="scan-spinner"></span>' +
-        '<span class="scan-status-label">Scanning nearby devices</span>' +
-        '<span class="scan-status-hint">~15 s</span>' +
-    '</span>';
-    box.hidden = true;
+    _btScanModalState.activeJobId = '';
+    _btScanModalState.isRunning = true;
+    _btScanModalState.lastDevices = [];
+    _btScanModalState.lastStats = null;
+    _btScanModalState.lastError = '';
+    _btScanModalState.expectedDuration = _estimateBtScanDurationForSelection(_btScanModalState.adapter);
+    _btScanModalState.startedAtMs = Date.now();
+    if (status) status.innerHTML = '';
+    if (listDiv) listDiv.innerHTML = '';
+    if (box) box.hidden = true;
+    _syncBtScanControls();
+    _startBtScanProgressTimer(_btScanModalState.expectedDuration, _btScanModalState.startedAtMs);
 
     try {
-        var resp = await fetch(API_BASE + '/api/bt/scan', { method: 'POST' });
+        var resp = await fetch(API_BASE + '/api/bt/scan', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                adapter: _btScanModalState.adapter || '',
+                audio_only: _btScanModalState.audioOnly !== false,
+            })
+        });
         var data = await resp.json();
 
         if (resp.status === 429 && data.retry_after) {
+            _btScanModalState.isRunning = false;
+            _btScanModalState.startedAtMs = 0;
+            _clearBtScanProgressTimer();
+            _renderBtScanProgress();
             _startScanCooldown(btn, data.retry_after);
-            status.innerHTML = '<span class="scan-status-pill">' +
-                '<span class="scan-status-label">Scan cooldown active</span>' +
-                '<span class="scan-status-hint">' + String(data.retry_after) + 's remaining</span>' +
-            '</span>';
-            return;
-        }
-
-        var jobId = data.job_id;
-        if (!jobId) { throw new Error(data.error || 'No job_id returned'); }
-
-        // Poll for result every 2 s
-        var devices = null;
-        for (var attempt = 0; attempt < 30; attempt++) {
-            await new Promise(function(resolve) { setTimeout(resolve, 2000); });
-            var pollResp = await fetch(API_BASE + '/api/bt/scan/result/' + jobId);
-            var pollData = await pollResp.json();
-            if (pollData.status === 'done') {
-                if (pollData.error) { throw new Error(pollData.error); }
-                devices = pollData.devices || [];
-                break;
+            if (status) {
+                status.innerHTML = '<span class="scan-status-pill">' +
+                    '<span class="scan-status-label">Scan cooldown active</span>' +
+                    '<span class="scan-status-hint">' + String(data.retry_after) + 's remaining</span>' +
+                '</span>';
             }
+            return false;
         }
-        if (devices === null) { throw new Error('Scan timed out'); }
+        if (!resp.ok) {
+            throw new Error(data.error || 'Bluetooth scan failed');
+        }
 
-        if (devices.length === 0) {
-            status.innerHTML = _renderEmptyStateHtml({
-                className: 'scan-status-card is-empty',
-                icon: 'search',
-                title: 'No devices found',
-                copyHtml: '<ul class="ui-empty-state-list">' +
-                    '<li>Make sure your speaker is in <strong>pairing mode</strong> (usually hold the Bluetooth button for 3–5 s)</li>' +
-                    '<li>Move the device closer to the Bluetooth adapter</li>' +
-                    '<li>Some devices need to be <strong>unpaired</strong> from other sources first</li>' +
-                    '<li>Try scanning again — some speakers advertise intermittently</li>' +
-                '</ul>',
-                compact: true,
-                inline: true,
-            });
+        _btScanModalState.activeJobId = data.job_id || '';
+        _btScanModalState.expectedDuration = data.expected_duration || _btScanModalState.expectedDuration;
+        if (data.scan_options) {
+            _btScanModalState.adapter = data.scan_options.adapter || '';
+            _btScanModalState.audioOnly = data.scan_options.audio_only !== false;
+        }
+        _btScanModalState.startedAtMs = data.started_at ? data.started_at * 1000 : _btScanModalState.startedAtMs;
+        _syncBtScanControls();
+        _startBtScanProgressTimer(_btScanModalState.expectedDuration, _btScanModalState.startedAtMs);
+
+        var result = await _pollBtScanResult(_btScanModalState.activeJobId);
+        _btScanModalState.isRunning = false;
+        _btScanModalState.lastDevices = result.devices || [];
+        _btScanModalState.lastStats = result.stats || null;
+        _btScanModalState.lastError = result.error || '';
+        if (result.scan_options) {
+            _btScanModalState.adapter = result.scan_options.adapter || '';
+            _btScanModalState.audioOnly = result.scan_options.audio_only !== false;
+        }
+        _clearBtScanProgressTimer();
+        _renderBtScanProgress();
+
+        if (_btScanModalState.lastError) {
+            throw new Error(_btScanModalState.lastError);
+        }
+
+        if (!_btScanModalState.lastDevices.length) {
+            if (status) {
+                status.innerHTML = _renderEmptyStateHtml({
+                    className: 'scan-status-card is-empty',
+                    icon: 'search',
+                    title: _btScanModalState.audioOnly ? 'No audio devices found' : 'No Bluetooth devices found',
+                    copyHtml: _btScanModalState.audioOnly
+                        ? '<ul class="ui-empty-state-list">' +
+                            '<li>Make sure your speaker is in <strong>pairing mode</strong> (usually hold the Bluetooth button for 3-5 s)</li>' +
+                            '<li>Move the device closer to the Bluetooth adapter</li>' +
+                            '<li>Some devices need to be <strong>unpaired</strong> from other sources first</li>' +
+                            '<li>Try scanning again — some speakers advertise intermittently</li>' +
+                        '</ul>'
+                        : 'No nearby Bluetooth devices were reported during this timed scan.',
+                    compact: true,
+                    inline: true,
+                });
+            }
         } else {
-            status.innerHTML = '<span class="scan-status-pill is-success">' +
-                '<span class="scan-status-label">Found ' + String(devices.length) + ' device(s)</span>' +
-            '</span>';
-            listDiv.innerHTML = devices.map(function(d, i) {
-                return '<div class="scan-result-item" data-scan-idx="' + i + '">' +
-                    '<span class="scan-result-actions">' +
-                    '<button type="button" class="scan-action-btn scan-action-btn--primary scan-add-btn" title="Add to config without pairing now">Add to fleet</button>' +
-                    '<button type="button" class="scan-action-btn scan-action-btn--pair scan-pair-btn" data-pair-idx="' + i + '" title="Pair, trust, and add to config">Add & pair</button>' +
+            if (status) {
+                var foundCount = (_btScanModalState.lastStats && _btScanModalState.lastStats.returned_candidates) || _btScanModalState.lastDevices.length;
+                status.innerHTML = '<span class="scan-status-pill is-success">' +
+                    '<span class="scan-status-label">Found ' + String(foundCount) + ' ' +
+                        (_btScanModalState.audioOnly ? 'device' : 'candidate') + (foundCount === 1 ? '' : 's') +
                     '</span>' +
-                    '<span class="scan-result-mac">' + escHtml(d.mac) + '</span>' +
-                    '<span class="scan-result-name">' + escHtml(d.name) + '</span>' +
-                    '</div>';
-            }).join('');
-            // "Add" button
-            listDiv.querySelectorAll('[data-scan-idx]').forEach(function(row) {
-                row.querySelector('.scan-add-btn').addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    var d = devices[parseInt(row.dataset.scanIdx)];
-                    addFromScan(d.mac, d.name, d.adapter);
-                });
-            });
-            // "Add & Pair" button
-            listDiv.querySelectorAll('.scan-pair-btn').forEach(function(btn) {
-                btn.addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    var d = devices[parseInt(this.dataset.pairIdx)];
-                    pairAndAdd(d.mac, d.name, d.adapter, this);
-                });
-            });
-            box.hidden = false;
+                '</span>';
+            }
+            _renderBtScanResults(_btScanModalState.lastDevices);
         }
         _startScanCooldown(btn, 10);
     } catch (err) {
-        status.innerHTML = '<span class="scan-status-pill is-error">' +
-            '<span class="scan-status-label">Scan failed: ' + escHtml(err.message || 'Unknown error') + '</span>' +
-        '</span>';
-        btn.disabled = false;
+        _btScanModalState.isRunning = false;
+        _btScanModalState.lastError = err && err.message ? err.message : 'Unknown error';
+        _clearBtScanProgressTimer();
+        _renderBtScanProgress();
+        if (status) {
+            status.innerHTML = '<span class="scan-status-pill is-error">' +
+                '<span class="scan-status-label">Scan failed: ' + escHtml(_btScanModalState.lastError) + '</span>' +
+            '</span>';
+        }
+    } finally {
+        _syncBtScanControls();
     }
+    return false;
 }
 
-var _scanCooldownTimer = null;
 function _startScanCooldown(btn, seconds) {
     if (_scanCooldownTimer) clearInterval(_scanCooldownTimer);
-    var remaining = seconds;
-    btn.disabled = true;
-    btn.innerHTML = _buttonLabelWithIconHtml('search', 'Scan nearby (' + remaining + 's)');
+    _scanCooldownRemaining = seconds;
+    _applyBtScanCooldownUi();
     _scanCooldownTimer = setInterval(function() {
-        remaining--;
-        if (remaining <= 0) {
+        _scanCooldownRemaining--;
+        if (_scanCooldownRemaining <= 0) {
             clearInterval(_scanCooldownTimer);
             _scanCooldownTimer = null;
-            btn.disabled = false;
-            btn.innerHTML = _buttonLabelWithIconHtml('search', 'Scan nearby');
-        } else {
-            btn.innerHTML = _buttonLabelWithIconHtml('search', 'Scan nearby (' + remaining + 's)');
+            _scanCooldownRemaining = 0;
         }
+        _applyBtScanCooldownUi();
     }, 1000);
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -3640,6 +3640,82 @@ body {
             line-height: 1.55;
             color: var(--secondary-text-color);
         }
+        .bt-scan-toolbar {
+            display: flex;
+            align-items: flex-end;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+        .bt-scan-field {
+            display: grid;
+            gap: 6px;
+            min-width: min(100%, 220px);
+            flex: 1 1 220px;
+        }
+        .bt-scan-field-label,
+        .bt-scan-progress-detail {
+            font-size: 12px;
+            color: var(--secondary-text-color);
+        }
+        .bt-scan-select {
+            width: 100%;
+            min-height: 34px;
+            padding: 7px 10px;
+            border: 1px solid var(--divider-color);
+            border-radius: 8px;
+            font-size: 13px;
+            background: var(--card-background-color);
+            color: var(--primary-text-color);
+        }
+        .bt-scan-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            min-height: 34px;
+            padding: 0 2px;
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--primary-text-color);
+        }
+        .bt-scan-progress {
+            display: grid;
+            gap: 10px;
+            padding: 12px;
+            border: 1px solid var(--divider-color);
+            border-radius: 12px;
+            background: var(--card-background-color);
+        }
+        .bt-scan-progress-copy {
+            display: grid;
+            gap: 6px;
+        }
+        .bt-scan-progress-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+        .bt-scan-progress-remaining {
+            font-size: 12px;
+            font-weight: 700;
+            color: var(--secondary-text-color);
+        }
+        .bt-scan-progress-bar {
+            position: relative;
+            height: 8px;
+            overflow: hidden;
+            border-radius: 999px;
+            background: rgba(107, 114, 128, 0.18);
+        }
+        .bt-scan-progress-bar-fill {
+            display: block;
+            width: 0;
+            height: 100%;
+            border-radius: inherit;
+            background: linear-gradient(90deg, var(--primary-color), rgba(3, 169, 244, 0.68));
+            transition: width 0.22s ease;
+        }
         .bt-scan-status-panel {
             display: grid;
             gap: 8px;
@@ -3772,7 +3848,54 @@ body {
         }
         .scan-result-item:last-child { border-bottom: none; }
         .scan-result-mac { font-family: monospace; color: var(--secondary-text-color); font-size: 12px; width: 132px; flex-shrink: 0; }
-        .scan-result-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .scan-result-name {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            flex: 1;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: normal;
+        }
+        .scan-result-meta {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            flex-wrap: wrap;
+            min-width: 0;
+        }
+        .scan-result-chip,
+        .scan-result-passive {
+            display: inline-flex;
+            align-items: center;
+            min-height: 22px;
+            padding: 0 8px;
+            border-radius: 999px;
+            font-size: 11px;
+            font-weight: 700;
+            line-height: 1;
+        }
+        .scan-result-chip {
+            border: 1px solid var(--divider-color);
+            background: rgba(107, 114, 128, 0.1);
+            color: var(--secondary-text-color);
+        }
+        .scan-result-chip.is-audio {
+            background: rgba(67, 160, 71, 0.12);
+            border-color: rgba(67, 160, 71, 0.2);
+            color: #2e7d32;
+        }
+        .scan-result-chip.is-other {
+            background: rgba(255, 166, 0, 0.14);
+            border-color: rgba(255, 166, 0, 0.22);
+            color: #c77700;
+        }
+        .scan-result-passive {
+            color: var(--secondary-text-color);
+            background: rgba(107, 114, 128, 0.08);
+            border: 1px dashed var(--divider-color);
+        }
         .paired-box {
             margin-top: 12px; border: 1px solid var(--divider-color); border-radius: 12px;
             padding: 12px; background: var(--card-background-color);

--- a/templates/index.html
+++ b/templates/index.html
@@ -555,6 +555,36 @@
                                 <div class="bt-scan-modal-copy">
                                     Discover nearby speakers from the Bluetooth tab without turning temporary discovery results into a permanent Devices-page block.
                                 </div>
+                                <div class="bt-scan-toolbar">
+                                    <label class="bt-scan-field">
+                                        <span class="bt-scan-field-label">Adapter</span>
+                                        <select id="scan-adapter-select" class="bt-scan-select" onchange="_onBtScanOptionChange()">
+                                            <option value="">All adapters</option>
+                                        </select>
+                                    </label>
+                                    <label class="bt-scan-toggle">
+                                        <span>Audio devices only</span>
+                                        <span class="config-switch compact">
+                                            <input type="checkbox" id="scan-audio-only" onchange="_onBtScanOptionChange()" checked>
+                                            <span class="config-switch-track"></span>
+                                        </span>
+                                    </label>
+                                    <button type="button" class="btn btn-sm btn-secondary" id="scan-rescan-btn" onclick="startBtScan()">
+                                        <span class="btn-icon-slot ui-icon-slot" data-ui-icon="refresh" aria-hidden="true"></span><span>Rescan</span>
+                                    </button>
+                                </div>
+                                <div id="scan-progress" class="bt-scan-progress" hidden>
+                                    <div class="bt-scan-progress-copy">
+                                        <div class="bt-scan-progress-head">
+                                            <span id="scan-progress-state" class="scan-status-pill">Ready to scan</span>
+                                            <span id="scan-progress-remaining" class="bt-scan-progress-remaining">15 s</span>
+                                        </div>
+                                        <div id="scan-progress-detail" class="bt-scan-progress-detail">All adapters · Audio devices only</div>
+                                    </div>
+                                    <div class="bt-scan-progress-bar" aria-hidden="true">
+                                        <span id="scan-progress-bar-fill" class="bt-scan-progress-bar-fill"></span>
+                                    </div>
+                                </div>
                                 <div id="scan-status" class="bt-scan-status-panel"></div>
                                 <div id="scan-results-box" class="scan-results-box bt-scan-results-box" hidden>
                                     <div class="scan-results-title">Discovered devices &mdash; add to fleet or pair first</div>

--- a/tests/test_scan_cooldown.py
+++ b/tests/test_scan_cooldown.py
@@ -82,6 +82,7 @@ def test_scan_allowed_after_cooldown_expires(client):
     with (
         patch("routes.api_bt.is_scan_running", return_value=False),
         patch("routes.api_bt.time") as mock_time,
+        patch("routes.api_bt.list_bt_adapters", return_value=["AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"]),
         patch("routes.api_bt.threading.Thread") as mock_thread,
     ):
         mock_time.monotonic.return_value = 100.0
@@ -95,6 +96,9 @@ def test_scan_allowed_after_cooldown_expires(client):
         assert resp.status_code == 200
         data = resp.get_json()
         assert "job_id" in data
+        assert data["scan_options"]["audio_only"] is True
+        assert data["scan_options"]["adapter_scope"] == "all"
+        assert data["expected_duration"] == 17
 
 
 def test_concurrent_scan_returns_409(client):
@@ -103,6 +107,62 @@ def test_concurrent_scan_returns_409(client):
         resp = client.post("/api/bt/scan")
         assert resp.status_code == 409
         assert "already in progress" in resp.get_json()["error"].lower()
+
+
+def test_scan_accepts_selected_adapter_and_audio_filter(client):
+    """POST /api/bt/scan forwards selected adapter and audio-only options."""
+    with (
+        patch("routes.api_bt.is_scan_running", return_value=False),
+        patch("routes.api_bt.time") as mock_time,
+        patch("routes.api_bt.list_bt_adapters", return_value=["AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"]),
+        patch("routes.api_bt.threading.Thread") as mock_thread,
+    ):
+        mock_time.monotonic.return_value = 100.0
+        _mod = importlib.import_module("routes.api_bt")
+        _mod._last_scan_completed = 80.0
+        mock_thread.return_value.start = lambda: None
+
+        resp = client.post("/api/bt/scan", json={"adapter": "hci1", "audio_only": False})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["scan_options"] == {
+            "adapter": "hci1",
+            "audio_only": False,
+            "adapter_scope": "selected",
+            "adapter_count": 1,
+        }
+        assert data["expected_duration"] == 15
+        assert mock_thread.call_args.kwargs["target"] is _mod._run_bt_scan
+        assert mock_thread.call_args.kwargs["args"][1:] == ("hci1", False)
+
+
+def test_scan_rejects_invalid_adapter_identifier(client):
+    """POST /api/bt/scan rejects malformed adapter values."""
+    with patch("routes.api_bt.is_scan_running", return_value=False):
+        resp = client.post("/api/bt/scan", json={"adapter": "hciX"})
+        assert resp.status_code == 400
+        assert "invalid adapter" in resp.get_json()["error"].lower()
+
+
+def test_scan_result_running_includes_metadata(client):
+    """GET /api/bt/scan/result exposes running scan metadata for the modal."""
+    with patch(
+        "routes.api_bt.get_scan_job",
+        return_value={
+            "status": "running",
+            "scan_options": {"adapter": "", "audio_only": True, "adapter_scope": "all", "adapter_count": 2},
+            "expected_duration": 17,
+            "started_at": 123.0,
+        },
+    ):
+        resp = client.get("/api/bt/scan/result/test-job")
+        assert resp.status_code == 200
+        assert resp.get_json() == {
+            "status": "running",
+            "scan_options": {"adapter": "", "audio_only": True, "adapter_scope": "all", "adapter_count": 2},
+            "expected_duration": 17,
+            "started_at": 123.0,
+        }
 
 
 def test_cooldown_timestamp_updated_after_scan(client):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -53,6 +53,14 @@ def test_create_scan_job():
     assert "created" in job
 
 
+def test_create_scan_job_with_metadata():
+    job_id = str(uuid.uuid4())
+    state.create_scan_job(job_id, {"scan_options": {"adapter": "", "audio_only": True}})
+    job = state.get_scan_job(job_id)
+    assert job is not None
+    assert job["scan_options"]["audio_only"] is True
+
+
 def test_create_async_job():
     job_id = str(uuid.uuid4())
     state.create_async_job(job_id, "update-check")


### PR DESCRIPTION
## Summary
- add adapter selection, audio-only filtering, rescan, and timed progress to the Bluetooth scan modal
- extend Bluetooth scan job metadata and API payloads for modal state and progress hints
- add coverage for scan request parsing, result metadata, and async scan job state

## Validation
- python3 -m pytest -q
- python3 -m ruff check .
- node --check static/app.js
- git --no-pager diff --check