### PR TITLE
Scope release CI triggers

### DIFF
--- a/.github/workflows/docker-publish-armv7.yml
+++ b/.github/workflows/docker-publish-armv7.yml
@@ -19,7 +19,15 @@ env:
 
 jobs:
   prepare:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          startsWith(github.event.workflow_run.head_branch, 'v') &&
+          !contains(github.event.workflow_run.head_branch, '-')
+        )
+      }}
     runs-on: ubuntu-latest
     outputs:
       sendspin_version: ${{ steps.resolve_sendspin.outputs.version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,17 @@ permissions:
 
 jobs:
   pytest:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          (
+            github.event.workflow_run.head_branch == 'beta' ||
+            startsWith(github.event.workflow_run.head_branch, 'v')
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +43,17 @@ jobs:
         run: python -m pytest tests/ -v --tb=short
 
   container-smoke:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          (
+            github.event.workflow_run.head_branch == 'beta' ||
+            startsWith(github.event.workflow_run.head_branch, 'v')
+          )
+        )
+      }}
     needs: pytest
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- run downstream Pytest only for release refs (`beta` and `v*`)
- stop armv7 workflow from starting for prerelease refs
- keep manual workflow dispatch available as an override