### PR TITLE
rc.9: HA addon settings persistence + diagnostics + UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Settings UI: experimental "Allow HFP / HSP profile" toggle
+
+`ALLOW_HFP_PROFILE` was previously a config-only field — operators
+had to hand-edit `/config/config.json` to enable it for HFP-only
+headsets.  Now exposed as the seventh experimental toggle in the
+Settings page (Show experimental features → Allow HFP / HSP profile),
+with an explicit warning in the tooltip that most BT speakers and
+headphones will collapse to an 8 kHz mono call codec when HSP/HFP is
+permitted.  Persisted across HA addon restarts via the new
+preservation list (see below).
+
 ### Fixed — HA addon: web-UI-only settings now survive restart
 
 In HA addon mode every restart ran `scripts/translate_ha_config.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — HA addon: web-UI-only settings now survive restart
+
+In HA addon mode every restart ran `scripts/translate_ha_config.py`
+which rebuilds `config.json` from the addon's `options.json`.  The
+addon schema doesn't expose the `EXPERIMENTAL_*` family or several
+auth / update / sync settings — those are managed only via the
+bridge web UI (Settings → Show experimental features).  The
+translator's preservation list missed them, so a single restart
+silently rewrote each toggle to its default and operators saw the
+controls "not save".
+
+Now preserved across restart in addon mode:
+
+- `EXPERIMENTAL_A2DP_SINK_RECOVERY_DANCE`,
+  `EXPERIMENTAL_PA_MODULE_RELOAD`,
+  `EXPERIMENTAL_PAIR_JUST_WORKS`,
+  `EXPERIMENTAL_ADAPTER_AUTO_RECOVERY`,
+  `EXPERIMENTAL_RSSI_BADGE` — the entire experimental-flags family.
+- `AUTH_ENABLED`, `BRUTE_FORCE_PROTECTION` — auth toggles.
+- `MA_WEBSOCKET_MONITOR` — MA real-time sync toggle.
+- `AUTO_UPDATE`, `CHECK_UPDATES`, `SMOOTH_RESTART` — update / restart
+  behaviour.
+- `ALLOW_HFP_PROFILE` — HFP/HSP authorisation override.
+- `TRUSTED_PROXIES` — X-Forwarded-For accept list.
+
+Two new tests in `tests/test_translate_ha_config.py` pin the
+experimental-flags group and the broader web-UI-only group so a
+future field added to either family doesn't silently regress on
+addon-mode restarts.
+
 ### Diagnostics — surface MA server version
 
 The bug-report payload (`/api/bugreport`) and the runtime log now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Diagnostics — surface MA server version
+
+The bug-report payload (`/api/bugreport`) and the runtime log now
+both expose the **Music Assistant server version**.  Previously only
+the bridge's `music-assistant-client` *library* pin (e.g.
+`1.3.5`) appeared in the report, which left auth-flow incidents
+like #190 stuck on "what MA build is the reporter running?" before
+any debugging could start.
+
+- `routes/api_status._collect_environment` — new `ma_server_version`
+  key, sourced from the cached value populated at WS handshake;
+  falls back to `"unknown"` if the bridge hasn't connected to MA yet
+  (matches the existing `bluez` / `audio_server` pattern so the key
+  always appears in the markdown body).
+- `services/ma_monitor` — emits one INFO line right after the
+  handshake in the form
+  `MA server: version=<x> schema=<y> url=<z>` so operators can grep
+  for it without trawling subprocess logs.  Mirrors the
+  `entrypoint.sh` banner's style (the entrypoint can't include the
+  version because it runs before any Python / WS connection).
+
+Three new tests in `tests/test_bugreport_environment.py` pin both
+the present-when-known and unknown-when-pre-handshake branches plus
+the existing runtime-deps key.
+
 ### UI follow-ups on rc.8 RSSI badge
 
 - ``_getRssiBadgeRenderData`` / ``_renderRssiBadgeHtml`` gain a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ headphones will collapse to an 8 kHz mono call codec when HSP/HFP is
 permitted.  Persisted across HA addon restarts via the new
 preservation list (see below).
 
+### Changed — BT info modal shows full ``bluetoothctl info`` output
+
+The BT info modal previously rendered a 9-field summary (Name,
+Alias, MAC, Paired/Trusted/Connected/Bonded/Blocked, Class, Icon).
+That dropped the ``UUID:`` lines which carry the load-bearing
+diagnostic for "does this speaker actually advertise A2DP Sink"
+(``0000110b``), AVRCP target/controller, etc. — the same data that
+took an SSH round-trip to extract during issue #168 triage.
+
+Modal now renders ``info.raw`` directly: the full line-by-line
+bluetoothctl output (Class, Icon, Paired, Bonded, Trusted, Blocked,
+Connected, LegacyPairing, every UUID with friendly name, Modalias).
+Backend already collected all of this in ``raw``; the frontend just
+needed to use it.  Bluetoothctl's piped-stdin noise (``Agent
+registered``, ``[bluetooth]#`` prompts) is filtered client-side.
+Modal width bumped 440 → 620 px to fit the long UUID lines.
+
+One new test in ``tests/test_bt_info_adapter_awareness`` pins the
+parser contract: every UUID, Modalias, Class, and LegacyPairing
+line must appear in ``info["raw"]``.
+
 ### Changed — Settings UI: experimental flags moved to dedicated card
 
 All five experimental toggles (A2DP sink recovery dance, Reload PA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 `ALLOW_HFP_PROFILE` was previously a config-only field — operators
 had to hand-edit `/config/config.json` to enable it for HFP-only
-headsets.  Now exposed as the seventh experimental toggle in the
-Settings page (Show experimental features → Allow HFP / HSP profile),
-with an explicit warning in the tooltip that most BT speakers and
+headsets.  Now exposed in the new "Experimental features" card with
+an explicit warning in the tooltip that most BT speakers and
 headphones will collapse to an 8 kHz mono call codec when HSP/HFP is
 permitted.  Persisted across HA addon restarts via the new
 preservation list (see below).
+
+### Changed — Settings UI: experimental flags moved to dedicated card
+
+All five experimental toggles (A2DP sink recovery dance, Reload PA
+BT module, Adapter auto-recovery, Live RSSI badge, Allow HFP / HSP)
+moved out of the Connection-recovery card into a new "Experimental
+features" card directly below it.  The card itself carries
+`data-experimental` so the entire group hides when "Show
+experimental features" is off — Connection recovery now contains
+only the two production-stable inputs (BT check interval +
+Auto-disable threshold), eliminating the cluttered mix of stable
+and experimental rows it had since rc.2.
 
 ### Fixed — HA addon: web-UI-only settings now survive restart
 

--- a/routes/api_status.py
+++ b/routes/api_status.py
@@ -1071,6 +1071,15 @@ def _collect_environment() -> dict:
 
     env.update(get_runtime_dependency_versions())
 
+    # MA *server* version (vs. ``music-assistant-client`` library
+    # version, which lives in the runtime-deps pin).  Cached at WS
+    # handshake; pre-handshake it's an empty string.  Surfaced as
+    # "unknown" so the bug-report markdown stays consistent with the
+    # other "?" fields rather than silently dropping the key — issue
+    # #190 was diagnosed slowly because we couldn't tell which MA
+    # build the operator was running.
+    env["ma_server_version"] = get_ma_server_version() or "unknown"
+
     return env
 
 

--- a/scripts/translate_ha_config.py
+++ b/scripts/translate_ha_config.py
@@ -181,6 +181,30 @@ def main() -> None:
         for key in ("AUTH_PASSWORD_HASH", "SECRET_KEY"):
             if key in existing:
                 config[key] = existing[key]
+        # UI-only settings that POST /api/config writes to config.json
+        # but the addon options.json schema doesn't expose.  Without
+        # explicit preservation a restart silently rewrites them to
+        # defaults, which looked to operators like the toggles "don't
+        # save".  Includes every EXPERIMENTAL_* flag plus the broader
+        # auth / update / sync / proxy family.
+        web_ui_only_keys = (
+            "EXPERIMENTAL_A2DP_SINK_RECOVERY_DANCE",
+            "EXPERIMENTAL_PA_MODULE_RELOAD",
+            "EXPERIMENTAL_PAIR_JUST_WORKS",
+            "EXPERIMENTAL_ADAPTER_AUTO_RECOVERY",
+            "EXPERIMENTAL_RSSI_BADGE",
+            "AUTH_ENABLED",
+            "BRUTE_FORCE_PROTECTION",
+            "MA_WEBSOCKET_MONITOR",
+            "AUTO_UPDATE",
+            "CHECK_UPDATES",
+            "SMOOTH_RESTART",
+            "ALLOW_HFP_PROFILE",
+            "TRUSTED_PROXIES",
+        )
+        for key in web_ui_only_keys:
+            if key in existing:
+                config[key] = existing[key]
         for key in ("MA_ACCESS_TOKEN", "MA_REFRESH_TOKEN"):
             if existing.get(key):
                 config[key] = existing[key]

--- a/services/ma_monitor.py
+++ b/services/ma_monitor.py
@@ -816,11 +816,23 @@ class MaMonitor:
             # Server info
             server_info = await _recv(ws, timeout=10.0)
             self._detect_ha_addon(server_info)
-            # Cache MA server version
+            # Cache MA server version + banner-line it into the runtime
+            # log so operators can grep one line for "what MA build
+            # are we talking to".  Mirrors the entrypoint banner's
+            # format (which can't include the version because it runs
+            # before the WS handshake).  Issue #190 was slowed by not
+            # knowing which MA build the reporter ran.
             si = server_info.get("server_info", server_info)
             _ma_ver = si.get("server_version", "")
+            _ma_schema = si.get("schema_version", "")
             if _ma_ver:
                 _state.set_ma_server_version(_ma_ver)
+                logger.info(
+                    "MA server: version=%s schema=%s url=%s",
+                    _ma_ver,
+                    _ma_schema or "?",
+                    self._ws_url,
+                )
 
             # Auth
             mid = self._next_id()

--- a/static/app.js
+++ b/static/app.js
@@ -6905,19 +6905,50 @@ async function showBtDeviceInfo(mac, adapter) {
             body: JSON.stringify(body)
         });
         var info = await resp.json();
-        var lines = [];
-        if (info.name) lines.push('Name: ' + info.name);
-        if (info.alias) lines.push('Alias: ' + info.alias);
-        lines.push('MAC: ' + mac);
-        if (info.paired) lines.push('Paired: ' + info.paired);
-        if (info.trusted) lines.push('Trusted: ' + info.trusted);
-        if (info.connected) lines.push('Connected: ' + info.connected);
-        if (info.bonded) lines.push('Bonded: ' + info.bonded);
-        if (info.blocked) lines.push('Blocked: ' + info.blocked);
-        if (info['class']) lines.push('Class: ' + info['class']);
-        if (info.icon) lines.push('Icon: ' + info.icon);
-        if (info.error) lines.push('\nError: ' + info.error);
-        var text = lines.join('\n') || 'No info available for ' + mac;
+        // Render the full ``bluetoothctl info`` output verbatim (UUIDs,
+        // Modalias, LegacyPairing, Class, etc.) so issue-triage doesn't
+        // need a follow-up SSH session.  Backend stashes every
+        // ANSI-stripped non-empty line in ``raw``; we filter the
+        // bluetoothctl prompt / agent-registration noise it emits when
+        // commands are piped on stdin.
+        var text = '';
+        if (Array.isArray(info.raw) && info.raw.length) {
+            // Bluetoothctl noise we drop:
+            // - "Waiting to connect to bluetoothd..." — startup line
+            // - any line beginning with "[xxx]>" or "[xxx]#" — prompt
+            //   (the bracketed name varies: [bluetoothctl], [bluetooth],
+            //    or the currently-selected device's name)
+            // - "Agent registered" / "Agent unregistered"
+            // - "Changing ... succeeded/failed" status echoes
+            text = info.raw
+                .filter(function(ln) {
+                    if (!ln) return false;
+                    if (/^\[[^\]]+\][>#]/.test(ln)) return false;
+                    if (ln === 'Agent registered') return false;
+                    if (ln.indexOf('Agent unregistered') !== -1) return false;
+                    if (ln.indexOf('Waiting to connect to bluetoothd') !== -1) return false;
+                    return true;
+                })
+                .join('\n');
+        }
+        if (!text) {
+            // Fallback — backend returned no raw payload (older version
+            // or parse failure).  Build the minimal MAC-only summary
+            // from individual fields so the modal isn't empty.
+            var lines = [];
+            if (info.name) lines.push('Name: ' + info.name);
+            if (info.alias) lines.push('Alias: ' + info.alias);
+            lines.push('MAC: ' + mac);
+            if (info.paired) lines.push('Paired: ' + info.paired);
+            if (info.trusted) lines.push('Trusted: ' + info.trusted);
+            if (info.connected) lines.push('Connected: ' + info.connected);
+            if (info.bonded) lines.push('Bonded: ' + info.bonded);
+            if (info.blocked) lines.push('Blocked: ' + info.blocked);
+            if (info['class']) lines.push('Class: ' + info['class']);
+            if (info.icon) lines.push('Icon: ' + info.icon);
+            text = lines.join('\n') || 'No info available for ' + mac;
+        }
+        if (info.error) text += '\n\nError: ' + info.error;
         _showBtInfoModal(info.name || mac, text);
     } catch (err) {
         showToast('Failed to get info: ' + err.message, 'error');
@@ -6931,7 +6962,9 @@ function _showBtInfoModal(title, text) {
 
     var modal = document.createElement('div');
     modal.className = 'bugreport-modal bt-info-modal';
-    modal.style.maxWidth = '440px';
+    // Wider than other modals — UUID lines are 60+ chars and look
+    // ugly when wrapped in a narrow column.
+    modal.style.maxWidth = '620px';
 
     var header = document.createElement('div');
     header.className = 'bugreport-header bt-info-header';

--- a/static/app.js
+++ b/static/app.js
@@ -6919,7 +6919,9 @@ async function showBtDeviceInfo(mac, adapter) {
             //   (the bracketed name varies: [bluetoothctl], [bluetooth],
             //    or the currently-selected device's name)
             // - "Agent registered" / "Agent unregistered"
-            // - "Changing ... succeeded/failed" status echoes
+            // - "Changing ... succeeded/failed" status echoes from
+            //   trust/connect commands that pass through the same
+            //   bluetoothctl session
             text = info.raw
                 .filter(function(ln) {
                     if (!ln) return false;
@@ -6927,6 +6929,7 @@ async function showBtDeviceInfo(mac, adapter) {
                     if (ln === 'Agent registered') return false;
                     if (ln.indexOf('Agent unregistered') !== -1) return false;
                     if (ln.indexOf('Waiting to connect to bluetoothd') !== -1) return false;
+                    if (/^Changing .+ (succeeded|failed)$/.test(ln)) return false;
                     return true;
                 })
                 .join('\n');

--- a/static/app.js
+++ b/static/app.js
@@ -7188,6 +7188,7 @@ function _buildConfigPayload(options) {
     config.EXPERIMENTAL_PA_MODULE_RELOAD = !!(document.getElementById('experimental-pa-module-reload') || {}).checked;
     config.EXPERIMENTAL_ADAPTER_AUTO_RECOVERY = !!(document.getElementById('experimental-adapter-auto-recovery') || {}).checked;
     config.EXPERIMENTAL_RSSI_BADGE = !!(document.getElementById('experimental-rssi-badge') || {}).checked;
+    config.ALLOW_HFP_PROFILE = !!(document.getElementById('experimental-allow-hfp-profile') || {}).checked;
     // EXPERIMENTAL_PAIR_JUST_WORKS is a per-pair transient override from the
     // scan modal toolbar (see pairAndAdd) — deliberately NOT persisted via
     // the Settings form. The config key is still honoured as a fallback for
@@ -9771,6 +9772,8 @@ async function loadConfig(options) {
         if (expAdapterRecoveryCheck) expAdapterRecoveryCheck.checked = !!config.EXPERIMENTAL_ADAPTER_AUTO_RECOVERY;
         var expRssiBadgeCheck = document.getElementById('experimental-rssi-badge');
         if (expRssiBadgeCheck) expRssiBadgeCheck.checked = !!config.EXPERIMENTAL_RSSI_BADGE;
+        var expAllowHfpCheck = document.getElementById('experimental-allow-hfp-profile');
+        if (expAllowHfpCheck) expAllowHfpCheck.checked = !!config.ALLOW_HFP_PROFILE;
         var authCheck = document.getElementById('auth-enabled');
         if (authCheck) authCheck.checked = !!config.AUTH_ENABLED;
         var haAreaAssistCheck = document.getElementById('ha-area-name-assist-enabled');

--- a/static/style.css
+++ b/static/style.css
@@ -5717,6 +5717,28 @@ body {
         .config-settings-card--utility {
             background: rgba(255, 166, 0, 0.03);
         }
+        /* Experimental-flags grouping card.  Mirrors the amber palette
+           used by .notice-card--warning so operators read it as
+           "in-development, may bite" at a glance.  Border-inline-start
+           accent + faint tint match the notice-card pattern; title gets
+           the warning colour and an icon to the left. */
+        .config-settings-card--experimental {
+            background: rgba(255, 166, 0, 0.05);
+            border-color: rgba(255, 166, 0, 0.32);
+            border-inline-start: 4px solid #c77700;
+        }
+        .config-settings-card--experimental .config-card-title {
+            color: #c77700;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .config-settings-card--experimental .config-card-title-icon {
+            width: 18px;
+            height: 18px;
+            color: #c77700;
+            flex: 0 0 auto;
+        }
         .config-card-stack {
             display: flex;
             flex-direction: column;

--- a/templates/index.html
+++ b/templates/index.html
@@ -656,9 +656,9 @@
                             </div>
                         </div>
 
-                        <div class="config-settings-card" data-experimental style="display:none">
+                        <div class="config-settings-card config-settings-card--experimental" data-experimental style="display:none">
                             <div class="config-card-header ui-stack ui-stack--sm">
-                                <div class="config-card-title">Experimental features</div>
+                                <div class="config-card-title"><span class="config-card-title-icon ui-icon-slot" data-ui-icon="warning" aria-hidden="true"></span>Experimental features</div>
                                 <p class="config-card-subtitle">Opt-in toggles for in-development behaviour. Visible only when "Show experimental features" is enabled in the onboarding section. Each requires an addon / container restart to take effect.</p>
                             </div>
                             <label class="config-setting-row config-setting-row--compact" title="Last-resort workaround for bluez/bluez#1922. If a sink fails to publish after connect, the bridge disconnects and reconnects the device once per attempt. May cause extra churn — try leaving disabled first.">

--- a/templates/index.html
+++ b/templates/index.html
@@ -654,10 +654,17 @@
                                     <input type="number" name="BT_MAX_RECONNECT_FAILS" placeholder="0" min="0" max="100">
                                 </div>
                             </div>
-                            <label class="config-setting-row config-setting-row--compact" data-experimental style="display:none" title="Last-resort workaround for bluez/bluez#1922. If a sink fails to publish after connect, the bridge disconnects and reconnects the device once per attempt. May cause extra churn — try leaving disabled first.">
+                        </div>
+
+                        <div class="config-settings-card" data-experimental style="display:none">
+                            <div class="config-card-header ui-stack ui-stack--sm">
+                                <div class="config-card-title">Experimental features</div>
+                                <p class="config-card-subtitle">Opt-in toggles for in-development behaviour. Visible only when "Show experimental features" is enabled in the onboarding section. Each requires an addon / container restart to take effect.</p>
+                            </div>
+                            <label class="config-setting-row config-setting-row--compact" title="Last-resort workaround for bluez/bluez#1922. If a sink fails to publish after connect, the bridge disconnects and reconnects the device once per attempt. May cause extra churn — try leaving disabled first.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
-                                    <strong>Experimental: A2DP sink recovery dance</strong>
-                                    <span class="form-hint">Disconnect→reconnect on missing sink. Requires restart.</span>
+                                    <strong>A2DP sink recovery dance</strong>
+                                    <span class="form-hint">Disconnect→reconnect on missing sink.</span>
                                 </span>
                                 <span class="config-setting-control">
                                     <span class="config-switch">
@@ -666,10 +673,10 @@
                                     </span>
                                 </span>
                             </label>
-                            <label class="config-setting-row config-setting-row--compact" data-experimental style="display:none" title="Last-resort recovery when a BT card never registers in PulseAudio. Reloads module-bluez5-discover — disrupts all Bluetooth audio bridge-wide. Throttled to once per 60 seconds.">
+                            <label class="config-setting-row config-setting-row--compact" title="Last-resort recovery when a BT card never registers in PulseAudio. Reloads module-bluez5-discover — disrupts all Bluetooth audio bridge-wide. Throttled to once per 60 seconds.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
-                                    <strong>Experimental: Reload PulseAudio BT module</strong>
-                                    <span class="form-hint">Last-resort sink recovery. Disrupts all BT audio. Requires restart.</span>
+                                    <strong>Reload PulseAudio BT module</strong>
+                                    <span class="form-hint">Last-resort sink recovery. Disrupts all BT audio.</span>
                                 </span>
                                 <span class="config-setting-control">
                                     <span class="config-switch">
@@ -678,10 +685,10 @@
                                     </span>
                                 </span>
                             </label>
-                            <label class="config-setting-row config-setting-row--compact" data-experimental style="display:none" title="Last-ditch adapter recovery: when reconnects fail BT_MAX_RECONNECT_FAILS times, run the bluetooth-auto-recovery ladder (mgmt reset → rfkill unblock → USB unbind/rebind). The USB step briefly disconnects every device on that controller — throttled per-adapter to once per 60 seconds. Requires CAP_NET_ADMIN, /dev/rfkill, /sys/bus/usb.">
+                            <label class="config-setting-row config-setting-row--compact" title="Last-ditch adapter recovery: when reconnects fail BT_MAX_RECONNECT_FAILS times, run the bluetooth-auto-recovery ladder (mgmt reset → rfkill unblock → USB unbind/rebind). The USB step briefly disconnects every device on that controller — throttled per-adapter to once per 60 seconds. Requires CAP_NET_ADMIN, /dev/rfkill, /sys/bus/usb.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
-                                    <strong>Experimental: Adapter auto-recovery</strong>
-                                    <span class="form-hint">HCI mgmt reset → rfkill → USB rebind before auto-release. Requires restart.</span>
+                                    <strong>Adapter auto-recovery</strong>
+                                    <span class="form-hint">HCI mgmt reset → rfkill → USB rebind before auto-release.</span>
                                 </span>
                                 <span class="config-setting-control">
                                     <span class="config-switch">
@@ -690,10 +697,10 @@
                                     </span>
                                 </span>
                             </label>
-                            <label class="config-setting-row config-setting-row--compact" data-experimental style="display:none" title="Poll live RSSI for connected speakers via the kernel mgmt socket (opcode 0x0031) every 30 s and surface a coloured signal-strength chip in the device card. BR/EDR returns delta from the controller's Golden Receive Power Range (0 = good); LE returns absolute dBm. Adds one mgmt round-trip per connected device per tick. Requires CAP_NET_ADMIN.">
+                            <label class="config-setting-row config-setting-row--compact" title="Poll live RSSI for connected speakers via the kernel mgmt socket (opcode 0x0031) every 30 s and surface a coloured signal-strength chip in the device card. BR/EDR returns delta from the controller's Golden Receive Power Range (0 = good); LE returns absolute dBm. Adds one mgmt round-trip per connected device per tick. Requires CAP_NET_ADMIN.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
-                                    <strong>Experimental: Live RSSI badge</strong>
-                                    <span class="form-hint">Poll every 30 s via mgmt 0x0031. Requires restart.</span>
+                                    <strong>Live RSSI badge</strong>
+                                    <span class="form-hint">Poll every 30 s via mgmt 0x0031.</span>
                                 </span>
                                 <span class="config-setting-control">
                                     <span class="config-switch">
@@ -702,10 +709,10 @@
                                     </span>
                                 </span>
                             </label>
-                            <label class="config-setting-row config-setting-row--compact" data-experimental style="display:none" title="Permit HSP/HFP service UUIDs in the pairing agent. Default off — most DSPs (Bose QC, AKG Y500, Sony XM4/5) prefer HFP over A2DP and collapse the link to an 8 kHz mono call codec, so HSP/HFP are rejected at AuthorizeService time. Enable only for HFP-only headsets that A2DP-block at the peer.">
+                            <label class="config-setting-row config-setting-row--compact" title="Permit HSP/HFP service UUIDs in the pairing agent. Default off — most DSPs (Bose QC, AKG Y500, Sony XM4/5) prefer HFP over A2DP and collapse the link to an 8 kHz mono call codec, so HSP/HFP are rejected at AuthorizeService time. Enable only for HFP-only headsets that A2DP-block at the peer.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
-                                    <strong>Experimental: Allow HFP / HSP profile</strong>
-                                    <span class="form-hint">For HFP-only headsets. Risk: most BT speakers/headphones drop to 8 kHz mono. Requires restart.</span>
+                                    <strong>Allow HFP / HSP profile</strong>
+                                    <span class="form-hint">For HFP-only headsets. Risk: most BT speakers/headphones drop to 8 kHz mono.</span>
                                 </span>
                                 <span class="config-setting-control">
                                     <span class="config-switch">

--- a/templates/index.html
+++ b/templates/index.html
@@ -702,6 +702,18 @@
                                     </span>
                                 </span>
                             </label>
+                            <label class="config-setting-row config-setting-row--compact" data-experimental style="display:none" title="Permit HSP/HFP service UUIDs in the pairing agent. Default off — most DSPs (Bose QC, AKG Y500, Sony XM4/5) prefer HFP over A2DP and collapse the link to an 8 kHz mono call codec, so HSP/HFP are rejected at AuthorizeService time. Enable only for HFP-only headsets that A2DP-block at the peer.">
+                                <span class="config-setting-copy ui-stack ui-stack--xs">
+                                    <strong>Experimental: Allow HFP / HSP profile</strong>
+                                    <span class="form-hint">For HFP-only headsets. Risk: most BT speakers/headphones drop to 8 kHz mono. Requires restart.</span>
+                                </span>
+                                <span class="config-setting-control">
+                                    <span class="config-switch">
+                                        <input type="checkbox" name="ALLOW_HFP_PROFILE" id="experimental-allow-hfp-profile">
+                                        <span class="config-switch-track"></span>
+                                    </span>
+                                </span>
+                            </label>
                         </div>
                     </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -661,7 +661,7 @@
                                 <div class="config-card-title"><span class="config-card-title-icon ui-icon-slot" data-ui-icon="warning" aria-hidden="true"></span>Experimental features</div>
                                 <p class="config-card-subtitle">Opt-in toggles for in-development behaviour. Visible only when "Show experimental features" is enabled in the onboarding section. Each requires an addon / container restart to take effect.</p>
                             </div>
-                            <label class="config-setting-row config-setting-row--compact" title="Last-resort workaround for bluez/bluez#1922. If a sink fails to publish after connect, the bridge disconnects and reconnects the device once per attempt. May cause extra churn — try leaving disabled first.">
+                            <label class="config-setting-row config-setting-row--compact" data-experimental title="Last-resort workaround for bluez/bluez#1922. If a sink fails to publish after connect, the bridge disconnects and reconnects the device once per attempt. May cause extra churn — try leaving disabled first.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
                                     <strong>A2DP sink recovery dance</strong>
                                     <span class="form-hint">Disconnect→reconnect on missing sink.</span>
@@ -673,7 +673,7 @@
                                     </span>
                                 </span>
                             </label>
-                            <label class="config-setting-row config-setting-row--compact" title="Last-resort recovery when a BT card never registers in PulseAudio. Reloads module-bluez5-discover — disrupts all Bluetooth audio bridge-wide. Throttled to once per 60 seconds.">
+                            <label class="config-setting-row config-setting-row--compact" data-experimental title="Last-resort recovery when a BT card never registers in PulseAudio. Reloads module-bluez5-discover — disrupts all Bluetooth audio bridge-wide. Throttled to once per 60 seconds.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
                                     <strong>Reload PulseAudio BT module</strong>
                                     <span class="form-hint">Last-resort sink recovery. Disrupts all BT audio.</span>
@@ -685,7 +685,7 @@
                                     </span>
                                 </span>
                             </label>
-                            <label class="config-setting-row config-setting-row--compact" title="Last-ditch adapter recovery: when reconnects fail BT_MAX_RECONNECT_FAILS times, run the bluetooth-auto-recovery ladder (mgmt reset → rfkill unblock → USB unbind/rebind). The USB step briefly disconnects every device on that controller — throttled per-adapter to once per 60 seconds. Requires CAP_NET_ADMIN, /dev/rfkill, /sys/bus/usb.">
+                            <label class="config-setting-row config-setting-row--compact" data-experimental title="Last-ditch adapter recovery: when reconnects fail BT_MAX_RECONNECT_FAILS times, run the bluetooth-auto-recovery ladder (mgmt reset → rfkill unblock → USB unbind/rebind). The USB step briefly disconnects every device on that controller — throttled per-adapter to once per 60 seconds. Requires CAP_NET_ADMIN, /dev/rfkill, /sys/bus/usb.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
                                     <strong>Adapter auto-recovery</strong>
                                     <span class="form-hint">HCI mgmt reset → rfkill → USB rebind before auto-release.</span>
@@ -697,7 +697,7 @@
                                     </span>
                                 </span>
                             </label>
-                            <label class="config-setting-row config-setting-row--compact" title="Poll live RSSI for connected speakers via the kernel mgmt socket (opcode 0x0031) every 30 s and surface a coloured signal-strength chip in the device card. BR/EDR returns delta from the controller's Golden Receive Power Range (0 = good); LE returns absolute dBm. Adds one mgmt round-trip per connected device per tick. Requires CAP_NET_ADMIN.">
+                            <label class="config-setting-row config-setting-row--compact" data-experimental title="Poll live RSSI for connected speakers via the kernel mgmt socket (opcode 0x0031) every 30 s and surface a coloured signal-strength chip in the device card. BR/EDR returns delta from the controller's Golden Receive Power Range (0 = good); LE returns absolute dBm. Adds one mgmt round-trip per connected device per tick. Requires CAP_NET_ADMIN.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
                                     <strong>Live RSSI badge</strong>
                                     <span class="form-hint">Poll every 30 s via mgmt 0x0031.</span>
@@ -709,7 +709,7 @@
                                     </span>
                                 </span>
                             </label>
-                            <label class="config-setting-row config-setting-row--compact" title="Permit HSP/HFP service UUIDs in the pairing agent. Default off — most DSPs (Bose QC, AKG Y500, Sony XM4/5) prefer HFP over A2DP and collapse the link to an 8 kHz mono call codec, so HSP/HFP are rejected at AuthorizeService time. Enable only for HFP-only headsets that A2DP-block at the peer.">
+                            <label class="config-setting-row config-setting-row--compact" data-experimental title="Permit HSP/HFP service UUIDs in the pairing agent. Default off — most DSPs (Bose QC, AKG Y500, Sony XM4/5) prefer HFP over A2DP and collapse the link to an 8 kHz mono call codec, so HSP/HFP are rejected at AuthorizeService time. Enable only for HFP-only headsets that A2DP-block at the peer.">
                                 <span class="config-setting-copy ui-stack ui-stack--xs">
                                     <strong>Allow HFP / HSP profile</strong>
                                     <span class="form-hint">For HFP-only headsets. Risk: most BT speakers/headphones drop to 8 kHz mono.</span>

--- a/tests/test_bt_info_adapter_awareness.py
+++ b/tests/test_bt_info_adapter_awareness.py
@@ -171,6 +171,68 @@ def test_api_bt_info_forwards_adapter_field(client, monkeypatch):
     assert captured == {"mac": "AA:BB:CC:DD:EE:FF", "adapter": "C0:FB:F9:62:D7:D6"}
 
 
+_DEVICE_INFO_FULL_WITH_UUIDS = (
+    "Agent registered\n"
+    "[bluetooth]# select C0:FB:F9:62:D7:D6\n"
+    "[bluetooth]# info AA:BB:CC:DD:EE:FF\n"
+    "Device AA:BB:CC:DD:EE:FF (public)\n"
+    "\tName: VAPPEBY Outdoor\n"
+    "\tAlias: VAPPEBY Outdoor\n"
+    "\tClass: 0x00240404\n"
+    "\tIcon: audio-headset\n"
+    "\tPaired: yes\n"
+    "\tBonded: yes\n"
+    "\tTrusted: yes\n"
+    "\tBlocked: no\n"
+    "\tConnected: no\n"
+    "\tLegacyPairing: no\n"
+    "\tUUID: Vendor specific           (00000000-deca-fade-deca-deafdecacaff)\n"
+    "\tUUID: Audio Sink                (0000110b-0000-1000-8000-00805f9b34fb)\n"
+    "\tUUID: A/V Remote Control Target (0000110c-0000-1000-8000-00805f9b34fb)\n"
+    "\tUUID: A/V Remote Control        (0000110e-0000-1000-8000-00805f9b34fb)\n"
+    "\tUUID: PnP Information           (00001200-0000-1000-8000-00805f9b34fb)\n"
+    "\tModalias: bluetooth:vE003p3528d0001\n"
+)
+
+
+def test_get_bt_device_info_raw_includes_uuids_modalias_and_legacypairing(monkeypatch):
+    """The info modal in the UI now renders ``info["raw"]`` directly so
+    operators see everything ``bluetoothctl info`` outputs.  Pin the
+    parser contract: every non-prompt line — including UUIDs (the
+    A2DP Sink / AVRCP / etc. service UUID list that's load-bearing
+    for diagnosing why a speaker won't play), Modalias (vendor /
+    product / version), LegacyPairing, and the ``Class`` octet —
+    must reach the ``raw`` array.  Without UUIDs in the modal,
+    issue #168 would have taken another round of asking the
+    reporter for ``bluetoothctl info`` over SSH."""
+    import routes.api_bt as module
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *_a, **_kw: _FakeCompletedProcess(stdout=_DEVICE_INFO_FULL_WITH_UUIDS),
+    )
+
+    info = module._get_bt_device_info("AA:BB:CC:DD:EE:FF", adapter="C0:FB:F9:62:D7:D6")
+
+    raw = info.get("raw") or []
+    raw_text = "\n".join(raw)
+    # Header + every diagnostic field the parser used to drop
+    assert "Device AA:BB:CC:DD:EE:FF (public)" in raw
+    assert "Class: 0x00240404" in raw_text
+    assert "LegacyPairing: no" in raw_text
+    # All five UUIDs must be present verbatim — UI treats them as
+    # the load-bearing diagnostic for "does this speaker actually
+    # advertise A2DP Sink".
+    assert "UUID: Audio Sink                (0000110b-0000-1000-8000-00805f9b34fb)" in raw_text
+    assert "UUID: A/V Remote Control Target (0000110c-0000-1000-8000-00805f9b34fb)" in raw_text
+    assert "UUID: A/V Remote Control        (0000110e-0000-1000-8000-00805f9b34fb)" in raw_text
+    assert "UUID: PnP Information           (00001200-0000-1000-8000-00805f9b34fb)" in raw_text
+    assert "UUID: Vendor specific           (00000000-deca-fade-deca-deafdecacaff)" in raw_text
+    # Vendor identity for the speaker
+    assert "Modalias: bluetooth:vE003p3528d0001" in raw_text
+
+
 def test_api_bt_info_rejects_invalid_adapter(client, monkeypatch):
     """Garbage adapter strings must 400 before touching bluetoothctl."""
     import routes.api_bt as module

--- a/tests/test_bugreport_environment.py
+++ b/tests/test_bugreport_environment.py
@@ -1,0 +1,70 @@
+"""Tests for the bug-report environment payload.
+
+The auto-attached diagnostics block (``_collect_environment``) feeds
+both the in-UI Report dialog and the GitHub-issue body.  Every key
+here ends up rendered as ``key: value`` in the issue markdown, so
+each addition is also a documentation contract — operators see
+exactly these fields when triaging.
+
+These tests pin only the additions that aren't already covered by
+the higher-level bug-report endpoint tests in
+``test_api_endpoints.py``.  Specifically: the MA server version,
+which the bridge learns at WS handshake time and used to be
+invisible in reports (only the ``music-assistant-client`` *library*
+version was present, leaving us guessing about the actual MA build).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from routes import api_status
+from services import ma_runtime_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_ma_server_version():
+    """The MA server version is module-level singleton state shared
+    with the rest of the suite (``test_demo_mode`` writes it too).
+    Snapshot + restore around each test so we don't leak."""
+    saved = ma_runtime_state.get_ma_server_version()
+    yield
+    ma_runtime_state.set_ma_server_version(saved)
+
+
+def test_collect_environment_includes_ma_server_version_when_known():
+    """After the WS handshake the bridge caches the MA server version
+    via ``set_ma_server_version``.  ``_collect_environment`` must
+    surface it under a stable key so the bug-report markdown shows
+    something concrete (e.g. ``ma_server_version: 2.5.7``) instead of
+    forcing maintainers to ask "what MA version are you on?" — that
+    was a real gap exposed by issue #190 where only
+    ``music-assistant-client=1.3.5`` (a Python lib pin) appeared."""
+    ma_runtime_state.set_ma_server_version("2.5.7")
+
+    env = api_status._collect_environment()
+
+    assert env.get("ma_server_version") == "2.5.7"
+
+
+def test_collect_environment_emits_unknown_when_ma_version_not_set():
+    """Pre-handshake (or MA never connected) the cache returns ''.
+    The key should still appear in the report — explicit "unknown"
+    is more useful than a silently-missing field, and matches the
+    pattern already used for ``bluez`` and ``audio_server``."""
+    ma_runtime_state.set_ma_server_version("")
+
+    env = api_status._collect_environment()
+
+    assert env.get("ma_server_version") == "unknown"
+
+
+def test_collect_environment_keeps_runtime_deps():
+    """Sanity guard: adding the MA *server* version must not displace
+    the existing ``music-assistant-client`` *library* version (they
+    answer different questions — the lib pin tells us which API
+    surface the bridge expects, the server version tells us what
+    the operator actually runs)."""
+    env = api_status._collect_environment()
+
+    assert "music-assistant-client" in env

--- a/tests/test_translate_ha_config.py
+++ b/tests/test_translate_ha_config.py
@@ -346,22 +346,29 @@ def test_translation_respects_explicit_ha_area_name_assist_setting(tmp_path):
     assert cfg["HA_AREA_NAME_ASSIST_ENABLED"] is False
 
 
-def test_translation_preserves_experimental_flags_set_via_web_ui(tmp_path):
-    """In HA addon mode the EXPERIMENTAL_* family is managed only via
-    the bridge web UI (Settings → Show experimental features) — none
-    of these fields are exposed in the addon's options.json schema.
-    Without explicit preservation the translator rewrites config.json
-    on every restart and silently drops the operator's choices, which
-    looks like the toggle "doesn't save".  Pin all five flags so a
-    single restart can never erase them."""
+def test_translation_preserves_settings_experimental_card_toggles(tmp_path):
+    """All five toggles in the Settings → Experimental features card
+    are managed only via the bridge web UI — none are exposed in the
+    addon's options.json schema.  Without explicit preservation the
+    translator rewrites config.json on every restart and silently
+    drops the operator's choices, which looks like the toggles
+    "don't save".
+
+    The card holds: A2DP sink recovery dance, Reload PA BT module,
+    Adapter auto-recovery, Live RSSI badge, Allow HFP / HSP profile.
+
+    NOTE: ``EXPERIMENTAL_PAIR_JUST_WORKS`` is *not* in this card —
+    it lives in the scan modal as a per-pair transient override.
+    Its preservation is asserted in the separate scan-modal-flag
+    test below so the two concerns stay separable."""
     _write_json(
         tmp_path / "config.json",
         {
             "EXPERIMENTAL_A2DP_SINK_RECOVERY_DANCE": True,
             "EXPERIMENTAL_PA_MODULE_RELOAD": True,
-            "EXPERIMENTAL_PAIR_JUST_WORKS": True,
             "EXPERIMENTAL_ADAPTER_AUTO_RECOVERY": True,
             "EXPERIMENTAL_RSSI_BADGE": True,
+            "ALLOW_HFP_PROFILE": True,
             "BLUETOOTH_DEVICES": [],
         },
     )
@@ -376,21 +383,41 @@ def test_translation_preserves_experimental_flags_set_via_web_ui(tmp_path):
     cfg = _read_json(tmp_path / "config.json")
     assert cfg["EXPERIMENTAL_A2DP_SINK_RECOVERY_DANCE"] is True
     assert cfg["EXPERIMENTAL_PA_MODULE_RELOAD"] is True
-    assert cfg["EXPERIMENTAL_PAIR_JUST_WORKS"] is True
     assert cfg["EXPERIMENTAL_ADAPTER_AUTO_RECOVERY"] is True
     assert cfg["EXPERIMENTAL_RSSI_BADGE"] is True
+    assert cfg["ALLOW_HFP_PROFILE"] is True
+
+
+def test_translation_preserves_scan_modal_pair_just_works_flag(tmp_path):
+    """``EXPERIMENTAL_PAIR_JUST_WORKS`` lives in the scan modal as a
+    per-pair toggle (not in the Settings card) — but the value can
+    still end up in config.json via POST /api/config when the bridge
+    persists a global default, so the translator must preserve it
+    across addon restarts the same way as the Settings flags."""
+    _write_json(
+        tmp_path / "config.json",
+        {"EXPERIMENTAL_PAIR_JUST_WORKS": True, "BLUETOOTH_DEVICES": []},
+    )
+    _write_json(tmp_path / "options.json", _minimal_options())
+
+    with (
+        patch("scripts.translate_ha_config._detect_adapters", return_value=[]),
+        patch("scripts.translate_ha_config.get_self_delivery_channel", return_value="stable"),
+    ):
+        main()
+
+    cfg = _read_json(tmp_path / "config.json")
+    assert cfg["EXPERIMENTAL_PAIR_JUST_WORKS"] is True
 
 
 def test_translation_preserves_other_config_only_settings(tmp_path):
-    """Same gap affects every config-only field that the addon
-    schema doesn't expose: AUTH_ENABLED, BRUTE_FORCE_PROTECTION,
+    """Same gap affects every other web-UI-managed field that the
+    addon schema doesn't expose: AUTH_ENABLED, BRUTE_FORCE_PROTECTION,
     MA_WEBSOCKET_MONITOR, AUTO_UPDATE, CHECK_UPDATES, SMOOTH_RESTART,
-    ALLOW_HFP_PROFILE, TRUSTED_PROXIES.  Most reach config.json via
-    POST /api/config from the bridge UI; ALLOW_HFP_PROFILE is the
-    one no-UI-at-all field (set by hand-editing config.json) and is
-    pinned here too so a manual edit doesn't get clobbered by the
-    next addon restart.  Surface the regression now so we don't have
-    to re-discover it per flag."""
+    TRUSTED_PROXIES.  All reach config.json via POST /api/config from
+    the bridge UI.  Pin them here so addon restarts can't silently
+    clobber operator choices, and surface the regression now so we
+    don't have to re-discover it per flag."""
     _write_json(
         tmp_path / "config.json",
         {
@@ -400,7 +427,6 @@ def test_translation_preserves_other_config_only_settings(tmp_path):
             "AUTO_UPDATE": True,
             "CHECK_UPDATES": False,
             "SMOOTH_RESTART": False,
-            "ALLOW_HFP_PROFILE": True,
             "TRUSTED_PROXIES": ["10.0.0.1", "10.0.0.2"],
             "BLUETOOTH_DEVICES": [],
         },
@@ -420,7 +446,6 @@ def test_translation_preserves_other_config_only_settings(tmp_path):
     assert cfg["AUTO_UPDATE"] is True
     assert cfg["CHECK_UPDATES"] is False
     assert cfg["SMOOTH_RESTART"] is False
-    assert cfg["ALLOW_HFP_PROFILE"] is True
     assert cfg["TRUSTED_PROXIES"] == ["10.0.0.1", "10.0.0.2"]
 
 

--- a/tests/test_translate_ha_config.py
+++ b/tests/test_translate_ha_config.py
@@ -346,6 +346,84 @@ def test_translation_respects_explicit_ha_area_name_assist_setting(tmp_path):
     assert cfg["HA_AREA_NAME_ASSIST_ENABLED"] is False
 
 
+def test_translation_preserves_experimental_flags_set_via_web_ui(tmp_path):
+    """In HA addon mode the EXPERIMENTAL_* family is managed only via
+    the bridge web UI (Settings → Show experimental features) — none
+    of these fields are exposed in the addon's options.json schema.
+    Without explicit preservation the translator rewrites config.json
+    on every restart and silently drops the operator's choices, which
+    looks like the toggle "doesn't save".  Pin all five flags so a
+    single restart can never erase them."""
+    _write_json(
+        tmp_path / "config.json",
+        {
+            "EXPERIMENTAL_A2DP_SINK_RECOVERY_DANCE": True,
+            "EXPERIMENTAL_PA_MODULE_RELOAD": True,
+            "EXPERIMENTAL_PAIR_JUST_WORKS": True,
+            "EXPERIMENTAL_ADAPTER_AUTO_RECOVERY": True,
+            "EXPERIMENTAL_RSSI_BADGE": True,
+            "BLUETOOTH_DEVICES": [],
+        },
+    )
+    _write_json(tmp_path / "options.json", _minimal_options())
+
+    with (
+        patch("scripts.translate_ha_config._detect_adapters", return_value=[]),
+        patch("scripts.translate_ha_config.get_self_delivery_channel", return_value="stable"),
+    ):
+        main()
+
+    cfg = _read_json(tmp_path / "config.json")
+    assert cfg["EXPERIMENTAL_A2DP_SINK_RECOVERY_DANCE"] is True
+    assert cfg["EXPERIMENTAL_PA_MODULE_RELOAD"] is True
+    assert cfg["EXPERIMENTAL_PAIR_JUST_WORKS"] is True
+    assert cfg["EXPERIMENTAL_ADAPTER_AUTO_RECOVERY"] is True
+    assert cfg["EXPERIMENTAL_RSSI_BADGE"] is True
+
+
+def test_translation_preserves_other_config_only_settings(tmp_path):
+    """Same gap affects every config-only field that the addon
+    schema doesn't expose: AUTH_ENABLED, BRUTE_FORCE_PROTECTION,
+    MA_WEBSOCKET_MONITOR, AUTO_UPDATE, CHECK_UPDATES, SMOOTH_RESTART,
+    ALLOW_HFP_PROFILE, TRUSTED_PROXIES.  Most reach config.json via
+    POST /api/config from the bridge UI; ALLOW_HFP_PROFILE is the
+    one no-UI-at-all field (set by hand-editing config.json) and is
+    pinned here too so a manual edit doesn't get clobbered by the
+    next addon restart.  Surface the regression now so we don't have
+    to re-discover it per flag."""
+    _write_json(
+        tmp_path / "config.json",
+        {
+            "AUTH_ENABLED": True,
+            "BRUTE_FORCE_PROTECTION": False,
+            "MA_WEBSOCKET_MONITOR": False,
+            "AUTO_UPDATE": True,
+            "CHECK_UPDATES": False,
+            "SMOOTH_RESTART": False,
+            "ALLOW_HFP_PROFILE": True,
+            "TRUSTED_PROXIES": ["10.0.0.1", "10.0.0.2"],
+            "BLUETOOTH_DEVICES": [],
+        },
+    )
+    _write_json(tmp_path / "options.json", _minimal_options())
+
+    with (
+        patch("scripts.translate_ha_config._detect_adapters", return_value=[]),
+        patch("scripts.translate_ha_config.get_self_delivery_channel", return_value="stable"),
+    ):
+        main()
+
+    cfg = _read_json(tmp_path / "config.json")
+    assert cfg["AUTH_ENABLED"] is True
+    assert cfg["BRUTE_FORCE_PROTECTION"] is False
+    assert cfg["MA_WEBSOCKET_MONITOR"] is False
+    assert cfg["AUTO_UPDATE"] is True
+    assert cfg["CHECK_UPDATES"] is False
+    assert cfg["SMOOTH_RESTART"] is False
+    assert cfg["ALLOW_HFP_PROFILE"] is True
+    assert cfg["TRUSTED_PROXIES"] == ["10.0.0.1", "10.0.0.2"]
+
+
 def test_translation_preserves_existing_startup_banner_grace_when_option_omitted(tmp_path):
     _write_json(
         tmp_path / "config.json",


### PR DESCRIPTION
## Summary

Six related improvements that grew out of issue #190 (HA OAuth sign-in failure) and rc.8 follow-ups. All small, all independent — kept in one PR because they share the rc.9 release window and CHANGELOG section.

### 1. HA addon: web-UI / config-only settings now survive restart

User report: \`EXPERIMENTAL_RSSI_BADGE\` toggle didn't survive an addon restart. Root cause is broader — \`scripts/translate_ha_config.py\` rebuilds \`config.json\` from \`options.json\` on every start, and the preservation list missed every web-UI-managed key. The same regression silently clobbered:

- All five EXPERIMENTAL_* flags
- \`AUTH_ENABLED\`, \`BRUTE_FORCE_PROTECTION\`
- \`MA_WEBSOCKET_MONITOR\`
- \`AUTO_UPDATE\`, \`CHECK_UPDATES\`, \`SMOOTH_RESTART\`
- \`ALLOW_HFP_PROFILE\` (no UI, hand-edited config.json case)
- \`TRUSTED_PROXIES\`

Now all preserved when present in the previous config.json. Two new tests pin the experimental-flags group and the broader config-only group so a future field doesn't silently regress.

### 2. Diagnostics: surface MA server version

Issue [#190](https://github.com/trudenboy/sendspin-bt-bridge/issues/190) was slow to triage because the bug-report payload only carried the bridge's \`music-assistant-client\` *library* pin (\`1.3.5\`) — never the MA *server* version the operator runs.

- \`routes/api_status._collect_environment\` adds \`ma_server_version\` to the env dict (sourced from the cached WS-handshake value, \`"unknown"\` pre-handshake).
- \`services/ma_monitor\` emits one INFO line right after the handshake: \`MA server: version=2.5.7 schema=29 url=ws://...\`. Mirrors entrypoint banner style; entrypoint can't include the version because it runs before any Python/WS.

### 3. New experimental toggle: Allow HFP / HSP profile

\`ALLOW_HFP_PROFILE\` was previously config-only — operators had to hand-edit \`/config/config.json\` to enable it for HFP-only headsets. Now in the new "Experimental features" card (see #4) with a tooltip warning that most BT speakers / headphones collapse to an 8 kHz mono call codec when HSP/HFP is permitted.

### 4. Settings UI: experimental flags moved to a dedicated highlighted card

Connection recovery card mixed two stable inputs (BT check, Auto-disable) with five experimental toggles, conflating production behaviour with in-development feature flags. All five toggles (A2DP sink recovery dance, Reload PA BT module, Adapter auto-recovery, Live RSSI badge, Allow HFP / HSP) now live in a new "Experimental features" card directly below Connection recovery:

- Amber border-inline-start (4 px) + faint amber tint, matching the \`.notice-card--warning\` palette already used for caution notices.
- Title in the warning colour with a ⚠ icon to the left.
- Hidden as a single unit via \`data-experimental\` on the card itself.
- Per-row \`data-experimental\` retained so the existing per-row red "!" badge styling and \`test_settings_experimental_toggle_has_template_checkbox\` tests still hold.

### 5. BT info modal: render full \`bluetoothctl info\` output

The info modal previously rendered a 9-field summary (Name, Alias, MAC, Paired/Trusted/Connected/Bonded/Blocked, Class, Icon), dropping the \`UUID:\` lines — the load-bearing diagnostic for "does this speaker actually advertise A2DP Sink (\`0000110b\`)" that took an SSH round-trip during issue #168 triage.

Modal now renders \`info.raw\` directly: every line bluetoothctl prints (Class, Icon, Paired/Bonded/Trusted/Blocked/Connected/LegacyPairing, every UUID with friendly name, Modalias). Backend already collected all of this; the frontend just needed to use it. Bluetoothctl piped-stdin noise filtered client-side (\`[bluetooth]#\`, \`[<DeviceName>]>\`, \`Agent registered\`, \`Waiting to connect to bluetoothd\`). Modal width 440 → 620 px to fit 60+ char UUID lines.

## Test plan

- [x] \`pytest tests/test_translate_ha_config.py\` — 22 passing including 2 new (experimental + config-only preservation groups).
- [x] \`pytest tests/test_bugreport_environment.py\` — 3 new (MA version present / unknown / runtime-deps coexistence).
- [x] \`pytest tests/test_bt_info_adapter_awareness.py\` — 7 passing including 1 new (UUID/Modalias/Class/LegacyPairing in \`info.raw\`).
- [x] \`pytest tests/test_ui_experimental_toggles.py\` — all green after restoring per-row \`data-experimental\`.
- [x] \`pytest -q\` — full suite **1700 passing**.
- [x] \`ruff\` clean.
- [ ] Manual on HAOS 104:
  - enable EXPERIMENTAL_RSSI_BADGE → restart addon → verify toggle stays on,
  - download bug-report → confirm \`ma_server_version\` line in body + grep \`MA server: version=\` in logs,
  - open BT info modal on a connected speaker → confirm UUID list and Modalias visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)