### PR TITLE
fix(docker): un-ignore pyproject.toml; refresh stale dockerignore paths

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,14 @@
 # Large dirs not needed in Docker build context
 docs-site/
+docs/
 .git/
-lxc/
+deployment/
 ha-addon/
 ha-addon-beta/
 ha-addon-rc/
 ha-addon-assets/
 .github/
+.scratch/
 patches/
 .playwright-mcp/
 .wrangler/
@@ -60,6 +62,9 @@ docker-compose.yml
 .gitattributes
 .pre-commit-config.yaml
 .hadolint.yaml
-pyproject.toml
-render.yaml
+# pyproject.toml is REQUIRED in the build context (B9 of src-layout
+# migration: Dockerfile does `COPY pyproject.toml /app/` and then
+# `pip install -e /app` so `python -m sendspin_bridge` resolves).
+# Do NOT add pyproject.toml here.
 repository.yaml
+hacs.json


### PR DESCRIPTION
## Summary

Hotfix for the `2.66.0-rc.1` release run — Docker build failed because
`.dockerignore` excluded `pyproject.toml`, which the src-layout
Dockerfile now needs to `pip install -e /app` the bridge package.

CI evidence: https://github.com/trudenboy/sendspin-bt-bridge/actions/runs/25110300187

```
ERROR: failed to compute cache key: failed to calculate checksum
of ref ...: \"/pyproject.toml\": not found
```

## Changes

- Remove `pyproject.toml` from `.dockerignore` (with an inline comment
  pinning the rule against accidental re-add).
- Replace stale `lxc/` rule with `deployment/` (whole tree moved in B10).
- Add `docs/`, `.scratch/`, `hacs.json` (created/moved during the
  migration; not used at runtime).

## Test plan

- [ ] CI lint / test green
- [ ] `release.yml` `docker-build` matrix completes (amd64 + arm64)
- [ ] After merge: bump VERSION push triggers a fresh release run that
      gets past docker-build into addon-sync / publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)