### PR TITLE
fix(ha): mirror HA_INTEGRATION to Supervisor options on web-UI save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — HA addon Configuration tab kept showing stale `ha_integration`
+
+When operators saved ``HA_INTEGRATION`` changes through the bridge web
+UI on a HA addon deployment, the bridge applied them immediately
+(hot-apply via the reconfig orchestrator) but ``_sync_ha_options``
+did NOT mirror the block back to Supervisor.  Symptoms: HAOS
+Configuration tab kept showing the old broker / mode / toggle
+values, and the next addon restart wrote those stale values back
+over the live config — silently undoing the change.
+
+``_sync_ha_options`` now mirrors the full ``ha_integration`` block in
+the flat shape Supervisor's options schema expects (the inverse of
+``translate_ha_config._translate_ha_integration``).  Five regression
+tests in ``test_sync_ha_options_ha_integration.py`` cover full
+mirror, missing-block defaults, partial-block defaults, corrupted
+``HA_INTEGRATION`` values, and the no-op branch outside addon mode.
+
 ## [2.65.0-rc.3] - 2026-04-28
 
 ### Changed — auth-gate read switched to `current_app.config`

--- a/routes/api_config.py
+++ b/routes/api_config.py
@@ -485,6 +485,32 @@ def _sync_ha_options(config: dict) -> None:
         }
         if config.get("BASE_LISTEN_PORT") is not None:
             options["base_listen_port"] = int(config["BASE_LISTEN_PORT"])
+
+        # Mirror the HA_INTEGRATION block back to Supervisor in the flat
+        # shape the addon options schema expects (translate_ha_config does
+        # the inverse on addon startup).  Without this the HAOS
+        # Configuration tab keeps showing stale values after operators
+        # change them in the bridge web UI, and the next addon restart
+        # writes those stale values back over the live config.
+        ha_integration = config.get("HA_INTEGRATION") or {}
+        if isinstance(ha_integration, dict):
+            raw_mqtt = ha_integration.get("mqtt")
+            mqtt_block: dict = raw_mqtt if isinstance(raw_mqtt, dict) else {}
+            raw_rest = ha_integration.get("rest")
+            rest_block: dict = raw_rest if isinstance(raw_rest, dict) else {}
+            options["ha_integration"] = {
+                "enabled": bool(ha_integration.get("enabled", False)),
+                "mode": str(ha_integration.get("mode") or "off"),
+                "mqtt_broker": str(mqtt_block.get("broker") or "auto"),
+                "mqtt_port": int(mqtt_block.get("port") or 1883),
+                "mqtt_username": str(mqtt_block.get("username") or ""),
+                "mqtt_password": str(mqtt_block.get("password") or ""),
+                "mqtt_discovery_prefix": str(mqtt_block.get("discovery_prefix") or "homeassistant"),
+                "mqtt_tls": bool(mqtt_block.get("tls", False)),
+                "advertise_mdns": bool(rest_block.get("advertise_mdns", True)),
+                "supervisor_pair": bool(rest_block.get("supervisor_pair", True)),
+            }
+
         sup_opts = {"options": options}
         body = json.dumps(sup_opts).encode()
         req = _ur.Request(

--- a/tests/test_sync_ha_options_ha_integration.py
+++ b/tests/test_sync_ha_options_ha_integration.py
@@ -1,0 +1,170 @@
+"""``_sync_ha_options`` mirrors ``HA_INTEGRATION`` to Supervisor options.
+
+Without this mirror, the HAOS Configuration tab silently shows stale
+``ha_integration`` values after the operator saves changes via the
+bridge web UI — and the next addon restart writes those stale values
+back over the live config, undoing the change.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def captured_supervisor_post(monkeypatch):
+    """Capture the JSON body the bridge would have POSTed to Supervisor.
+
+    ``_sync_ha_options`` no-ops outside HA addon mode and when there's
+    no ``SUPERVISOR_TOKEN`` env var; we set both up before importing the
+    target so it takes the addon-mode branch.
+    """
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "test-token")
+
+    # Drop any cached stub for routes.api_config from prior tests.
+    if "routes.api_config" in sys.modules and getattr(sys.modules["routes.api_config"], "__file__", None) is None:
+        sys.modules.pop("routes.api_config")
+
+    import routes.api_config as M
+
+    monkeypatch.setattr(M, "_detect_runtime", lambda: "ha_addon")
+
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=10):
+        captured["url"] = getattr(req, "full_url", None) or req.get_full_url()
+        captured["body"] = json.loads(req.data.decode())
+        captured["headers"] = dict(req.headers.items())
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return b'{"result":"ok"}'
+
+        return _Resp()
+
+    import urllib.request as ur
+
+    monkeypatch.setattr(ur, "urlopen", fake_urlopen)
+    return M, captured
+
+
+# ---------------------------------------------------------------------------
+# Mirror correctness
+# ---------------------------------------------------------------------------
+
+
+def test_ha_integration_block_mirrored_in_full(captured_supervisor_post):
+    M, captured = captured_supervisor_post
+    config = {
+        "BLUETOOTH_DEVICES": [],
+        "BLUETOOTH_ADAPTERS": [],
+        "HA_INTEGRATION": {
+            "enabled": True,
+            "mode": "mqtt",
+            "mqtt": {
+                "broker": "core-mosquitto",
+                "port": 1883,
+                "username": "sendspin-bridge",
+                "password": "supersecret",
+                "discovery_prefix": "homeassistant",
+                "tls": False,
+                "client_id": "",
+            },
+            "rest": {"advertise_mdns": True, "supervisor_pair": True},
+        },
+    }
+    M._sync_ha_options(config)
+
+    posted = captured["body"]["options"]
+    assert "ha_integration" in posted, "ha_integration block missing from Supervisor sync"
+    flat = posted["ha_integration"]
+    assert flat["enabled"] is True
+    assert flat["mode"] == "mqtt"
+    assert flat["mqtt_broker"] == "core-mosquitto"
+    assert flat["mqtt_port"] == 1883
+    assert flat["mqtt_username"] == "sendspin-bridge"
+    assert flat["mqtt_password"] == "supersecret"
+    assert flat["mqtt_discovery_prefix"] == "homeassistant"
+    assert flat["mqtt_tls"] is False
+    assert flat["advertise_mdns"] is True
+    assert flat["supervisor_pair"] is True
+
+
+def test_missing_block_yields_safe_defaults(captured_supervisor_post):
+    M, captured = captured_supervisor_post
+    config = {
+        "BLUETOOTH_DEVICES": [],
+        "BLUETOOTH_ADAPTERS": [],
+        # No HA_INTEGRATION key at all — first-boot config.
+    }
+    M._sync_ha_options(config)
+    flat = captured["body"]["options"]["ha_integration"]
+    assert flat["enabled"] is False
+    assert flat["mode"] == "off"
+    assert flat["mqtt_broker"] == "auto"
+    assert flat["mqtt_port"] == 1883
+    assert flat["mqtt_username"] == ""
+    assert flat["mqtt_password"] == ""
+    assert flat["mqtt_discovery_prefix"] == "homeassistant"
+    assert flat["mqtt_tls"] is False
+    assert flat["advertise_mdns"] is True
+    assert flat["supervisor_pair"] is True
+
+
+def test_partial_block_falls_back_to_defaults(captured_supervisor_post):
+    """Operator hand-edited config.json with a sparse HA_INTEGRATION
+    sub-tree — every missing leaf should get the canonical default,
+    NOT cause a KeyError."""
+    M, captured = captured_supervisor_post
+    config = {
+        "BLUETOOTH_DEVICES": [],
+        "BLUETOOTH_ADAPTERS": [],
+        "HA_INTEGRATION": {"enabled": True, "mode": "rest"},  # no mqtt/rest sub-blocks
+    }
+    M._sync_ha_options(config)
+    flat = captured["body"]["options"]["ha_integration"]
+    assert flat["enabled"] is True
+    assert flat["mode"] == "rest"
+    assert flat["mqtt_broker"] == "auto"
+    assert flat["advertise_mdns"] is True
+
+
+def test_non_dict_block_does_not_crash(captured_supervisor_post):
+    """Defensive: corrupt or accidentally-string HA_INTEGRATION must
+    not raise — the rest of the sync should still go through."""
+    M, captured = captured_supervisor_post
+    config = {
+        "BLUETOOTH_DEVICES": [],
+        "BLUETOOTH_ADAPTERS": [],
+        "HA_INTEGRATION": "garbage",
+    }
+    M._sync_ha_options(config)
+    # No ha_integration block written, but the call still succeeded
+    # and the rest of the options dict is intact.
+    assert "sendspin_server" in captured["body"]["options"]
+
+
+def test_no_op_outside_addon_mode(monkeypatch):
+    """Outside HA addon mode the function returns silently — neither
+    Supervisor nor stale options matter for Docker / standalone."""
+    monkeypatch.setenv("SUPERVISOR_TOKEN", "")
+    if "routes.api_config" in sys.modules and getattr(sys.modules["routes.api_config"], "__file__", None) is None:
+        sys.modules.pop("routes.api_config")
+    import routes.api_config as M
+
+    monkeypatch.setattr(M, "_detect_runtime", lambda: "docker")
+
+    called = MagicMock()
+    monkeypatch.setattr("urllib.request.urlopen", called)
+    M._sync_ha_options({"HA_INTEGRATION": {"enabled": True, "mode": "mqtt"}})
+    called.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes a sync gap exposed during v2.65.0-rc.3 testing on HAOS.

**Symptom:** operator opens *Settings → Home Assistant* in the bridge web UI, edits broker host / mode / TLS / etc., clicks **Save**.  The bridge applies the change immediately (hot-apply via the reconfig orchestrator → ``HaIntegrationLifecycle.reload()``).  But the HAOS *Configuration* tab still shows the **old** \`ha_integration\` values, and the next \`ha apps restart\` writes those stale options.json values back over \`/data/config.json\` — silently undoing what the operator just saved.

**Root cause:** \`_sync_ha_options\` (in \`routes/api_config.py\`) mirrors most config keys back to Supervisor's \`/addons/self/options\` endpoint after every \`/api/config\` POST.  But the \`ha_integration\` block was added in v2.65.0-rc.1 and never wired into this mirror function.

## Fix

Add the full \`ha_integration\` block to the Supervisor options payload in the flat shape the addon schema expects (the inverse of \`translate_ha_config._translate_ha_integration\`).  Defensive: corrupted / sparse / missing \`HA_INTEGRATION\` keys fall back to canonical defaults rather than crash.

## Tests

Five regression tests in \`tests/test_sync_ha_options_ha_integration.py\`:

- \`test_ha_integration_block_mirrored_in_full\` — full block round-trip.
- \`test_missing_block_yields_safe_defaults\` — first-boot config without the key.
- \`test_partial_block_falls_back_to_defaults\` — sparse hand-edit.
- \`test_non_dict_block_does_not_crash\` — corrupted/string \`HA_INTEGRATION\`.
- \`test_no_op_outside_addon_mode\` — Docker / standalone path stays silent.

**Full regression: 2193 tests green.**

## Test plan

- [x] \`pytest tests/\` — 2193 green.
- [x] mypy + ruff clean (pre-commit).
- [ ] Manual on HAOS RC addon: change MQTT broker host in *Settings → Home Assistant*, click Save, confirm HAOS Configuration tab now shows the new value (was: stale).  Restart addon, confirm new value persists (was: silently reverted to stale options.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)