### PR TITLE
docs: scope Boosty to Russian-language surfaces only

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ Use the docs site for the full guides and reference:
 If this bridge saves you time or fits your setup well, consider sponsoring development:
 
 - 💛 [Liberapay](https://liberapay.com/trudenboy) — recurring, opensource-friendly, 0% platform fee
-- 💜 [Boosty](https://boosty.to/trudenboy) — для аудитории СНГ, разовые и регулярные донаты
 - 💎 [Crypto via NOWPayments](https://nowpayments.io/donation/trudenboy) — one-click donation page, 70+ coins, no account required
 
 ### Direct crypto (zero fees, no intermediaries)

--- a/docs-site/src/content/docs/support.mdx
+++ b/docs-site/src/content/docs/support.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sponsor the project
-description: Ways to sponsor development of Sendspin Bluetooth Bridge — Liberapay, Boosty, NOWPayments, and direct crypto donations
+description: Ways to sponsor development of Sendspin Bluetooth Bridge — Liberapay, NOWPayments, and direct crypto donations
 ---
 
 import { Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -14,11 +14,6 @@ If this bridge saves you time or fits your setup well, you can sponsor developme
     title="💛 Liberapay"
     description="Recurring donations, opensource-friendly, 0% platform fee. Best for Western supporters."
     href="https://liberapay.com/trudenboy"
-  />
-  <LinkCard
-    title="💜 Boosty"
-    description="Для аудитории СНГ. Разовые и регулярные донаты, RU-карты принимаются напрямую."
-    href="https://boosty.to/trudenboy"
   />
   <LinkCard
     title="💎 Crypto via NOWPayments"
@@ -94,7 +89,7 @@ Honestly: nothing exclusive. All features are available to everyone, all source 
 
 No — this is a personal opensource project, not a registered nonprofit. Donations are voluntary contributions, not charitable gifts in any tax-recognized sense.
 
-### My country is not in the supported list of Liberapay / Boosty / NOWPayments. What now?
+### My country is not in the supported list of Liberapay / NOWPayments. What now?
 
 The direct crypto addresses above work from anywhere. If crypto isn't an option for you either, drop a note via [GitHub Issues](https://github.com/trudenboy/sendspin-bt-bridge/issues) — we can sort out a SWIFT/Wise transfer for larger one-time contributions.
 


### PR DESCRIPTION
## Description

Boosty is a Russian platform; Western readers don't have a straightforward path to use it (cards from non-RU/CIS regions face friction, and the donor experience is RU-localised). Removes Boosty from the **English** README and the **English** docs Sponsor page so that surface stays focused on channels Western donors can actually use (Liberapay + NOWPayments + direct crypto).

The Russian README and Russian docs Sponsor page keep Boosty as before — it's the natural primary channel for that audience. \`.github/FUNDING.yml\` stays untouched because the GitHub Sponsor button has no language switch and removing Boosty there would also hide it from Russian-language visitors.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📖 Documentation update
- [ ] 🔧 Refactor / code cleanup
- [ ] 🧪 Test improvement
- [ ] 📦 Dependency update

## Testing Performed

- [x] Pre-commit hooks pass (whitespace, EOL)
- [x] \`npm run build\` succeeds locally on docs-site
- [x] grep confirms Boosty removed from EN README and EN docs Sponsor; grep confirms RU surfaces still mention Boosty

## Checklist

- [x] My code follows the existing style of this project
- [x] I have run \`pytest\` and all tests pass *(no Python code touched — Markdown / MDX only)*
- [x] I have updated documentation where relevant
- [x] I have not committed any secrets or credentials
- [ ] I have tested on the target platform (Raspberry Pi / HAOS / LXC) if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)