### PR TITLE
Update troubleshooting and fix for Bluetooth A2DP sinks

### DIFF
--- a/docs-site/src/content/docs/installation/docker.mdx
+++ b/docs-site/src/content/docs/installation/docker.mdx
@@ -217,11 +217,15 @@ Then restart the container and see whether `pactl` starts working. Treat that as
 
 ## Headless PipeWire: Bluetooth sinks not appearing after reboot
 
-On PipeWire systems (Ubuntu 22.04+, Fedora, Raspberry Pi OS Bookworm), Bluetooth A2DP audio sinks are created by **WirePlumber** — a session manager that runs as a `systemd --user` service. By default, user services only start when the user logs in (GUI or SSH).
+On PipeWire systems (Ubuntu 22.04+, Fedora, Raspberry Pi OS Bookworm), Bluetooth A2DP audio sinks are created by **WirePlumber** — a session manager that runs as a `systemd --user` service. By default, user services only start when the user logs in (GUI or SSH), and they may only be active when there's an active interactive session.
 
 **Symptom:** After a host reboot the bridge connects to the Bluetooth speaker (`bluetoothctl` shows `Connected: yes`), but `pactl list sinks short` shows no `bluez_output.*` or `bluez_sink.*` sink — only `sendspin_fallback`. Audio works again once you log in interactively.
 
-**Fix:** Enable *linger* for the audio user so PipeWire + WirePlumber start at boot:
+**Fix:**
+
+1. Enable system-wide (instead of per active user) persistent Bluetooth connections. In the file `/usr/share/wireplumber/bluetooth.lua.d/50-bluez-config.lua`, change `["with-logind"] = true` to `false`. 
+
+2. Enable *linger* for the audio user so PipeWire + WirePlumber start at boot:
 
 ```bash
 # Replace 1000 with your AUDIO_UID if different


### PR DESCRIPTION
Clarify the troubleshooting steps for Bluetooth A2DP audio sinks on PipeWire systems and provide a fix for enabling persistent Bluetooth connections.

## Description

At least on Ubuntu Server 24.04, PipeWire is configured by default to constrain persistent bluetooth connections to when a user is logged in (e.g. via SSH), resulting in BT disconnects when finishing an interactive session, and connections resuming when logging in once again. This change instructs the user to review the flag if they observe this behavior.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📖 Documentation update
- [ ] 🔧 Refactor / code cleanup
- [ ] 🧪 Test improvement
- [ ] 📦 Dependency update

## Testing Performed

Only changes the documentation base, just made sure that the tests pass and the documentation shows as intended.

- [x] Tested locally with `docker compose up --build`
- [x] Verified via web UI at `http://localhost:8080`
- [x] Checked `docker logs` for errors

## Checklist

- [x] My code follows the existing style of this project
- [x] I have run `pytest` and all tests pass
- [x] I have updated documentation where relevant
- [x] I have not committed any secrets or credentials
- [x] I have tested on the target platform (Raspberry Pi / HAOS / LXC) if applicable
