### PR TITLE
chore: release 2.42.2-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.42.2-rc.2] - 2026-03-21
+
+### Added
+- The Bluetooth scan modal now exposes adapter selection, an explicit audio-only filter, and a dedicated rescan action so multi-adapter discovery is easier to control.
+
+### Changed
+- Bluetooth discovery now reports richer scan metadata to the frontend, letting the modal show timed progress, countdown state, and clearer result context without turning the workflow into a permanent page block.
+
+### Fixed
+- Scan modal results now stay aligned with the selected discovery scope, and non-audio Bluetooth candidates are surfaced more honestly when the audio-only filter is disabled.
+
 ## [2.42.2-rc.1] - 2026-03-20
 
 ### Changed

--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-VERSION = "2.42.2-rc.1"
+VERSION = "2.42.2-rc.2"
 BUILD_DATE = "2026-03-20"
 CONFIG_SCHEMA_VERSION = 1
 UPDATE_CHANNELS = ("stable", "rc", "beta")


### PR DESCRIPTION
## Summary
- bump version to 2.42.2-rc.2
- document the enhanced Bluetooth scan modal RC changes in the changelog

## Validation
- python3 -m pytest -q
- python3 -m ruff check .
- node --check static/app.js
- git --no-pager diff --check