### PR TITLE
feat(bt): clear BlueZ device cache + scan BR/EDR only during pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operators see the root cause without grepping for
   `AuthenticationFailed`. Non-auth failures are logged verbatim as
   before.
+- **Scan narrowed to BR/EDR during pairing** — `bluetoothctl scan on`
+  replaced with `scan bredr` at all five pair/scan sites (reset &
+  reconnect, standalone pair, background BT scan, runtime pair-device
+  loop). Excluding LE-only advertisers keeps the scan window
+  responsive on adapters shared with BLE traffic and avoids
+  interleaved BR/EDR discovery delays seen on BlueZ 5.85
+  (bluez/bluez#826). Safe on bluetoothctl ≥ 5.65.
+
+### Fixed
+- **Stale BlueZ device cache cleared on remove** — after
+  `bluetoothctl remove`, `bt_remove_device` now also deletes
+  `/var/lib/bluetooth/<adapter>/cache/<device>` when an adapter MAC is
+  known. BlueZ leaves stale `ServiceRecords` / `Endpoints` entries in
+  that file, which on re-pair surface as
+  `org.bluez.Error.Failed — Protocol not available` on A2DP sinks
+  (bluez/bluez#191, #348, #698). Silent if the file is absent; cleanup
+  only runs when the adapter is known to avoid walking the BlueZ tree
+  blindly.
 
 ## [2.61.0-rc.3] - 2026-04-22
 

--- a/bluetooth_manager.py
+++ b/bluetooth_manager.py
@@ -421,7 +421,13 @@ class BluetoothManager:
         initial_cmds = []
         if self._adapter_select:
             initial_cmds.append(f"select {self._adapter_select}")
-        initial_cmds.extend(["power on", "agent on", "default-agent", "scan on"])
+        # `scan bredr` (not `scan on`) narrows discovery to the BR/EDR
+        # transport — A2DP sinks only speak classic BT. Excluding LE-only
+        # advertisers (beacons, BLE wearables) keeps the scan window
+        # responsive and sidesteps BlueZ's occasional LE/BR/EDR result
+        # interleaving that can delay the pair target appearing
+        # (bluez/bluez#826 workaround; safe on bluetoothctl ≥ 5.65).
+        initial_cmds.extend(["power on", "agent on", "default-agent", "scan bredr"])
 
         pair_cmds = [f"pair {mac}"]
 

--- a/routes/api_bt.py
+++ b/routes/api_bt.py
@@ -658,7 +658,7 @@ def _run_reset_reconnect(job_id: str, mac: str, adapter: str) -> None:
         initial_cmds: list[str] = []
         if adapter:
             initial_cmds.append(f"select {adapter}")
-        initial_cmds.extend(["power on", "agent on", "default-agent", "scan on"])
+        initial_cmds.extend(["power on", "agent on", "default-agent", "scan bredr"])
         pair_cmds = [f"pair {mac}"]
 
         proc = subprocess.Popen(
@@ -928,9 +928,9 @@ def _run_bluetoothctl_scan(adapter_macs: "list[str]") -> str:
         if adapter_macs:
             init_cmds: list[str] = ["agent on", "default-agent"]
             for m in adapter_macs:
-                init_cmds.extend([f"select {m}", "power on", "scan on"])
+                init_cmds.extend([f"select {m}", "power on", "scan bredr"])
         else:
-            init_cmds = ["power on", "agent on", "default-agent", "scan on"]
+            init_cmds = ["power on", "agent on", "default-agent", "scan bredr"]
         if proc.stdin is None:
             raise RuntimeError("bluetoothctl subprocess stdin unavailable")
         proc.stdin.write("\n".join(init_cmds) + "\n")
@@ -1319,7 +1319,7 @@ def _run_standalone_pair_inner(
         initial_cmds: list[str] = []
         if adapter:
             initial_cmds.append(f"select {adapter}")
-        initial_cmds.extend(["power on", agent_cmd, "default-agent", "scan on"])
+        initial_cmds.extend(["power on", agent_cmd, "default-agent", "scan bredr"])
 
         pair_cmds = [f"pair {mac}"]
 

--- a/services/bluetooth.py
+++ b/services/bluetooth.py
@@ -169,16 +169,33 @@ def bt_remove_device(mac: str, adapter_mac: str = "") -> None:
         cmds.append(f"remove {mac}")
         cmd_str = "\n".join(cmds) + "\n"
         try:
-            subprocess.run(
+            result = subprocess.run(
                 ["bluetoothctl"],
                 input=cmd_str,
                 capture_output=True,
                 text=True,
                 timeout=10,
             )
-            logger.info("BT stack: removed %s (adapter: %s)", mac, adapter_mac or "default")
+            # `bluetoothctl` returns 0 even when `remove <mac>` fails with
+            # "Device not available" (device not in the BlueZ object tree).
+            # Rely on the stdout marker instead of returncode.
+            out = (result.stdout or "") + (result.stderr or "")
+            if "not available" in out.lower() or "failed to remove" in out.lower():
+                logger.warning(
+                    "BT stack: remove %s reported failure (adapter: %s): %s",
+                    mac,
+                    adapter_mac or "default",
+                    out.strip() or "no output",
+                )
+            else:
+                logger.info("BT stack: removed %s (adapter: %s)", mac, adapter_mac or "default")
         except Exception as e:
             logger.warning("BT stack cleanup failed for %s: %s", mac, e)
+        # Cache cleanup is intentionally independent of the remove outcome:
+        # stale cache files survive even when bluetoothctl reports "not
+        # available" (device already gone from the tree but its
+        # /var/lib/bluetooth/<adapter>/cache/<device> file lingers and
+        # still causes the next-pair Protocol-not-available regression).
         if adapter_mac:
             _clean_bluez_cache(adapter_mac, mac)
 

--- a/services/bluetooth.py
+++ b/services/bluetooth.py
@@ -56,6 +56,27 @@ _ADAPTER_RE = re.compile(r"Controller\s+([\dA-F:]{17})\s", re.IGNORECASE)
 _MAC_RE = re.compile(r"^[\dA-Fa-f]{2}(:[\dA-Fa-f]{2}){5}$")
 _BLUEZ_ERROR_RE = re.compile(r"org\.bluez\.Error\.[A-Za-z]+")
 
+# BlueZ stores per-adapter device cache files at /var/lib/bluetooth/<adapter>/cache/<device>.
+# `bluetoothctl remove` does NOT delete these; stale ServiceRecords/Endpoints in that file
+# cause org.bluez.Error.Failed "Protocol not available" on the next A2DP pair attempt
+# (bluez/bluez#191, #348, #698). Tests inject a temp path via monkeypatch.
+_BLUEZ_LIB_DIR: Path = Path("/var/lib/bluetooth")
+
+
+def _clean_bluez_cache(adapter_mac: str, device_mac: str) -> None:
+    """Best-effort removal of the stale BlueZ cache file for *device_mac*
+    under *adapter_mac*. Silent on ``FileNotFoundError`` (already gone);
+    warns on other OS errors but never raises — the caller runs in a
+    daemon thread and must not die."""
+    cache_file = _BLUEZ_LIB_DIR / adapter_mac / "cache" / device_mac
+    try:
+        cache_file.unlink()
+        logger.info("BlueZ cache: removed stale %s", cache_file)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.warning("BlueZ cache cleanup failed for %s: %s", cache_file, e)
+
 
 def is_valid_mac(mac: str) -> bool:
     """Return True if *mac* looks like a valid colon-separated MAC address."""
@@ -158,6 +179,8 @@ def bt_remove_device(mac: str, adapter_mac: str = "") -> None:
             logger.info("BT stack: removed %s (adapter: %s)", mac, adapter_mac or "default")
         except Exception as e:
             logger.warning("BT stack cleanup failed for %s: %s", mac, e)
+        if adapter_mac:
+            _clean_bluez_cache(adapter_mac, mac)
 
     threading.Thread(target=_run, daemon=True).start()
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -371,7 +371,10 @@ def test_run_standalone_pair_cleans_stale_device_before_trusting(monkeypatch):
     assert "select C0:FB:F9:62:D7:D6\n" in cleanup_input
     assert "remove AA:BB:CC:DD:EE:FF\n" in cleanup_input
     assert fake_proc.stdin.writes[0].startswith("select C0:FB:F9:62:D7:D6\n")
-    assert fake_proc.stdin.writes[0].endswith("scan on\n")
+    # `scan bredr` (not `scan on`) — BlueZ 5.85 supports explicit transport
+    # selection; filtering out LE-only advertisers prevents scan-result
+    # noise during A2DP sink pairing (bluez/bluez#826 workaround).
+    assert fake_proc.stdin.writes[0].endswith("scan bredr\n")
     assert fake_proc.stdin.writes[1] == "pair AA:BB:CC:DD:EE:FF\n"
     assert fake_proc.stdin.writes[2].startswith("trust AA:BB:CC:DD:EE:FF\n")
     finish_job.assert_called_once_with("job-1", {"success": True, "mac": "AA:BB:CC:DD:EE:FF"})

--- a/tests/test_bluetooth_svc.py
+++ b/tests/test_bluetooth_svc.py
@@ -120,6 +120,50 @@ def test_bt_remove_device_skips_cache_cleanup_without_adapter(tmp_path, monkeypa
         clean_mock.assert_not_called()
 
 
+def test_bt_remove_device_logs_warning_when_bluetoothctl_reports_failure(caplog):
+    """bluetoothctl returns exit 0 even when `remove <mac>` fails (device
+    not in BlueZ tree, etc.). The "BT stack: removed" info log must not
+    fire in that case — it misrepresents the state and misleads operators
+    reading logs. Instead, a warning with the output detail is logged.
+    """
+    import logging
+
+    with patch("services.bluetooth.threading.Thread") as mock_thread:
+        bt_remove_device("AA:BB:CC:DD:EE:FF")
+        target_fn = mock_thread.call_args[1]["target"]
+        failure_output = "Device AA:BB:CC:DD:EE:FF not available\n"
+        with patch("services.bluetooth.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=failure_output, stderr="", returncode=0)
+            with caplog.at_level(logging.DEBUG, logger="services.bluetooth"):
+                target_fn()
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert not any("BT stack: removed" in m for m in messages), (
+        "Must not claim success when bluetoothctl reports the device was not available"
+    )
+    assert any("not available" in m for m in messages), (
+        "Expected a warning/log surfacing the bluetoothctl failure detail"
+    )
+
+
+def test_bt_remove_device_logs_removed_only_on_success(caplog):
+    """When bluetoothctl actually removes the device (output contains
+    "Device has been removed"), the success log fires as before."""
+    import logging
+
+    with patch("services.bluetooth.threading.Thread") as mock_thread:
+        bt_remove_device("AA:BB:CC:DD:EE:FF")
+        target_fn = mock_thread.call_args[1]["target"]
+        success_output = "[DEL] Device AA:BB:CC:DD:EE:FF Speaker\nDevice has been removed\n"
+        with patch("services.bluetooth.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=success_output, stderr="", returncode=0)
+            with caplog.at_level(logging.INFO, logger="services.bluetooth"):
+                target_fn()
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("BT stack: removed" in m for m in messages)
+
+
 # ---------------------------------------------------------------------------
 # is_audio_device
 # ---------------------------------------------------------------------------

--- a/tests/test_bluetooth_svc.py
+++ b/tests/test_bluetooth_svc.py
@@ -46,6 +46,80 @@ def test_bt_remove_device_valid_mac():
             assert "AA:BB:CC:DD:EE:FF" in args[1]["input"]
 
 
+def test_bt_remove_device_cleans_bluez_cache_when_adapter_given(tmp_path, monkeypatch):
+    """After ``bluetoothctl remove``, the stale cache file at
+    ``/var/lib/bluetooth/<adapter>/cache/<device>`` must be deleted too —
+    BlueZ's `RemoveDevice` leaves service-record entries there, and the
+    next pair attempt picks up the stale `ServiceRecords`/`Endpoints`,
+    producing ``org.bluez.Error.Failed — Protocol not available`` on
+    A2DP sinks (bluez/bluez#191, #348, #698). Guarding the cleanup
+    behind an injectable base path keeps the test hermetic.
+    """
+    import services.bluetooth as _bt_mod
+
+    adapter_mac = "C0:FB:F9:62:D6:9D"
+    device_mac = "AA:BB:CC:DD:EE:FF"
+    bluez_root = tmp_path / "var_lib_bluetooth"
+    cache_dir = bluez_root / adapter_mac / "cache"
+    cache_dir.mkdir(parents=True)
+    cache_file = cache_dir / device_mac
+    cache_file.write_text("[ServiceRecords] stale junk")
+    assert cache_file.exists()
+
+    monkeypatch.setattr(_bt_mod, "_BLUEZ_LIB_DIR", bluez_root)
+
+    with patch("services.bluetooth.threading.Thread") as mock_thread:
+        bt_remove_device(device_mac, adapter_mac)
+        target_fn = mock_thread.call_args[1]["target"]
+        with patch("services.bluetooth.subprocess.run"):
+            target_fn()
+
+    assert not cache_file.exists(), (
+        "bt_remove_device must delete /var/lib/bluetooth/<adapter>/cache/<device> "
+        "after `bluetoothctl remove` to prevent stale-cache Protocol-not-available "
+        "on the next pair attempt"
+    )
+
+
+def test_bt_remove_device_cache_cleanup_missing_file_does_not_raise(tmp_path, monkeypatch):
+    """If the cache file does not exist (e.g. device never paired, or
+    another process cleaned it first), the cleanup is a no-op — no
+    exception propagates to kill the daemon thread and nothing is
+    logged at warning level for this expected case."""
+    import services.bluetooth as _bt_mod
+
+    bluez_root = tmp_path / "var_lib_bluetooth"
+    (bluez_root / "C0:FB:F9:62:D6:9D" / "cache").mkdir(parents=True)
+    monkeypatch.setattr(_bt_mod, "_BLUEZ_LIB_DIR", bluez_root)
+
+    with patch("services.bluetooth.threading.Thread") as mock_thread:
+        bt_remove_device("AA:BB:CC:DD:EE:FF", "C0:FB:F9:62:D6:9D")
+        target_fn = mock_thread.call_args[1]["target"]
+        with patch("services.bluetooth.subprocess.run"):
+            target_fn()  # must not raise
+
+
+def test_bt_remove_device_skips_cache_cleanup_without_adapter(tmp_path, monkeypatch):
+    """No adapter MAC → no known cache path → cleanup must not walk the
+    BlueZ tree blindly (could match the wrong device if multiple
+    adapters cached the same peer). Only the bluetoothctl remove runs."""
+    import services.bluetooth as _bt_mod
+
+    bluez_root = tmp_path / "var_lib_bluetooth"
+    bluez_root.mkdir(parents=True)
+    monkeypatch.setattr(_bt_mod, "_BLUEZ_LIB_DIR", bluez_root)
+
+    with patch("services.bluetooth.threading.Thread") as mock_thread:
+        bt_remove_device("AA:BB:CC:DD:EE:FF")  # no adapter_mac
+        target_fn = mock_thread.call_args[1]["target"]
+        with (
+            patch("services.bluetooth.subprocess.run"),
+            patch.object(_bt_mod, "_clean_bluez_cache") as clean_mock,
+        ):
+            target_fn()
+        clean_mock.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # is_audio_device
 # ---------------------------------------------------------------------------

--- a/tests/test_bt_manager.py
+++ b/tests/test_bt_manager.py
@@ -571,7 +571,10 @@ def test_pair_device_trusts_only_after_pair_success(bt_manager):
     ):
         assert bt_manager.pair_device() is True
 
-    assert fake_proc.stdin.writes[0].endswith("scan on\n")
+    # `scan bredr` — constrains discovery to BR/EDR transport for A2DP
+    # sinks; LE-only devices (beacons, BLE wearables) are filtered out
+    # upstream by the kernel so they don't compete in the scan window.
+    assert fake_proc.stdin.writes[0].endswith("scan bredr\n")
     assert fake_proc.stdin.writes[1] == f"pair {bt_manager.mac_address}\n"
     assert fake_proc.stdin.writes[2] == "yes\n"
     assert fake_proc.stdin.writes[3].startswith(f"trust {bt_manager.mac_address}\n")


### PR DESCRIPTION
## Summary

Two small BlueZ 5.x hardening items surfaced by the research pass on popular Linux-BT projects. Both are low-risk, local edits that benefit the common A2DP pair/re-pair flow on HAOS.

### 1. Clear stale BlueZ device cache on `bt_remove_device`

After `bluetoothctl remove`, BlueZ leaves the per-device file
`/var/lib/bluetooth/<adapter>/cache/<device>` on disk with cached
`ServiceRecords` / `Endpoints`. The next pair attempt reads that file,
and if the device's SDP layout changed (firmware update, factory
reset) it surfaces as:

```
org.bluez.Error.Failed — Protocol not available
```

on A2DP sinks. Known in upstream: bluez/bluez#191, #348, #698.

`_clean_bluez_cache()` best-effort unlinks the file after the
`bluetoothctl remove` call. Silent on `FileNotFoundError`, warns on
other OS errors, never raises (the caller runs in a daemon thread).
Only runs when the adapter MAC is known to avoid walking the BlueZ
tree blindly. Hermetically testable via a module-level
`_BLUEZ_LIB_DIR` that tests override with `monkeypatch`.

### 2. `scan bredr` replaces `scan on` at all five pair/scan sites

A2DP sinks only speak classic BT. `bluetoothctl scan on` scans both
BR/EDR and LE, which on BlueZ 5.85 can interleave results and delay
the pair target appearing (bluez/bluez#826). Excluding LE-only
advertisers keeps the scan window responsive and — on adapters
shared with BLE traffic — keeps our pair flow deterministic.

bluetoothctl ≥ 5.65 accepts `scan bredr` directly; HAOS 17.1 ships
5.85, Ubuntu 24.04 ships 5.72, Debian 12 ships 5.66 — all fine.

Sites touched:

- `bluetooth_manager.py:424` — runtime pair-device loop
- `routes/api_bt.py:661` — reset & reconnect
- `routes/api_bt.py:931, 933` — background BT scan (with/without adapters)
- `routes/api_bt.py:1322` — standalone pair (scan-modal flow)

## TDD log

Three RED tests for #1 (cache file deletion, missing-file no-op,
no-adapter short-circuit) + flipped assertions in two existing tests
for #4 (`scan bredr` in first stdin write). All implemented after
RED was confirmed. Full suite: 1480 passing (the pre-existing
order-dependent `test_api_diagnostics_reports_failed_collections_for_sink_input_timeout`
still fails in isolation, passes in full run — unrelated).

## Test plan

- [ ] Local: `pytest tests/test_bluetooth_svc.py tests/test_bt_manager.py -k 'pair_device or remove_device'`
- [ ] Staging (sendspin-test VM 105): pair a BT speaker, remove it via UI, verify `/var/lib/bluetooth/*/cache/<mac>` is gone, re-pair succeeds
- [ ] HAOS prod: watch scan window during pair from scan-modal — LE-only devices should no longer appear in the result list

🤖 Generated with [Claude Code](https://claude.com/claude-code)