### PR TITLE
feat(diagnostics): Last-run card in UI + s6 exit code normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- "Previous run ended ungracefully" card at the top of the
+  Diagnostics tab — surfaces the breadcrumb-derived `exit_kind`,
+  last reached startup phase, last log message, and exit
+  code/signal from the prior run.  Hidden when the previous run
+  was graceful or there is no history yet.  Backed by a new
+  `last_run` field in `/api/diagnostics`.
+
+### Fixed
+- s6 finish now normalises s6-supervise's `256` sentinel exit code
+  ("killed by signal — see `$2`") into the conventional
+  `128 + signal` value used by every shell, so the breadcrumb's
+  `exit_code` matches what users see in `docker ps` /  `$?` /
+  journald (e.g. `137` for SIGKILL, `143` for SIGTERM).
+  Cosmetic — `exit_signal` was already authoritative.
+
 ## [2.66.9] - 2026-04-30
 
 ### Added

--- a/rootfs/etc/s6-overlay/s6-rc.d/sendspin/finish
+++ b/rootfs/etc/s6-overlay/s6-rc.d/sendspin/finish
@@ -4,6 +4,16 @@
 EXIT_CODE=${1:-0}
 SIGNAL=${2:-0}
 
+# s6-supervise passes 256 as a sentinel meaning "killed by signal —
+# look at $2 for the signal number".  POSIX only allows 0-255 in
+# exit codes, so normalise to the conventional 128+signal value
+# that every shell uses (e.g. SIGKILL/9 -> 137, SIGTERM/15 -> 143).
+# This makes the exit_code we surface in breadcrumbs match what
+# users see in `docker ps` / `$?` / journald.
+if [ "$EXIT_CODE" -eq 256 ] && [ "$SIGNAL" -gt 0 ]; then
+    EXIT_CODE=$((128 + SIGNAL))
+fi
+
 # ---------------------------------------------------------------------------
 # Authoritative exit-info breadcrumb. Captures (exit_code, signal,
 # wall-clock timestamp) into ``$BC_DIR/exit.json`` so the next boot

--- a/src/sendspin_bridge/web/routes/api_status.py
+++ b/src/sendspin_bridge/web/routes/api_status.py
@@ -961,6 +961,16 @@ def api_diagnostics():
                 log_message="Failed to build telemetry payload for diagnostics",
             )
 
+        # Surface the prior-run breadcrumb (boot.prev.json + exit.prev.json
+        # paired into a derived ``exit_kind``) so the live diagnostics UI
+        # can render a "Last run" card without needing the user to download
+        # the text bundle. Always include the key so the frontend can
+        # detect the absence of a prior run cleanly (value is ``None``).
+        try:
+            diag["last_run"] = _collect_last_run_summary()
+        except Exception:
+            diag["last_run"] = None
+
         diag["status"] = "degraded" if failed_collections else "ok"
         diag["failed_collections"] = failed_collections
         diag["collections_status"] = collections_status

--- a/src/sendspin_bridge/web/routes/api_status.py
+++ b/src/sendspin_bridge/web/routes/api_status.py
@@ -966,10 +966,9 @@ def api_diagnostics():
         # can render a "Last run" card without needing the user to download
         # the text bundle. Always include the key so the frontend can
         # detect the absence of a prior run cleanly (value is ``None``).
-        try:
-            diag["last_run"] = _collect_last_run_summary()
-        except Exception:
-            diag["last_run"] = None
+        # ``_collect_last_run_summary`` handles its own errors and returns
+        # ``None`` on failure — no extra guard needed here.
+        diag["last_run"] = _collect_last_run_summary()
 
         diag["status"] = "degraded" if failed_collections else "ok"
         diag["failed_collections"] = failed_collections

--- a/src/sendspin_bridge/web/static/app.js
+++ b/src/sendspin_bridge/web/static/app.js
@@ -12644,6 +12644,41 @@ function renderDiagnostics(d) {
         },
     ].map(_renderDiagSummaryCard).join('');
 
+    var lastRun = d.last_run || null;
+    var lastRunHtml = '';
+    if (lastRun && lastRun.exit_kind && lastRun.exit_kind !== 'graceful') {
+        // exit_kind palette:
+        //   err  → process killed or crashed (sigkill, crash_unhandled_exception)
+        //   warn → softer ungraceful states or unknowns
+        var lrTone = (lastRun.exit_kind === 'sigkill' || lastRun.exit_kind === 'crash_unhandled_exception')
+            ? 'err'
+            : 'warn';
+        var lrPhase = lastRun.last_phase
+            ? (lastRun.last_phase + (lastRun.last_phase_status ? ' (' + lastRun.last_phase_status + ')' : ''))
+            : null;
+        var hasExit = (lastRun.exit_code !== null && lastRun.exit_code !== undefined)
+            || (lastRun.exit_signal !== null && lastRun.exit_signal !== undefined);
+        var lrCodeSignal = hasExit
+            ? ('code=' + (lastRun.exit_code != null ? lastRun.exit_code : '?')
+               + ' signal=' + (lastRun.exit_signal != null ? lastRun.exit_signal : '?'))
+            : null;
+        lastRunHtml = '<div class="diag-card diag-last-run is-' + lrTone + '">' +
+            '<div class="diag-card-header"><div>' +
+                '<div class="diag-card-title">' + dot(lrTone) + '<span>Previous run ended ungracefully</span></div>' +
+                '<div class="diag-card-subtitle">Captured from boot/exit breadcrumbs written before the most recent restart.</div>' +
+            '</div></div>' +
+            '<div class="diag-mini-meta">' +
+                _renderDiagMetaRow('Exit kind', lastRun.exit_kind, {code: true}) +
+                (lastRun.bridge_version ? _renderDiagMetaRow('Bridge version', lastRun.bridge_version, {code: true}) : '') +
+                (lrPhase ? _renderDiagMetaRow('Last phase', lrPhase, {stack: true}) : '') +
+                (lastRun.last_message ? _renderDiagMetaRow('Last message', lastRun.last_message, {stack: true}) : '') +
+                (lrCodeSignal ? _renderDiagMetaRow('Exit', lrCodeSignal, {code: true}) : '') +
+                (lastRun.started_at ? _renderDiagMetaRow('Started at', lastRun.started_at, {stack: true}) : '') +
+                (lastRun.exit_recorded_at ? _renderDiagMetaRow('Exit recorded', lastRun.exit_recorded_at, {stack: true}) : '') +
+            '</div>' +
+        '</div>';
+    }
+
     var healthStripHtml = '<div class="diag-health-strip">' + [
         {label: connectedDevices.length + '/' + activeDevices.length + ' speakers', tone: connectedDevices.length === activeDevices.length && activeDevices.length ? 'ok' : (connectedDevices.length ? 'warn' : 'err')},
         {label: routedDevices.length + '/' + activeDevices.length + ' sinks', tone: routedDevices.length === activeDevices.length && activeDevices.length ? 'ok' : (routedDevices.length ? 'warn' : 'err')},
@@ -12965,6 +13000,7 @@ function renderDiagnostics(d) {
                 (localStorage.getItem('sendspin-diag-mode') === 'advanced' ? 'Simple' : 'Advanced') +
             '</button>' +
         '</nav>' +
+        lastRunHtml +
         healthStripHtml +
         '<div class="diag-overview-head">' +
             '<div class="diag-overview-title">Overview</div>' +

--- a/src/sendspin_bridge/web/static/style.css
+++ b/src/sendspin_bridge/web/static/style.css
@@ -4800,6 +4800,24 @@ body {
         .diag-card--primary .diag-card-header {
             background: rgba(33, 150, 243, 0.08);
         }
+        /* "Last run" breadcrumb banner — only rendered when prior run was
+           non-graceful (sigkill, crash, etc.). Tone follows the err/warn
+           palette already established for diagnostics pills. */
+        .diag-last-run {
+            margin-bottom: 12px;
+        }
+        .diag-last-run.is-err {
+            border-color: rgba(244, 67, 54, 0.32);
+        }
+        .diag-last-run.is-err .diag-card-header {
+            background: rgba(244, 67, 54, 0.08);
+        }
+        .diag-last-run.is-warn {
+            border-color: rgba(255, 152, 0, 0.32);
+        }
+        .diag-last-run.is-warn .diag-card-header {
+            background: rgba(255, 152, 0, 0.08);
+        }
         .diag-card-header {
             display: flex;
             align-items: center;

--- a/tests/integration/test_breadcrumb_lifecycle.py
+++ b/tests/integration/test_breadcrumb_lifecycle.py
@@ -174,27 +174,48 @@ def test_sigkill_paired_with_exit_json_yields_sigkill(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
+_FINISH_BREADCRUMB_BLOCK = """
+EXIT_CODE=$1
+SIGNAL=$2
+# Normalise s6's 256 sentinel ("killed by signal — see $2") into the
+# conventional 128+signal exit code that every shell uses.
+if [ "$EXIT_CODE" -eq 256 ] && [ "$SIGNAL" -gt 0 ]; then
+    EXIT_CODE=$((128 + SIGNAL))
+fi
+if [ -f /data/options.json ]; then BC_DIR="/data/breadcrumbs"; else BC_DIR="${CONFIG_DIR:-/config}/breadcrumbs"; fi
+mkdir -p "$BC_DIR" 2>/dev/null || true
+BC_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+BC_NOW=$(date +%s 2>/dev/null || echo 0)
+printf '{"schema_version":1,"exit_recorded_at":"%s","exit_code":%s,"exit_signal":%s,"wall_clock_unix":%s}\\n' \\
+    "$BC_TS" "$EXIT_CODE" "$SIGNAL" "$BC_NOW" > "$BC_DIR/exit.json.tmp" 2>/dev/null || true
+mv -f "$BC_DIR/exit.json.tmp" "$BC_DIR/exit.json" 2>/dev/null || true
+"""
+
+
 @pytest.mark.skipif(not FINISH_SCRIPT.exists(), reason="s6 finish script not present in checkout")
-def test_finish_shell_block_writes_valid_exit_json(tmp_path: Path):
+@pytest.mark.parametrize(
+    ("raw_exit_code", "signal", "expected_code"),
+    [
+        # Already-normalised exit code → passes through unchanged.
+        (137, 9, 137),
+        # s6 sentinel for SIGKILL → must normalise to 128+9 = 137.
+        (256, 9, 137),
+        # s6 sentinel for SIGTERM → must normalise to 128+15 = 143.
+        (256, 15, 143),
+        # Plain non-zero exit (no signal) → unchanged.
+        (1, 0, 1),
+        # 256 with no signal (shouldn't happen in practice but the
+        # guard ``[ $SIGNAL -gt 0 ]`` must keep it as-is).
+        (256, 0, 256),
+    ],
+)
+def test_finish_shell_block_writes_valid_exit_json(tmp_path: Path, raw_exit_code: int, signal: int, expected_code: int):
     """Run the breadcrumb portion of ``finish`` against a temp CONFIG_DIR."""
     # Extract just the breadcrumb-writing portion so we don't have to
     # invoke /command/with-contenv (only present inside the container).
-    script = textwrap.dedent(
-        """
-        EXIT_CODE=$1
-        SIGNAL=$2
-        if [ -f /data/options.json ]; then BC_DIR="/data/breadcrumbs"; else BC_DIR="${CONFIG_DIR:-/config}/breadcrumbs"; fi
-        mkdir -p "$BC_DIR" 2>/dev/null || true
-        BC_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
-        BC_NOW=$(date +%s 2>/dev/null || echo 0)
-        printf '{"schema_version":1,"exit_recorded_at":"%s","exit_code":%s,"exit_signal":%s,"wall_clock_unix":%s}\\n' \
-            "$BC_TS" "$EXIT_CODE" "$SIGNAL" "$BC_NOW" > "$BC_DIR/exit.json.tmp" 2>/dev/null || true
-        mv -f "$BC_DIR/exit.json.tmp" "$BC_DIR/exit.json" 2>/dev/null || true
-        """
-    )
     env = {**os.environ, "CONFIG_DIR": str(tmp_path)}
     subprocess.run(
-        ["bash", "-c", script, "_", "137", "9"],
+        ["bash", "-c", _FINISH_BREADCRUMB_BLOCK, "_", str(raw_exit_code), str(signal)],
         check=True,
         env=env,
         timeout=10,
@@ -204,8 +225,8 @@ def test_finish_shell_block_writes_valid_exit_json(tmp_path: Path):
     assert exit_path.exists(), "finish script should have written exit.json"
     payload = json.loads(exit_path.read_text())
     assert payload["schema_version"] == 1
-    assert payload["exit_code"] == 137
-    assert payload["exit_signal"] == 9
+    assert payload["exit_code"] == expected_code
+    assert payload["exit_signal"] == signal
     assert payload["exit_recorded_at"]
 
 

--- a/tests/integration/test_breadcrumb_lifecycle.py
+++ b/tests/integration/test_breadcrumb_lifecycle.py
@@ -174,24 +174,6 @@ def test_sigkill_paired_with_exit_json_yields_sigkill(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-_FINISH_BREADCRUMB_BLOCK = """
-EXIT_CODE=$1
-SIGNAL=$2
-# Normalise s6's 256 sentinel ("killed by signal — see $2") into the
-# conventional 128+signal exit code that every shell uses.
-if [ "$EXIT_CODE" -eq 256 ] && [ "$SIGNAL" -gt 0 ]; then
-    EXIT_CODE=$((128 + SIGNAL))
-fi
-if [ -f /data/options.json ]; then BC_DIR="/data/breadcrumbs"; else BC_DIR="${CONFIG_DIR:-/config}/breadcrumbs"; fi
-mkdir -p "$BC_DIR" 2>/dev/null || true
-BC_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
-BC_NOW=$(date +%s 2>/dev/null || echo 0)
-printf '{"schema_version":1,"exit_recorded_at":"%s","exit_code":%s,"exit_signal":%s,"wall_clock_unix":%s}\\n' \\
-    "$BC_TS" "$EXIT_CODE" "$SIGNAL" "$BC_NOW" > "$BC_DIR/exit.json.tmp" 2>/dev/null || true
-mv -f "$BC_DIR/exit.json.tmp" "$BC_DIR/exit.json" 2>/dev/null || true
-"""
-
-
 @pytest.mark.skipif(not FINISH_SCRIPT.exists(), reason="s6 finish script not present in checkout")
 @pytest.mark.parametrize(
     ("raw_exit_code", "signal", "expected_code"),
@@ -209,13 +191,23 @@ mv -f "$BC_DIR/exit.json.tmp" "$BC_DIR/exit.json" 2>/dev/null || true
         (256, 0, 256),
     ],
 )
-def test_finish_shell_block_writes_valid_exit_json(tmp_path: Path, raw_exit_code: int, signal: int, expected_code: int):
-    """Run the breadcrumb portion of ``finish`` against a temp CONFIG_DIR."""
-    # Extract just the breadcrumb-writing portion so we don't have to
-    # invoke /command/with-contenv (only present inside the container).
+def test_finish_writes_valid_exit_json(tmp_path: Path, raw_exit_code: int, signal: int, expected_code: int):
+    """Execute the in-tree ``finish`` script and verify its breadcrumb output.
+
+    Sources the actual file at ``rootfs/.../sendspin/finish`` rather than a
+    duplicated copy so any drift in the production script is caught
+    immediately.  Stubs out ``sleep`` so the supervisor restart-delay
+    branch returns instantly during tests, and bypasses the
+    ``/command/with-contenv`` shebang (not present outside the container)
+    by sourcing under a plain bash invocation.
+    """
     env = {**os.environ, "CONFIG_DIR": str(tmp_path)}
+    # ``sleep() { :; }`` shadows both the bash builtin and the binary,
+    # so the script's ``sleep 5`` on the unexpected-exit branch is a
+    # no-op in tests but unchanged in production.
+    wrapper = f"sleep() {{ :; }}; . {FINISH_SCRIPT}"
     subprocess.run(
-        ["bash", "-c", _FINISH_BREADCRUMB_BLOCK, "_", str(raw_exit_code), str(signal)],
+        ["bash", "-c", wrapper, "_", str(raw_exit_code), str(signal)],
         check=True,
         env=env,
         timeout=10,
@@ -234,6 +226,19 @@ def test_finish_shell_block_writes_valid_exit_json(tmp_path: Path, raw_exit_code
 def test_finish_script_passes_bash_n(tmp_path: Path):
     """Defence in depth: the file in tree must parse cleanly under bash -n."""
     subprocess.run(["bash", "-n", str(FINISH_SCRIPT)], check=True, timeout=10)
+
+
+@pytest.mark.skipif(not FINISH_SCRIPT.exists(), reason="s6 finish script not present in checkout")
+def test_finish_script_contains_exit_code_normalization():
+    """Cheap explicit guard: the production script must keep the 256→128+signal
+    normalization. ``test_finish_writes_valid_exit_json`` already asserts the
+    behaviour by sourcing the real file, but this string-level assertion
+    surfaces a much clearer failure if the line is accidentally deleted in
+    a refactor.
+    """
+    src = FINISH_SCRIPT.read_text()
+    assert "EXIT_CODE=$((128 + SIGNAL))" in src, "rootfs/.../finish lost the s6 exit-code normalization line"
+    assert "-eq 256" in src, "rootfs/.../finish lost the 256 sentinel guard"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two follow-ups to the breadcrumb feature shipped in v2.66.9:

- **Last-run card in Diagnostics UI** — `/api/diagnostics` now exposes a `last_run` field from `BreadcrumbStore.read_previous()`. When the prior run was non-graceful, a banner-style card at the top of the Diagnostics tab surfaces `exit_kind`, `bridge_version`, last reached phase, last log message, and `exit_code` / `exit_signal`. Hidden on graceful exits and first-ever boot.
- **s6 exit code normalization** — s6-supervise passes `256` as a sentinel meaning "killed by signal — see `\$2`", which leaked into our `exit.json` as `exit_code=256`. Normalise to the conventional `128+signal` value (e.g. `137` for SIGKILL/9, `143` for SIGTERM/15) so the breadcrumb matches what users see in `docker ps` / `\$?` / journald. Cosmetic — `exit_signal` was already authoritative.

## Why

After v2.66.9 went live, smoke-test on the test VM showed:
- `exit_code: 256` in `exit.json` after a `kill -9` (functional but visually confusing).
- The breadcrumb data was only visible by downloading the diagnostics text or via the in-UI Report button — there was no live UI surface, despite this being the highest-signal "what happened" field for a user looking at a freshly-rebooted bridge.

## Test plan

- [x] Parametrised the s6 shell-block test over 5 input tuples — `(137, 9, 137)`, `(256, 9, 137)`, `(256, 15, 143)`, `(1, 0, 1)`, `(256, 0, 256)` (safety guard) — all green.
- [x] Full pytest suite: 2301 passed, 1 skipped.
- [ ] After merge + image rebuild: deploy to test VM, kill -9 the bridge, restart, open Diagnostics tab in browser — expect a red "Previous run ended ungracefully" card at the top with `exit_kind=sigkill`, `Exit: code=137 signal=9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)