### PR TITLE
feat(bt-pair): retry popular PINs + annotate PIN rejection in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Popular-PIN retry for legacy BT pairing** — when a BT 2.x device asks
+  for a numeric PIN and rejects the bridge's default `0000` with
+  `AuthenticationFailed`, the standalone pair flow
+  (`POST /api/bt/pair_new`) now re-runs with the next popular PIN
+  (`0000, 1234, 1111, 8888, 1212, 9999`) before giving up. Non-PIN
+  failures (connection errors, timeouts) still stop the loop
+  immediately — retrying against an unreachable device wasted ~20s per
+  attempt. The list is intentionally short: each extra attempt adds a
+  BlueZ auth-fail timeout to total pair time.
+
+### Changed
+- **Clearer pairing-failure logs** — both the scan-modal pair flow and
+  the long-running reconnect pair flow now annotate the failure log
+  with the rejected PIN when the device auto-prompted for one and
+  `AuthenticationFailed` was seen (`… — device rejected PIN 0000`). A
+  new `describe_pair_failure()` helper centralises the rule so
+  operators see the root cause without grepping for
+  `AuthenticationFailed`. Non-auth failures are logged verbatim as
+  before.
+
 ## [2.61.0-rc.3] - 2026-04-22
 
 UI follow-up to the `2.61.0-rc.1` experimental flags. No Bluetooth

--- a/bluetooth_manager.py
+++ b/bluetooth_manager.py
@@ -33,7 +33,7 @@ from bt_dbus import (
     _dbus_get_device_uuids,
     _dbus_wait_services_resolved,
 )
-from services.bluetooth import extract_pair_failure_reason
+from services.bluetooth import describe_pair_failure
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -457,6 +457,7 @@ class BluetoothManager:
             # leave BlueZ with a stale Trusted=yes, Paired=no entry.
             collected: list[str] = []
             paired_ok = False
+            pin_attempted = False
             deadline = time.monotonic() + _PAIRING_WAIT_DURATION
             import selectors
 
@@ -490,6 +491,7 @@ class BluetoothManager:
                         logger.info("Legacy PIN prompt — auto-entering 0000: %s", stripped)
                         proc.stdin.write("0000\n")
                         proc.stdin.flush()
+                        pin_attempted = True
                     # Early exit on success
                     if "pairing successful" in stripped.lower() or "already paired" in stripped.lower():
                         paired_ok = True
@@ -523,7 +525,8 @@ class BluetoothManager:
                 self._check_audio_profiles_after_pair()
             else:
                 failure_reason = (
-                    extract_pair_failure_reason(out, tail_chars=200) or "no explicit bluetoothctl reason captured"
+                    describe_pair_failure(out, pin_attempted=pin_attempted, pin_used="0000")
+                    or "no explicit bluetoothctl reason captured"
                 )
                 logger.warning("Pairing may have failed: %s", failure_reason)
                 logger.debug("Pair output tail: %s", out[-600:])

--- a/routes/api_bt.py
+++ b/routes/api_bt.py
@@ -23,6 +23,7 @@ from services.bluetooth import (
     _AUDIO_UUIDS,
     COMMON_BT_PAIR_PINS,
     describe_pair_failure,
+    is_pin_rejection,
     list_bt_adapters,
 )
 from services.bluetooth import bt_remove_device as _bt_remove_device
@@ -1432,9 +1433,11 @@ def _run_standalone_pair_inner(
                     or "no explicit bluetoothctl reason captured"
                 )
                 # A PIN rejection means the device asked for a PIN AND the
-                # attempt failed with AuthenticationFailed — the outer
-                # orchestrator will retry with the next popular PIN.
-                pin_rejected = pin_attempted and "rejected PIN" in reason
+                # attempt failed with AuthenticationFailed — derived from
+                # the raw bluetoothctl output so the check is independent
+                # of the human-readable `reason` wording (otherwise a reword
+                # of `describe_pair_failure` would silently break retry).
+                pin_rejected = pin_attempted and is_pin_rejection(out)
                 # Log full captured output (not just a tail) so passkey/agent
                 # prompts near the start of the session are visible in bug
                 # reports. bluetoothctl's SSP dialog is typically <4 KB per

--- a/routes/api_bt.py
+++ b/routes/api_bt.py
@@ -19,7 +19,12 @@ from config import CONFIG_FILE, config_lock, load_config
 from routes._helpers import get_client_or_error, validate_adapter, validate_mac
 from services import persist_device_enabled as _persist_device_enabled
 from services.async_job_state import create_scan_job, finish_scan_job, get_scan_job, is_scan_running
-from services.bluetooth import _AUDIO_UUIDS, extract_pair_failure_reason, list_bt_adapters
+from services.bluetooth import (
+    _AUDIO_UUIDS,
+    COMMON_BT_PAIR_PINS,
+    describe_pair_failure,
+    list_bt_adapters,
+)
 from services.bluetooth import bt_remove_device as _bt_remove_device
 from services.bluetooth import persist_device_released as _persist_device_released
 from services.pairing_quiesce import quiesce_adapter_peers
@@ -1204,13 +1209,61 @@ def _run_standalone_pair(
     default) means "use whatever config.EXPERIMENTAL_PAIR_JUST_WORKS
     says". A bool explicitly wins over config — the scan-modal toggle is
     the authoritative intent for this pair attempt.
+
+    When the device asks for a legacy PIN and rejects our first guess,
+    the orchestrator retries the whole pair flow with the next PIN from
+    ``COMMON_BT_PAIR_PINS``. Non-PIN failures (connection errors,
+    timeouts) stop the loop — they aren't PIN-related and retrying
+    wastes ~20 s per attempt.
     """
     adapter = _resolve_adapter_to_mac(adapter)
-    if quiesce and adapter:
-        with quiesce_adapter_peers(adapter, exclude_mac=mac):
-            _run_standalone_pair_inner(job_id, mac, adapter, no_input_no_output_agent=no_input_no_output_agent)
-    else:
-        _run_standalone_pair_inner(job_id, mac, adapter, no_input_no_output_agent=no_input_no_output_agent)
+
+    def _attempt(pin: str):
+        if quiesce and adapter:
+            with quiesce_adapter_peers(adapter, exclude_mac=mac):
+                return _run_standalone_pair_inner(
+                    job_id, mac, adapter, pin=pin, no_input_no_output_agent=no_input_no_output_agent
+                )
+        return _run_standalone_pair_inner(
+            job_id, mac, adapter, pin=pin, no_input_no_output_agent=no_input_no_output_agent
+        )
+
+    tried_pins: list[str] = []
+    last_reason = ""
+    for pin in COMMON_BT_PAIR_PINS:
+        tried_pins.append(pin)
+        result = _attempt(pin)
+        last_reason = result.get("reason", "") or last_reason
+        if result.get("success"):
+            logger.info("Standalone pair %s: OK", mac)
+            finish_scan_job(job_id, {"success": True, "mac": mac})
+            return
+        if not result.get("pin_rejected"):
+            logger.warning(
+                "Standalone pair %s: FAIL (%s)",
+                mac,
+                result.get("reason") or "no explicit bluetoothctl reason captured",
+            )
+            finish_scan_job(job_id, {"success": False, "mac": mac})
+            return
+        logger.warning(
+            "Standalone pair %s: PIN %s rejected — retrying with next candidate",
+            mac,
+            pin,
+        )
+
+    # All popular PINs exhausted. The device almost certainly requires a
+    # custom PIN that the bridge can't auto-enter — surface that loud so
+    # the operator doesn't have to grep per-attempt warnings.
+    logger.warning(
+        "Standalone pair %s: FAIL — device rejected all popular PINs (%s). "
+        "Likely requires a custom PIN; the bridge cannot auto-enter non-popular PINs. "
+        "Last bluetoothctl reason: %s",
+        mac,
+        ", ".join(tried_pins),
+        last_reason or "no explicit bluetoothctl reason captured",
+    )
+    finish_scan_job(job_id, {"success": False, "mac": mac})
 
 
 def _run_standalone_pair_inner(
@@ -1218,9 +1271,15 @@ def _run_standalone_pair_inner(
     mac: str,
     adapter: str,
     *,
+    pin: str = "0000",
     no_input_no_output_agent: bool | None = None,
-) -> None:
-    """Actual bluetoothctl pair flow — split out so quiesce wraps the whole op."""
+) -> dict:
+    """Actual bluetoothctl pair flow — split out so quiesce wraps the whole op.
+
+    Returns a dict ``{success, pin_attempted, pin_rejected, reason, output}``
+    so the outer orchestrator can decide whether to retry with a different
+    PIN or surface the failure to the UI.
+    """
     try:
         cleanup_cmds: list[str] = []
         if adapter:
@@ -1283,6 +1342,7 @@ def _run_standalone_pair_inner(
             collected: list[str] = []
             paired_ok = False
             pair_sent = False
+            pin_attempted = False
             # Single loop that handles both scan-window observation and pair
             # outcome parsing. `pair <mac>` fires as soon as `[NEW] Device <mac>`
             # appears, rather than waiting the full `_PAIR_SCAN_DURATION` fixed
@@ -1332,10 +1392,13 @@ def _run_standalone_pair_inner(
                     elif "enter pin code" in stripped or "enter passkey" in stripped:
                         # Legacy BT 2.x devices (e.g. HMDX JAM, `LegacyPairing: yes`)
                         # ask for a numeric PIN. `0000` is the BlueZ-default fallback
-                        # and what most consumer audio sinks accept (issue #162).
-                        logger.info("Legacy PIN prompt — auto-entering 0000: %s", line.strip())
-                        proc.stdin.write("0000\n")
+                        # and works for most consumer audio sinks (issue #162). If
+                        # this attempt is a retry, the outer orchestrator supplies
+                        # the next popular PIN from ``COMMON_BT_PAIR_PINS``.
+                        logger.info("Legacy PIN prompt — auto-entering %s: %s", pin, line.strip())
+                        proc.stdin.write(f"{pin}\n")
                         proc.stdin.flush()
+                        pin_attempted = True
                     if "pairing successful" in stripped or "already paired" in stripped:
                         paired_ok = True
                         break
@@ -1361,19 +1424,29 @@ def _run_standalone_pair_inner(
 
             out = "".join(collected)
             ok = paired_ok or any(s in out.lower() for s in ("pairing successful", "already paired", "paired: yes"))
-            if ok:
-                logger.info("Standalone pair %s: OK", mac)
-            else:
-                failure_reason = (
-                    extract_pair_failure_reason(out, tail_chars=400) or "no explicit bluetoothctl reason captured"
+            reason = ""
+            pin_rejected = False
+            if not ok:
+                reason = (
+                    describe_pair_failure(out, pin_attempted=pin_attempted, pin_used=pin)
+                    or "no explicit bluetoothctl reason captured"
                 )
-                logger.warning("Standalone pair %s: FAIL (%s)", mac, failure_reason)
+                # A PIN rejection means the device asked for a PIN AND the
+                # attempt failed with AuthenticationFailed — the outer
+                # orchestrator will retry with the next popular PIN.
+                pin_rejected = pin_attempted and "rejected PIN" in reason
                 # Log full captured output (not just a tail) so passkey/agent
                 # prompts near the start of the session are visible in bug
                 # reports. bluetoothctl's SSP dialog is typically <4 KB per
                 # pair attempt (issue #168 diagnostic lost with 800-byte tail).
-                logger.debug("Standalone pair %s output: %s", mac, out)
-            finish_scan_job(job_id, {"success": ok, "mac": mac})
+                logger.debug("Standalone pair %s output (pin=%s): %s", mac, pin, out)
+            return {
+                "success": ok,
+                "pin_attempted": pin_attempted,
+                "pin_rejected": pin_rejected,
+                "reason": reason,
+                "output": out,
+            }
         finally:
             try:
                 proc.kill()
@@ -1382,4 +1455,10 @@ def _run_standalone_pair_inner(
                 pass
     except Exception:
         logger.exception("Standalone pair error for %s", mac)
-        finish_scan_job(job_id, {"success": False, "mac": mac, "error": "Pairing failed"})
+        return {
+            "success": False,
+            "pin_attempted": False,
+            "pin_rejected": False,
+            "reason": "Pairing failed",
+            "output": "",
+        }

--- a/services/bluetooth.py
+++ b/services/bluetooth.py
@@ -20,13 +20,29 @@ logger = logging.getLogger(__name__)
 _OPTIONS_FILE = Path("/data/options.json")
 
 __all__ = [
+    "COMMON_BT_PAIR_PINS",
     "bt_remove_device",
+    "describe_pair_failure",
     "extract_pair_failure_reason",
     "is_audio_device",
     "list_bt_adapters",
     "persist_device_enabled",
     "persist_device_released",
 ]
+
+# Ordered list of PINs the bridge tries when a device asks for one. `0000`
+# is the BlueZ/consumer default; the rest are the most common fallbacks
+# shipped by BT audio vendors (user guides for Anker, JBL, HMDX, Harman,
+# no-name OEM speakers). Kept short intentionally — every extra attempt
+# adds ~20 s to total pair time because BlueZ auth-fails only surface
+# after a timeout.
+COMMON_BT_PAIR_PINS: tuple[str, ...] = ("0000", "1234", "1111", "8888", "1212", "9999")
+
+_AUTH_FAIL_MARKERS = (
+    "authenticationfailed",
+    "authentication failed",
+    "failed to pair: authentication",
+)
 
 _AUDIO_UUIDS = {
     "0000110b",  # A2DP Sink
@@ -89,6 +105,31 @@ def extract_pair_failure_reason(output: str, *, tail_chars: int = 400) -> str:
             return line
 
     return text[-tail_chars:].strip()
+
+
+def is_pin_rejection(output: str) -> bool:
+    """Return True when bluetoothctl output indicates the device rejected
+    the PIN we supplied (AuthenticationFailed variants). Non-auth failures
+    like ConnectionAttemptFailed or ProtocolError are not PIN-related."""
+    lowered = str(output or "").lower()
+    return any(marker in lowered for marker in _AUTH_FAIL_MARKERS)
+
+
+def describe_pair_failure(output: str, *, pin_attempted: bool = False, pin_used: str = "") -> str:
+    """Return a human-readable pairing failure reason with a PIN hint.
+
+    When ``pin_attempted`` is True and the captured output contains an
+    authentication-failure marker, appends an explicit note that the
+    device rejected the PIN. That way operators see the root cause in
+    the log without grepping for ``AuthenticationFailed``.
+    """
+    base = extract_pair_failure_reason(output)
+    if not pin_attempted or not base:
+        return base
+    if not is_pin_rejection(base):
+        return base
+    pin_label = pin_used or "0000"
+    return f"{base} — device rejected PIN {pin_label}"
 
 
 def bt_remove_device(mac: str, adapter_mac: str = "") -> None:

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -731,6 +731,152 @@ def test_run_standalone_pair_no_io_agent_override_false_beats_config_true(monkey
     assert "agent NoInputNoOutput\n" not in init_batch
 
 
+# ---------------------------------------------------------------------------
+# PIN retry orchestration
+#
+# When a BT audio device asks for a legacy PIN and rejects the bridge's
+# first guess (``0000``), the orchestrator must retry the pair attempt
+# with the next popular PIN from ``COMMON_BT_PAIR_PINS``. Non-PIN failures
+# (connection timeouts, protocol errors) must NOT trigger retries.
+# ---------------------------------------------------------------------------
+
+
+def _make_pin_inner_stub(outcomes_by_pin):
+    """Build a fake ``_run_standalone_pair_inner`` that records each pin
+    the orchestrator tries and returns the mapped outcome dict for that
+    pin. Unmapped pins produce a default "no PIN prompt seen, success"
+    result so stale tests surface loud."""
+    calls: list[str] = []
+
+    def _fake_inner(job_id, mac, adapter, *, pin="0000", no_input_no_output_agent=None):
+        calls.append(pin)
+        default = {
+            "success": True,
+            "pin_attempted": False,
+            "pin_rejected": False,
+            "reason": "",
+            "output": "",
+        }
+        return outcomes_by_pin.get(pin, default)
+
+    return _fake_inner, calls
+
+
+def test_run_standalone_pair_retries_with_next_popular_pin_after_rejection(monkeypatch):
+    """If 0000 is rejected with AuthenticationFailed, the outer runner
+    must re-invoke the inner pair with the next PIN from
+    ``COMMON_BT_PAIR_PINS`` rather than surfacing the first failure."""
+    import routes.api_bt as api_bt_mod
+    from services.bluetooth import COMMON_BT_PAIR_PINS
+
+    first_pin, second_pin = COMMON_BT_PAIR_PINS[0], COMMON_BT_PAIR_PINS[1]
+    fake_inner, calls = _make_pin_inner_stub(
+        {
+            first_pin: {
+                "success": False,
+                "pin_attempted": True,
+                "pin_rejected": True,
+                "reason": f"AuthenticationFailed — device rejected PIN {first_pin}",
+                "output": "",
+            },
+            second_pin: {
+                "success": True,
+                "pin_attempted": True,
+                "pin_rejected": False,
+                "reason": "",
+                "output": "",
+            },
+        }
+    )
+    finish_job = MagicMock()
+    monkeypatch.setattr(api_bt_mod, "_run_standalone_pair_inner", fake_inner)
+    monkeypatch.setattr(api_bt_mod, "finish_scan_job", finish_job)
+
+    api_bt_mod._run_standalone_pair("job-retry", "AA:BB:CC:DD:EE:FF", "C0:FB:F9:62:D6:9D")
+
+    assert calls[:2] == [first_pin, second_pin], f"expected retry with {second_pin} after {first_pin}, got {calls}"
+    finish_job.assert_called_once_with("job-retry", {"success": True, "mac": "AA:BB:CC:DD:EE:FF"})
+
+
+def test_run_standalone_pair_does_not_retry_on_non_pin_failure(monkeypatch):
+    """Connection / timeout / protocol failures are not PIN-related —
+    retrying with more PINs against an unreachable device wastes ~20 s
+    per attempt. The orchestrator must stop after the first attempt."""
+    import routes.api_bt as api_bt_mod
+
+    fake_inner, calls = _make_pin_inner_stub(
+        {
+            "0000": {
+                "success": False,
+                "pin_attempted": False,
+                "pin_rejected": False,
+                "reason": "Failed to pair: org.bluez.Error.ConnectionAttemptFailed",
+                "output": "",
+            },
+        }
+    )
+    finish_job = MagicMock()
+    monkeypatch.setattr(api_bt_mod, "_run_standalone_pair_inner", fake_inner)
+    monkeypatch.setattr(api_bt_mod, "finish_scan_job", finish_job)
+
+    api_bt_mod._run_standalone_pair("job-no-retry", "AA:BB:CC:DD:EE:FF", "C0:FB:F9:62:D6:9D")
+
+    assert calls == ["0000"], f"expected exactly one attempt, got {calls}"
+    finish_job.assert_called_once_with("job-no-retry", {"success": False, "mac": "AA:BB:CC:DD:EE:FF"})
+
+
+def test_run_standalone_pair_exhausts_all_pins_and_logs_summary(monkeypatch, caplog):
+    """When every popular PIN is rejected, the warning log must list
+    every PIN tried and flag the "custom PIN required" remediation so
+    the operator doesn't have to grep per-attempt entries."""
+    import logging
+
+    import routes.api_bt as api_bt_mod
+    from services.bluetooth import COMMON_BT_PAIR_PINS
+
+    outcomes = {
+        pin: {
+            "success": False,
+            "pin_attempted": True,
+            "pin_rejected": True,
+            "reason": f"AuthenticationFailed — device rejected PIN {pin}",
+            "output": "",
+        }
+        for pin in COMMON_BT_PAIR_PINS
+    }
+    fake_inner, calls = _make_pin_inner_stub(outcomes)
+    finish_job = MagicMock()
+    monkeypatch.setattr(api_bt_mod, "_run_standalone_pair_inner", fake_inner)
+    monkeypatch.setattr(api_bt_mod, "finish_scan_job", finish_job)
+
+    caplog.set_level(logging.WARNING, logger=api_bt_mod.logger.name)
+    api_bt_mod._run_standalone_pair("job-exhaust", "AA:BB:CC:DD:EE:FF", "C0:FB:F9:62:D6:9D")
+
+    assert list(calls) == list(COMMON_BT_PAIR_PINS), f"expected each PIN tried once in order, got {calls}"
+    final_msg = "\n".join(r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING)
+    for pin in COMMON_BT_PAIR_PINS:
+        assert pin in final_msg, f"expected PIN {pin} in warning summary, got:\n{final_msg}"
+    assert "custom" in final_msg.lower(), f"expected 'custom PIN' remediation hint in warnings, got:\n{final_msg}"
+    finish_job.assert_called_once_with("job-exhaust", {"success": False, "mac": "AA:BB:CC:DD:EE:FF"})
+
+
+def test_run_standalone_pair_succeeds_on_first_pin_without_extra_attempts(monkeypatch):
+    """SSP pairing (no PIN prompt) must finish with exactly one inner
+    invocation — no unnecessary retries eating a scan window."""
+    import routes.api_bt as api_bt_mod
+    from services.bluetooth import COMMON_BT_PAIR_PINS
+
+    fake_inner, calls = _make_pin_inner_stub({})  # default stub → success, no pin
+    finish_job = MagicMock()
+    monkeypatch.setattr(api_bt_mod, "_run_standalone_pair_inner", fake_inner)
+    monkeypatch.setattr(api_bt_mod, "finish_scan_job", finish_job)
+
+    api_bt_mod._run_standalone_pair("job-first", "AA:BB:CC:DD:EE:FF", "C0:FB:F9:62:D6:9D")
+
+    assert calls == [COMMON_BT_PAIR_PINS[0]], f"expected a single attempt on success, got {calls}"
+    finish_job.assert_called_once_with("job-first", {"success": True, "mac": "AA:BB:CC:DD:EE:FF"})
+
+
 def test_bt_pair_new_endpoint_forwards_no_io_agent_to_pair_runner(client, monkeypatch):
     """POST /api/bt/pair_new must accept a ``no_input_no_output_agent``
     body field and pass it through to the pair runner as a per-request

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -731,6 +731,56 @@ def test_run_standalone_pair_no_io_agent_override_false_beats_config_true(monkey
     assert "agent NoInputNoOutput\n" not in init_batch
 
 
+def test_run_standalone_pair_inner_pin_rejected_uses_raw_output_not_log_wording(monkeypatch):
+    """Regression: `pin_rejected` must be derived from the raw bluetoothctl
+    output (via `is_pin_rejection`), NOT from substring-matching the
+    human-readable `reason` string. Coupling control flow to log wording
+    means a reword of `describe_pair_failure` silently breaks PIN retry.
+
+    This test monkey-patches `describe_pair_failure` to return a message
+    that does NOT contain the literal phrase "rejected PIN" — the legacy
+    substring check would wrongly report `pin_rejected=False` here.
+    """
+    import routes.api_bt as api_bt_mod
+
+    fake_proc = _FakeProc(
+        stdout_lines=[
+            "[agent] Enter PIN code: \n",
+            "Failed to pair: org.bluez.Error.AuthenticationFailed\n",
+        ],
+        tail="Device AA:BB:CC:DD:EE:FF not available\n",
+    )
+    monkeypatch.setattr(api_bt_mod.subprocess, "run", MagicMock())
+    monkeypatch.setattr(api_bt_mod.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
+    monkeypatch.setattr(api_bt_mod, "finish_scan_job", MagicMock())
+    monkeypatch.setattr(api_bt_mod.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(api_bt_mod, "list_bt_adapters", lambda: ["C0:FB:F9:62:D6:9D"])
+    monkeypatch.setattr(api_bt_mod, "_PAIR_WAIT_DURATION", 0.2)
+    monkeypatch.setattr(api_bt_mod, "_PAIR_SCAN_DURATION", 0.1)
+    # Force a reason string that lacks the old "rejected PIN" literal —
+    # the legacy substring check would wrongly return pin_rejected=False.
+    monkeypatch.setattr(
+        api_bt_mod,
+        "describe_pair_failure",
+        lambda out, *, pin_attempted, pin_used: "auth broke somewhere (reworded)",
+    )
+
+    with patch("selectors.DefaultSelector", side_effect=lambda: _FakeSelector(fake_proc.stdout)):
+        result = api_bt_mod._run_standalone_pair_inner(
+            "job-raw-pin",
+            "AA:BB:CC:DD:EE:FF",
+            "C0:FB:F9:62:D6:9D",
+            pin="0000",
+        )
+
+    assert result["success"] is False
+    assert result["pin_attempted"] is True, "PIN prompt was in the fake output — pin_attempted must be True"
+    assert result["pin_rejected"] is True, (
+        "pin_rejected must be derived from raw AuthenticationFailed in output, "
+        "not from substring-matching the log wording"
+    )
+
+
 # ---------------------------------------------------------------------------
 # PIN retry orchestration
 #

--- a/tests/test_bluetooth_svc.py
+++ b/tests/test_bluetooth_svc.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from services.bluetooth import (
     bt_remove_device,
+    describe_pair_failure,
     extract_pair_failure_reason,
     is_audio_device,
     persist_device_enabled,
@@ -99,6 +100,61 @@ def test_extract_pair_failure_reason_falls_back_to_last_errorish_line():
     """
 
     assert extract_pair_failure_reason(output) == "AuthenticationFailed"
+
+
+# ---------------------------------------------------------------------------
+# describe_pair_failure — annotates PIN rejection cases
+# ---------------------------------------------------------------------------
+
+
+def test_describe_pair_failure_annotates_auth_fail_when_pin_attempted():
+    """When the bridge auto-entered a PIN and pairing failed with an
+    authentication error, the log message must explicitly call out PIN
+    rejection so operators don't have to grep output for the cause.
+    """
+    output = """
+    [agent] Enter PIN code: 0000
+    [CHG] Device AA:BB:CC:DD:EE:FF Connected: no
+    Failed to pair: org.bluez.Error.AuthenticationFailed
+    """
+    reason = describe_pair_failure(output, pin_attempted=True, pin_used="0000")
+    assert "AuthenticationFailed" in reason
+    assert "PIN" in reason
+    assert "0000" in reason
+
+
+def test_describe_pair_failure_does_not_annotate_when_no_pin_attempted():
+    """If no PIN prompt was observed during the attempt, auth failures
+    must not be misattributed to PIN rejection — the device may have
+    cancelled authentication for other reasons (unsupported agent, etc.).
+    """
+    output = """
+    [CHG] Device AA:BB:CC:DD:EE:FF Connected: no
+    Failed to pair: org.bluez.Error.AuthenticationFailed
+    """
+    reason = describe_pair_failure(output, pin_attempted=False)
+    assert reason == "Failed to pair: org.bluez.Error.AuthenticationFailed"
+    assert "PIN" not in reason
+
+
+def test_describe_pair_failure_does_not_annotate_non_auth_failure_even_with_pin():
+    """A PIN was entered but the device failed for a non-auth reason
+    (timeout, connection attempt failed): no PIN hint — PIN wasn't the
+    problem."""
+    output = """
+    [agent] Enter PIN code: 0000
+    Failed to pair: org.bluez.Error.ConnectionAttemptFailed
+    """
+    reason = describe_pair_failure(output, pin_attempted=True, pin_used="0000")
+    assert "ConnectionAttemptFailed" in reason
+    assert "PIN" not in reason
+
+
+def test_describe_pair_failure_empty_output_returns_fallback():
+    """Empty bluetoothctl output shouldn't crash — return an empty-ish
+    string the caller can still log as 'no explicit reason'."""
+    assert describe_pair_failure("", pin_attempted=False) == ""
+    assert describe_pair_failure("", pin_attempted=True, pin_used="0000") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Popular-PIN retry**: when `POST /api/bt/pair_new` gets `AuthenticationFailed` after auto-entering `0000`, the pair flow re-runs with the next popular PIN (`0000, 1234, 1111, 8888, 1212, 9999`). Non-PIN failures (connection errors, timeouts) stop the loop immediately.
- **Clearer PIN-rejection logging**: both the scan-modal pair flow and `bluetooth_manager` reconnect pair flow now annotate the warning log with the rejected PIN (`… — device rejected PIN 0000`) when a PIN was auto-entered and `AuthenticationFailed` followed. Centralised in a new `describe_pair_failure()` helper in `services/bluetooth.py`.
- **Inner-outer split in `_run_standalone_pair`**: `_run_standalone_pair_inner` now takes a `pin` kwarg and returns a result dict `{success, pin_attempted, pin_rejected, reason, output}`; the outer orchestrator loops `COMMON_BT_PAIR_PINS` and finalises the scan job. Payload to `finish_scan_job` unchanged.

## Motivation
Previous behaviour: auto-enter `0000` on any PIN prompt, log a generic `Pairing may have failed: AuthenticationFailed`, no retry. Operators had to grep logs and knew nothing about whether the device was asking for a non-default PIN. This PR makes the failure mode explicit and tries a handful of well-known vendor defaults before giving up.

List is intentionally short — each extra attempt adds a BlueZ auth-fail timeout (~20 s) to total pair time.

## Final failure log, after exhausting all popular PINs
```
Standalone pair AA:BB:CC:DD:EE:FF: FAIL — device rejected all popular PINs
(0000, 1234, 1111, 8888, 1212, 9999). Likely requires a custom PIN;
the bridge cannot auto-enter non-popular PINs. Last bluetoothctl reason:
AuthenticationFailed — device rejected PIN 9999
```

## Test plan
- [x] `pytest` — full suite (1476 passed)
- [x] `ruff check` + `ruff format --check`
- [x] 4 new RED→GREEN unit tests for `describe_pair_failure` (annotates iff `pin_attempted and AuthenticationFailed`)
- [x] 4 new RED→GREEN orchestration tests for PIN retry (success on 2nd PIN, stop on non-PIN failure, exhaust all PINs with summary log, single-attempt success path)
- [ ] Manual: re-pair a legacy BT speaker on test VM 105 to observe retry log path

🤖 Generated with [Claude Code](https://claude.com/claude-code)