### PR TITLE
fix: persist BT-release toggle across HA addon restarts (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **HA addon: "Release Bluetooth" toggle now survives an addon or Home Assistant restart.** Previously the released state was forgotten on restart, the bridge silently re-grabbed the BT device, and only released it again after the configured idle timeout — which interrupted whatever else was using the speaker (for example a TV soundbar over HDMI/ARC). The released flag now carries forward in the addon's options-to-config rebuild so reclaiming requires an explicit user action. ([#276](https://github.com/trudenboy/sendspin-bt-bridge/issues/276))
+
 ## [2.68.0] - 2026-05-02
 
 ### Added

--- a/scripts/translate_ha_config.py
+++ b/scripts/translate_ha_config.py
@@ -323,6 +323,13 @@ def main() -> None:
                     # config.json and would otherwise be reset on every
                     # addon restart that triggers a config rebuild.
                     "static_delay_ms",
+                    # Preserve "Release Bluetooth" toggle across addon restarts
+                    # (issue #276). The flag is set via the bridge's web UI
+                    # and isn't part of the addon options schema, so the
+                    # Supervisor strips it from options.json on the next
+                    # save — without preservation the bridge would silently
+                    # re-grab the released BT device on every HA restart.
+                    "released",
                 ):
                     if field not in dev and field in existing_devs[mac]:
                         dev[field] = existing_devs[mac][field]

--- a/tests/integration/test_translate_ha_config.py
+++ b/tests/integration/test_translate_ha_config.py
@@ -221,6 +221,57 @@ def test_static_delay_ms_in_options_overrides_existing(tmp_path):
     assert devs["AA:BB:CC:DD:EE:FF"]["static_delay_ms"] == 300
 
 
+def test_released_flag_preserved_across_addon_restart(tmp_path):
+    """The per-device `released` flag must survive an addon restart (issue #276).
+
+    HA Supervisor strips fields not declared in the addon options schema, so
+    `released` written via the bridge's "Release Bluetooth" button disappears
+    from options.json on the next save. The translator must carry it over from
+    the previous config.json — otherwise the bridge silently re-grabs the BT
+    device on every HA restart, defeating the user's intent.
+    """
+    existing = {
+        "BLUETOOTH_DEVICES": [
+            {"mac": "AA:BB:CC:DD:EE:FF", "released": True},
+        ],
+    }
+    _write_json(tmp_path / "config.json", existing)
+    _write_json(tmp_path / "options.json", _minimal_options())
+
+    with patch("scripts.translate_ha_config._detect_adapters", return_value=[]):
+        main()
+
+    cfg = _read_json(tmp_path / "config.json")
+    devs = {d["mac"]: d for d in cfg["BLUETOOTH_DEVICES"]}
+    assert devs["AA:BB:CC:DD:EE:FF"]["released"] is True
+
+
+def test_released_false_in_options_overrides_existing(tmp_path):
+    """A reclaim (released=False) written via the addon UI must win over a stale
+    released=True in the existing config — preservation is only a fallback."""
+    existing = {
+        "BLUETOOTH_DEVICES": [
+            {"mac": "AA:BB:CC:DD:EE:FF", "released": True},
+        ],
+    }
+    _write_json(tmp_path / "config.json", existing)
+    _write_json(
+        tmp_path / "options.json",
+        _minimal_options(
+            bluetooth_devices=[
+                {"mac": "AA:BB:CC:DD:EE:FF", "name": "Speaker", "released": False},
+            ],
+        ),
+    )
+
+    with patch("scripts.translate_ha_config._detect_adapters", return_value=[]):
+        main()
+
+    cfg = _read_json(tmp_path / "config.json")
+    devs = {d["mac"]: d for d in cfg["BLUETOOTH_DEVICES"]}
+    assert devs["AA:BB:CC:DD:EE:FF"]["released"] is False
+
+
 def test_runtime_state_preserved(tmp_path):
     """LAST_VOLUMES, AUTH_PASSWORD_HASH, SECRET_KEY should survive translation."""
     existing = {


### PR DESCRIPTION
## Summary

- Adds `"released"` to the per-device carry-over allowlist in `scripts/translate_ha_config.py` so the "Release Bluetooth" toggle survives addon and Home Assistant restarts.
- Adds two integration tests: one for the preservation path (red without the fix), one for the options-overrides-existing path (regression guard for reclaim).
- Adds a `### Fixed` entry under `## [Unreleased]` in `CHANGELOG.md`.

## Why

HA Supervisor strips fields not declared in the addon options schema, so `released` written via the bridge web UI ("Release Bluetooth") disappears from `options.json` on the next save. On addon/HA restart, `translate_ha_config.py` rebuilds `config.json` from `options.json` with a carry-over allowlist of per-device runtime fields — and `released` was missing from that list. The bridge then silently re-grabbed the BT device until the idle timeout fired, which interrupted whatever else was using the speaker (a TV soundbar over HDMI/ARC in the reporter's case).

Bridge-side restore logic in `services/bluetooth/device_activation.py` was already designed to honour `released` on startup; the bug was purely in the HA-addon options-to-config rebuild path. Non-HA deployments (Docker Compose, Proxmox LXC) are unaffected because they don't re-translate config on restart.

Full root-cause walk-through in the [issue comment](https://github.com/trudenboy/sendspin-bt-bridge/issues/276#issuecomment-4403711295).

## Test plan

- [x] New test `test_released_flag_preserved_across_addon_restart` fails on `main` (`KeyError: 'released'`), passes after the fix.
- [x] New test `test_released_false_in_options_overrides_existing` passes — verifies reclaim via the addon UI still wins over a stale released flag in the existing config (preservation is fallback only, options.json stays authoritative for fields the user touches in the addon UI).
- [x] All 32 tests in `tests/integration/test_translate_ha_config.py` pass.
- [x] Pre-commit hooks pass: ruff, mypy, changelog lint.
- [ ] Manual verification on HAOS: Release → restart addon → confirm `bt_management_enabled=False` and bridge does not reconnect.

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)