### PR TITLE
fix(bt): surface BlueZ error in connect-failure log (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Connect-failure log lines now carry the underlying BlueZ error.** When a configured speaker is paired/bonded/trusted but won't connect, the bridge used to log only `Failed to connect (not connected after 5 status checks)` and discard `bluetoothctl`'s stdout — hiding the actual reason (`br-connection-page-timeout`, `br-connection-already-active`, `Profile unavailable`, link-key mismatch, …) behind a generic warning. The failure warning now includes a single-line excerpt of the connect output, so the operator can distinguish "speaker is off / out of range" from "speaker is already paired with another host" without a follow-up bug report. ([#302](https://github.com/trudenboy/sendspin-bt-bridge/issues/302))
+
 ## [2.71.1] - 2026-05-15
 
 ### Added

--- a/src/sendspin_bridge/bluetooth/manager.py
+++ b/src/sendspin_bridge/bluetooth/manager.py
@@ -77,6 +77,12 @@ _PAIRING_SCAN_DURATION = 12  # seconds to scan before pairing
 _PAIRING_WAIT_DURATION = 10  # seconds to wait for pairing to complete
 _MAX_RECONNECT_DELAY_S = 300.0  # max backoff for reconnect attempts (5 min)
 _CONNECT_CHECK_RETRIES = 5  # status checks after connect before giving up
+# Strips ANSI colour codes from bluetoothctl stdout before excerpting it
+# into the connect-failure warning line.
+_BCTL_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+# Caps the connect-output excerpt so a chatty `bluetoothctl` transcript
+# can't flood a single log line.
+_BCTL_EXCERPT_MAX_LEN = 200
 # Cadence for live-RSSI refresh via kernel mgmt opcode 0x0031.
 # 5 s feels live to the UI (chip updates while you walk past a
 # speaker) without exceeding the controller's internal averaging
@@ -91,6 +97,34 @@ _RSSI_REFRESH_INTERVAL_S = 5.0
 # device object, force-remove the stale BlueZ entry so the next reconnect cycle
 # can escalate to pair_device (KALLSUP-class loop, #162).
 _PAIRED_UNKNOWN_THRESHOLD = 3
+
+
+def _summarize_bluetoothctl_connect_output(output: str) -> str:
+    """Reduce multi-line bluetoothctl connect stdout to one diagnostic line.
+
+    Prefers a line containing the BlueZ error fingerprint (``Failed to
+    connect: …``); otherwise falls back to the last non-empty content
+    line. Strips ANSI colour codes and the ``[bluetooth]#`` prompt echo
+    so the result is safe to embed in a single log message. Returns an
+    empty string when ``output`` carries no usable signal — the caller
+    then falls back to the bare warning.
+    """
+    if not output:
+        return ""
+    cleaned: list[str] = []
+    for raw in output.splitlines():
+        line = _BCTL_ANSI_RE.sub("", raw).strip()
+        if not line:
+            continue
+        if line.endswith("]#") or line.startswith("[bluetooth]"):
+            continue
+        cleaned.append(line)
+    if not cleaned:
+        return ""
+    for line in cleaned:
+        if "failed to connect" in line.lower():
+            return line[:_BCTL_EXCERPT_MAX_LEN]
+    return cleaned[-1][:_BCTL_EXCERPT_MAX_LEN]
 
 
 class BluetoothManager:
@@ -900,7 +934,7 @@ class BluetoothManager:
             return False
 
         # Try to connect
-        _success, _output = self._run_bluetoothctl([f"connect {self.mac_address}"])
+        _success, _connect_output = self._run_bluetoothctl([f"connect {self.mac_address}"])
         if self._abort_connect_if_cancelled():
             return False
 
@@ -970,7 +1004,26 @@ class BluetoothManager:
                     sink_ok = self.configure_bluetooth_audio()
                 return not self._abort_connect_if_cancelled()
 
-        logger.warning("Failed to connect (not connected after 5 status checks)")
+        excerpt = _summarize_bluetoothctl_connect_output(_connect_output)
+        if excerpt:
+            # #302 — surface the underlying BlueZ error (page-timeout,
+            # br-connection-already-active, profile-unavailable, …) so the
+            # operator can distinguish "speaker is off" from "speaker is
+            # already paired with another host" without a follow-up bug
+            # report.  Kept on a single line; the `is_actionable_warning…`
+            # gate in services/diagnostics/log_analysis.py still treats
+            # the canonical prefix as non-issue, so this doesn't change
+            # how the line is bucketed in diagnostics.
+            logger.warning(
+                "Failed to connect (not connected after %d status checks): %s",
+                _CONNECT_CHECK_RETRIES,
+                excerpt,
+            )
+        else:
+            logger.warning(
+                "Failed to connect (not connected after %d status checks)",
+                _CONNECT_CHECK_RETRIES,
+            )
         if self.paired is None:
             self._paired_unknown_count += 1
             if self._paired_unknown_count >= _PAIRED_UNKNOWN_THRESHOLD:

--- a/src/sendspin_bridge/bluetooth/manager.py
+++ b/src/sendspin_bridge/bluetooth/manager.py
@@ -104,10 +104,12 @@ def _summarize_bluetoothctl_connect_output(output: str) -> str:
 
     Prefers a line containing the BlueZ error fingerprint (``Failed to
     connect: …``); otherwise falls back to the last non-empty content
-    line. Strips ANSI colour codes and the ``[bluetooth]#`` prompt echo
-    so the result is safe to embed in a single log message. Returns an
-    empty string when ``output`` carries no usable signal — the caller
-    then falls back to the bare warning.
+    line. Strips ANSI colour codes and discards bluetoothctl's prompt
+    variants (``[bluetooth]#``, ``[bluetoothctl]>``) and its
+    asynchronous discovery notifications (``[CHG]``/``[NEW]``/``[DEL]``)
+    so they can't masquerade as a diagnostic. Returns an empty string
+    when ``output`` carries no usable signal — the caller then falls
+    back to the bare warning.
     """
     if not output:
         return ""
@@ -116,7 +118,20 @@ def _summarize_bluetoothctl_connect_output(output: str) -> str:
         line = _BCTL_ANSI_RE.sub("", raw).strip()
         if not line:
             continue
-        if line.endswith("]#") or line.startswith("[bluetooth]"):
+        # Drop interactive prompt variants:
+        #   [bluetooth]#       — default prompt
+        #   [bluetooth]# foo   — prompt-echoed command (when bluetoothctl
+        #                        is run with stdin piped + a TTY-ish term)
+        #   [bluetoothctl]>    — prompt seen in some BlueZ versions, often
+        #                        with ANSI colour codes already stripped above
+        # And async discovery notifications (``[CHG] Device <mac> …``,
+        # ``[NEW] Device …``, ``[DEL] Device …``) that share the stdout
+        # stream and would otherwise become the last-line fallback.
+        if line.endswith(("]#", "]>")):
+            continue
+        if line.startswith(("[bluetooth]", "[bluetoothctl]")):
+            continue
+        if line.startswith(("[CHG]", "[NEW]", "[DEL]")):
             continue
         cleaned.append(line)
     if not cleaned:

--- a/tests/unit/bluetooth/test_bt_manager.py
+++ b/tests/unit/bluetooth/test_bt_manager.py
@@ -1075,6 +1075,51 @@ def test_connect_device_failure_log_surfaces_bluetoothctl_output(bt_manager, cap
 
 
 # ---------------------------------------------------------------------------
+# _summarize_bluetoothctl_connect_output — prompt + async-notification noise
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_connect_output_strips_ansi_prompt_and_chg_noise():
+    """Realistic bluetoothctl transcript: ANSI-coloured `[bluetoothctl]>`
+    prompt, `[CHG]` async discovery notifications, and a final
+    `Failed to connect:` line. The excerpt must be the BlueZ error,
+    not the prompt or any of the CHG lines.
+    """
+    from sendspin_bridge.bluetooth.manager import _summarize_bluetoothctl_connect_output
+
+    stdout = (
+        "[\x1b[0;94mbluetoothctl]> \x1b[0mconnect D0:C9:07:11:C9:DF\n"
+        "Attempting to connect to D0:C9:07:11:C9:DF\n"
+        "[\x1b[0;93mCHG\x1b[0m] Device 68:3A:48:D3:62:68 RSSI: 0xffffffaa (-86)\n"
+        "[\x1b[0;93mCHG\x1b[0m] Device D0:C9:07:11:C9:DF Connected: no\n"
+        "Failed to connect: org.bluez.Error.Failed br-connection-page-timeout\n"
+        "[\x1b[0;94mbluetoothctl]> \x1b[0m\n"
+    )
+    excerpt = _summarize_bluetoothctl_connect_output(stdout)
+    assert "br-connection-page-timeout" in excerpt
+    assert "bluetoothctl]" not in excerpt
+    assert "[CHG]" not in excerpt
+
+
+def test_summarize_connect_output_no_signal_returns_empty():
+    """When the transcript contains only prompt + async-notification
+    noise (no command echo, no BlueZ error), the helper must return an
+    empty string so the caller falls back to the bare warning instead
+    of logging `[bluetoothctl]>` as "the BlueZ error".
+    """
+    from sendspin_bridge.bluetooth.manager import _summarize_bluetoothctl_connect_output
+
+    stdout = (
+        "[\x1b[0;94mbluetoothctl]> \x1b[0m\n"
+        "[\x1b[0;93mCHG\x1b[0m] Device 68:3A:48:D3:62:68 RSSI: 0xffffffaa (-86)\n"
+        "[NEW] Device AA:BB:CC:DD:EE:FF Some Speaker\n"
+        "[DEL] Device 11:22:33:44:55:66 Old Speaker\n"
+        "[bluetooth]#\n"
+    )
+    assert _summarize_bluetoothctl_connect_output(stdout) == ""
+
+
+# ---------------------------------------------------------------------------
 # is_device_connected — various bluetoothctl output formats
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/bluetooth/test_bt_manager.py
+++ b/tests/unit/bluetooth/test_bt_manager.py
@@ -1039,6 +1039,41 @@ def test_connect_device_fails_after_all_retries(bt_manager):
     assert result is False
 
 
+def test_connect_device_failure_log_surfaces_bluetoothctl_output(bt_manager, caplog):
+    """When status checks fail, the warning must include the bluetoothctl
+    connect stdout so the actual BlueZ error reaches the operator.
+
+    Regression for #302: a Paired/Bonded/Trusted device that won't connect
+    used to log only "not connected after 5 status checks", discarding the
+    BlueZ-side reason (page-timeout / already-active / profile-unavailable
+    / link-key-mismatch / ...). Without it, neither the operator nor the
+    maintainer can distinguish the candidate causes.
+    """
+    connect_output = (
+        "Attempting to connect to D0:C9:07:11:C9:DF\n"
+        "Failed to connect: org.bluez.Error.Failed br-connection-page-timeout\n"
+    )
+
+    def _fake_bctl(cmds):
+        if cmds and cmds[0].startswith("connect "):
+            return False, connect_output
+        return True, ""
+
+    with (
+        patch.object(bt_manager, "is_device_connected", return_value=False),
+        patch.object(bt_manager, "is_device_paired", return_value=True),
+        patch.object(bt_manager, "_wait_with_cancel", return_value=True),
+        caplog.at_level("WARNING", logger="sendspin_bridge.bluetooth.manager"),
+    ):
+        bt_manager._run_bluetoothctl = MagicMock(side_effect=_fake_bctl)
+        result = bt_manager.connect_device()
+
+    assert result is False
+    assert any("br-connection-page-timeout" in msg for msg in caplog.messages), (
+        f"connect stdout missing from warning log; got: {caplog.messages!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # is_device_connected — various bluetoothctl output formats
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Capture and log the `bluetoothctl connect` stdout when status checks fail, so the actual BlueZ error reaches the operator.
- Without this, every "Paired/Bonded/Trusted but won't connect" report (#302) bottoms out at a generic `not connected after 5 status checks` warning — the BlueZ-side reason (`br-connection-page-timeout`, `br-connection-already-active`, `Profile unavailable`, link-key mismatch, …) is silently discarded.

## Root-cause notes for #302
Reporter (spolts, Pi 3 + built-in BT + Govee Floor Lamp Pro, bridge v2.70.1) has a device with `Paired: yes / Bonded: yes / Trusted: yes` and `Connected: no`. The 6 s connect cycle (`power on` → wait 1 s → `bluetoothctl connect` → 5 × 1 s polls) returns generic failure with no upstream signal — we discarded the connect stdout via `_success, _output = self._run_bluetoothctl(...)`. Candidate causes for that fingerprint (lamp off / out of range, speaker bonded with another host, link-key reset on speaker, Pi 3 BCM43438 + Wi-Fi 2.4 GHz coexistence) all map to distinct `Failed to connect: …` strings from BlueZ — we just hadn't been logging them. This PR doesn't change any reconnect or fallback logic; it makes the existing failure self-diagnosing.

## Implementation
- New module-level helper `_summarize_bluetoothctl_connect_output()` in `bluetooth/manager.py`:
  - strips ANSI colour codes,
  - drops `[bluetooth]#` prompt echoes / `]#` tail markers,
  - prefers a line containing `Failed to connect` (the BlueZ-side fingerprint),
  - falls back to the last non-empty content line,
  - caps at 200 chars.
- `_connect_device_inner()` now stores the connect output in `_connect_output` and appends a one-line excerpt to the failure warning. When the output is empty, the bare warning is logged unchanged.
- The canonical prefix (`Failed to connect (not connected after`) is preserved verbatim, so the non-issue gate in `services/diagnostics/log_analysis.py` (lowercase substring match) still buckets the line as non-actionable and the bug-report summary view doesn't suddenly flood with these.

## Test plan
- [x] New regression test `test_connect_device_failure_log_surfaces_bluetoothctl_output` — asserts the connect stdout (`br-connection-page-timeout` in the fixture) reaches the warning log when status checks fail. Confirmed red on `main`, green after the fix.
- [x] Existing `test_connect_device_fails_after_all_retries` / `test_connect_device_retries_status_checks` still pass.
- [x] `pytest tests/unit/bluetooth/ tests/unit/services/diagnostics/` — 405 passed.
- [x] `ruff check` / `ruff format` clean.
- [x] `scripts/lint_changelog.py CHANGELOG.md` — clean.

Closes follow-up triage on #302 (still needs reporter info on lamp state / manual connect output — separate comment on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)