### PR TITLE
fix(#314): discover bluez_output.{raw_mac} sinks + accept a2dp-sink alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Ubuntu 26.04 / WirePlumber: Bluetooth audio sinks published with a raw colon-separated MAC are now discovered.** WirePlumber's newer naming convention publishes BT outputs as `bluez_output.XX:XX:XX:XX:XX:XX` (raw MAC, no `.1` / `.a2dp-sink` suffix). The bridge previously tried four PipeWire/PulseAudio patterns based on the underscore-substituted MAC and missed this variant, falling back to the default audio device with no audible cue. The pattern is now included in the discovery list, last so the more specific PipeWire/PulseAudio shapes still win when both forms exist. ([#314](https://github.com/trudenboy/sendspin-bt-bridge/issues/314))
+- **BlueZ 5.82 + PipeWire: card-profile auto-switch and cycle helpers no longer false-warn on already-correct cards.** PipeWire publishes the A2DP sink profile as `a2dp-sink` (with a dash) while classic PulseAudio uses `a2dp_sink` (underscore); both are accepted by `pactl set-card-profile`. The bridge's profile auto-switch was hard-coded to the underscore form, so on PipeWire hosts it logged `BlueZ card … has no a2dp_sink profile available` even when the card already exposed `a2dp-sink` and was active on it. Both spellings are now treated as equivalent, and whichever variant the card advertises is the one passed through to pactl. ([#314](https://github.com/trudenboy/sendspin-bt-bridge/issues/314))
+
 ## [2.71.2-rc.1] - 2026-05-15
 
 ### Changed

--- a/src/sendspin_bridge/bluetooth/audio.py
+++ b/src/sendspin_bridge/bluetooth/audio.py
@@ -39,10 +39,29 @@ _A2DP_PROFILE_DELAY = 3.0
 _SINK_RETRY_DELAY = 3.0
 _SINK_RETRY_COUNT = int(os.environ.get("SINK_RETRY_COUNT", "5"))
 
+# BlueZ 5.82 + PipeWire publishes the A2DP sink profile as ``a2dp-sink``
+# (with a dash); classic PulseAudio uses ``a2dp_sink`` (underscore). Both
+# are accepted upstream by ``pactl set-card-profile``, so we treat them
+# as equivalent here and pass through whichever the card actually
+# advertises. Issue #314.
+_A2DP_SINK_PROFILE_ALIASES = ("a2dp_sink", "a2dp-sink")
+
+
+def _pick_a2dp_sink_profile(profiles: list[str]) -> str | None:
+    """Return the actual profile string the card advertises for A2DP
+    sink, accepting either underscore (PulseAudio / legacy) or dash
+    (PipeWire / BlueZ 5.82+) naming. ``None`` if neither is present.
+    """
+    for alias in _A2DP_SINK_PROFILE_ALIASES:
+        if alias in profiles:
+            return alias
+    return None
+
 
 def _switch_card_profile_to_a2dp(pa_mac: str) -> bool:
-    """If a bluez_card for *pa_mac* exists with a non-a2dp active profile and
-    a2dp_sink among its available profiles, switch it to a2dp_sink.
+    """If a bluez_card for *pa_mac* exists with a non-A2DP-sink active
+    profile and an A2DP-sink profile available, switch it. Accepts both
+    ``a2dp_sink`` and ``a2dp-sink`` spellings (PulseAudio vs PipeWire).
 
     Returns ``True`` when a switch was performed (caller should retry sink
     discovery), ``False`` otherwise. Silently ignores all subprocess errors.
@@ -60,26 +79,28 @@ def _switch_card_profile_to_a2dp(pa_mac: str) -> bool:
             continue
         active = card.get("active_profile") or ""
         profiles = card.get("profiles") or []
-        if active == "a2dp_sink":
+        if active in _A2DP_SINK_PROFILE_ALIASES:
             return False
-        if "a2dp_sink" not in profiles:
+        target = _pick_a2dp_sink_profile(profiles)
+        if target is None:
             logger.warning(
-                "BlueZ card %s has no a2dp_sink profile available (active=%s, profiles=%s)",
+                "BlueZ card %s has no A2DP sink profile available (active=%s, profiles=%s)",
                 name,
                 active or "—",
                 ",".join(profiles) or "—",
             )
             return False
         logger.warning(
-            "BlueZ card %s is in profile %s — switching to a2dp_sink to expose audio sink",
+            "BlueZ card %s is in profile %s — switching to %s to expose audio sink",
             name,
             active or "—",
+            target,
         )
         try:
-            if set_card_profile(name, "a2dp_sink"):
-                logger.info("✓ Switched %s to a2dp_sink profile", name)
+            if set_card_profile(name, target):
+                logger.info("✓ Switched %s to %s profile", name, target)
                 return True
-            logger.warning("Failed to switch %s to a2dp_sink profile", name)
+            logger.warning("Failed to switch %s to %s profile", name, target)
         except Exception as exc:  # pragma: no cover — defensive
             logger.warning("Profile switch for %s errored: %s", name, exc)
         return False
@@ -87,13 +108,15 @@ def _switch_card_profile_to_a2dp(pa_mac: str) -> bool:
 
 
 def _cycle_card_profile_for_mac(pa_mac: str) -> bool:
-    """Cycle the ``bluez_card.{pa_mac}`` profile off → a2dp_sink as a fallback.
+    """Cycle the ``bluez_card.{pa_mac}`` profile off → A2DP-sink as a
+    fallback. Accepts both ``a2dp_sink`` and ``a2dp-sink`` profile
+    names.
 
-    Used when the direct ``set_card_profile`` succeeded but PA still did not
-    publish a ``bluez_sink.*`` for the device (state-confusion after
-    ``module-rescue-streams`` / rapid reconnect). Returns ``True`` only when
-    the off → ``a2dp_sink`` cycle completes successfully, including the final
-    switch back to the target profile.
+    Used when the direct ``set_card_profile`` succeeded but PA still did
+    not publish a ``bluez_sink.*`` for the device (state-confusion after
+    ``module-rescue-streams`` / rapid reconnect). Returns ``True`` only
+    when the off → A2DP-sink cycle completes successfully, including
+    the final switch back to the target profile.
     """
     expected = f"bluez_card.{pa_mac}"
     try:
@@ -105,11 +128,12 @@ def _cycle_card_profile_for_mac(pa_mac: str) -> bool:
     if card is None:
         return False
     profiles = card.get("profiles") or []
-    if "a2dp_sink" not in profiles:
+    target = _pick_a2dp_sink_profile(profiles)
+    if target is None:
         return False
-    logger.info("Cycling %s profile off→a2dp_sink to force sink re-publish", expected)
+    logger.info("Cycling %s profile off→%s to force sink re-publish", expected, target)
     try:
-        return bool(cycle_card_profile(expected, "a2dp_sink"))
+        return bool(cycle_card_profile(expected, target))
     except Exception as exc:  # pragma: no cover — defensive
         logger.debug("cycle_card_profile(%s) errored: %s", expected, exc)
         return False
@@ -226,11 +250,16 @@ def configure_bluetooth_audio(
             # CRITICAL: Audio routing — sink discovery with bounded retries (_SINK_RETRY_COUNT).
             # If no sink found after retries, BT speaker will connect but play no audio.
             # Sink naming differs between PipeWire and PulseAudio — order matters.
+            # The raw-colon `bluez_output.{mac_address}` variant is what
+            # WirePlumber publishes on Ubuntu 26.04+; kept last so the
+            # more specific PipeWire/PulseAudio patterns win when both
+            # exist. Issue #314.
             sink_names = [
                 f"bluez_output.{pa_mac}.1",  # PipeWire format
                 f"bluez_output.{pa_mac}.a2dp-sink",
                 f"bluez_sink.{pa_mac}.a2dp_sink",  # Legacy PulseAudio format
                 f"bluez_sink.{pa_mac}",
+                f"bluez_output.{mac_address}",  # PipeWire / WirePlumber (Ubuntu 26.04, raw MAC)
             ]
             known_names = {s["name"] for s in sinks}
 

--- a/tests/unit/bluetooth/test_bt_manager.py
+++ b/tests/unit/bluetooth/test_bt_manager.py
@@ -163,6 +163,28 @@ def test_configure_bluetooth_audio_pulseaudio_pattern(bt_manager):
     assert result is True
 
 
+def test_configure_bluetooth_audio_pipewire_raw_mac_pattern(bt_manager):
+    """Finds a WirePlumber-style sink published as ``bluez_output.{MAC_with_colons}``.
+
+    Ubuntu 26.04 / PipeWire publishes BT sinks with the raw MAC (with
+    colons) and no ``.1`` / ``.a2dp-sink`` suffix. Regression test for
+    issue #314.
+    """
+    sink_name = f"bluez_output.{bt_manager.mac_address}"
+
+    fake_sinks = [{"name": sink_name, "description": "BT Speaker"}]
+    with (
+        patch("sendspin_bridge.bluetooth.audio.list_sinks", return_value=fake_sinks),
+        patch("sendspin_bridge.bluetooth.audio.get_sink_volume", return_value=50),
+        patch("sendspin_bridge.bluetooth.audio.set_sink_mute", return_value=True),
+        patch("sendspin_bridge.bluetooth.audio.set_sink_volume", return_value=True),
+        patch.object(bt_manager, "_wait_with_cancel", return_value=True),
+    ):
+        result = bt_manager.configure_bluetooth_audio()
+
+    assert result is True
+
+
 def test_configure_bluetooth_audio_no_sink(bt_manager):
     """Returns False when no matching sink is found."""
     with (
@@ -176,10 +198,14 @@ def test_configure_bluetooth_audio_no_sink(bt_manager):
     assert result is False
 
 
-def test_configure_bluetooth_audio_autoswitches_bluez_card_profile(bt_manager):
-    """When no sink found but bluez_card exists with non-a2dp profile, switch
-    to a2dp_sink and retry once. Covers AKG Y500 / BlueZ 5.82 regression where
-    the card connects in headset_head_unit profile and no sink is exposed."""
+@pytest.mark.parametrize("a2dp_profile_name", ["a2dp_sink", "a2dp-sink"])
+def test_configure_bluetooth_audio_autoswitches_bluez_card_profile(bt_manager, a2dp_profile_name):
+    """When no sink found but bluez_card exists with non-a2dp profile,
+    switch to the A2DP-sink profile and retry once. Covers AKG Y500 /
+    BlueZ 5.82 regression where the card connects in
+    ``headset_head_unit``. Parametrized over both spellings of the
+    profile name (PulseAudio underscore vs PipeWire dash). Issue #314.
+    """
     pa_mac = bt_manager.mac_address.replace(":", "_")
     card_name = f"bluez_card.{pa_mac}"
     sink_name = f"bluez_sink.{pa_mac}.a2dp_sink"
@@ -204,7 +230,7 @@ def test_configure_bluetooth_audio_autoswitches_bluez_card_profile(bt_manager):
             "name": card_name,
             "driver": "module-bluez5-device.c",
             "active_profile": "headset_head_unit",
-            "profiles": ["off", "a2dp_sink", "headset_head_unit"],
+            "profiles": ["off", a2dp_profile_name, "headset_head_unit"],
         }
     ]
 
@@ -227,7 +253,8 @@ def test_configure_bluetooth_audio_autoswitches_bluez_card_profile(bt_manager):
         result = bt_manager.configure_bluetooth_audio()
 
     assert result is True
-    assert set_profile_calls == [(card_name, "a2dp_sink")]
+    # Whichever spelling the card advertises is the one passed to pactl.
+    assert set_profile_calls == [(card_name, a2dp_profile_name)]
 
 
 def bt_audio_retry_threshold():
@@ -238,8 +265,10 @@ def bt_audio_retry_threshold():
     return bt_audio._SINK_RETRY_COUNT + 1
 
 
-def test_configure_bluetooth_audio_skips_profile_switch_when_already_a2dp(bt_manager):
-    """If active_profile is already a2dp_sink, do not call set_card_profile."""
+@pytest.mark.parametrize("a2dp_profile_name", ["a2dp_sink", "a2dp-sink"])
+def test_configure_bluetooth_audio_skips_profile_switch_when_already_a2dp(bt_manager, a2dp_profile_name):
+    """If active_profile is already an A2DP-sink variant (either
+    spelling), do not call set_card_profile. Issue #314."""
     pa_mac = bt_manager.mac_address.replace(":", "_")
     card_name = f"bluez_card.{pa_mac}"
 
@@ -247,8 +276,8 @@ def test_configure_bluetooth_audio_skips_profile_switch_when_already_a2dp(bt_man
         {
             "name": card_name,
             "driver": "module-bluez5-device.c",
-            "active_profile": "a2dp_sink",
-            "profiles": ["off", "a2dp_sink", "headset_head_unit"],
+            "active_profile": a2dp_profile_name,
+            "profiles": ["off", a2dp_profile_name, "headset_head_unit"],
         }
     ]
 

--- a/tests/unit/services/audio/test_pulse.py
+++ b/tests/unit/services/audio/test_pulse.py
@@ -4,6 +4,8 @@ import asyncio
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # Stub pulsectl libraries before importing the module under test.
 sys.modules.setdefault("pulsectl", MagicMock())
 sys.modules.setdefault("pulsectl_asyncio", MagicMock())
@@ -183,19 +185,22 @@ def test_fallback_list_cards_handles_subprocess_exception():
 # ---------------------------------------------------------------------------
 
 
-def test_fallback_set_card_profile_success():
-    """pactl returncode 0 → True."""
+@pytest.mark.parametrize("profile_name", ["a2dp_sink", "a2dp-sink"])
+def test_fallback_set_card_profile_success(profile_name):
+    """pactl returncode 0 → True. Profile string is passed through
+    verbatim — pactl accepts both ``a2dp_sink`` (PulseAudio) and
+    ``a2dp-sink`` (PipeWire) variants. Issue #314."""
     from sendspin_bridge.services.audio.pulse import _fallback_set_card_profile
 
     with patch.object(_pulse_mod, "subprocess") as mock_sub:
         mock_sub.run.return_value = MagicMock(returncode=0)
-        assert _fallback_set_card_profile("bluez_card.FC_58_FA_EB_08_6C", "a2dp_sink") is True
+        assert _fallback_set_card_profile("bluez_card.FC_58_FA_EB_08_6C", profile_name) is True
         cmd = mock_sub.run.call_args[0][0]
         assert cmd == [
             "pactl",
             "set-card-profile",
             "bluez_card.FC_58_FA_EB_08_6C",
-            "a2dp_sink",
+            profile_name,
         ]
 
 
@@ -213,8 +218,11 @@ def test_fallback_set_card_profile_failure():
 # ---------------------------------------------------------------------------
 
 
-def test_fallback_cycle_card_profile_sets_off_then_target():
-    """Cycle runs `pactl set-card-profile <card> off`, sleeps, then sets target."""
+@pytest.mark.parametrize("profile_name", ["a2dp_sink", "a2dp-sink"])
+def test_fallback_cycle_card_profile_sets_off_then_target(profile_name):
+    """Cycle runs `pactl set-card-profile <card> off`, sleeps, then sets
+    target. Profile string is passed through verbatim — pactl accepts
+    both ``a2dp_sink`` and ``a2dp-sink`` spellings. Issue #314."""
     from sendspin_bridge.services.audio.pulse import _fallback_cycle_card_profile
 
     with (
@@ -223,12 +231,12 @@ def test_fallback_cycle_card_profile_sets_off_then_target():
     ):
         mock_sub.run.return_value = MagicMock(returncode=0)
         mock_time.sleep = MagicMock()
-        result = _fallback_cycle_card_profile("bluez_card.xx", "a2dp_sink", off_wait=0.0)
+        result = _fallback_cycle_card_profile("bluez_card.xx", profile_name, off_wait=0.0)
 
     assert result is True
     cmds = [call.args[0] for call in mock_sub.run.call_args_list]
     assert ["pactl", "set-card-profile", "bluez_card.xx", "off"] in cmds
-    assert ["pactl", "set-card-profile", "bluez_card.xx", "a2dp_sink"] in cmds
+    assert ["pactl", "set-card-profile", "bluez_card.xx", profile_name] in cmds
 
 
 def test_fallback_cycle_card_profile_continues_when_off_set_fails():


### PR DESCRIPTION
## Summary

Two independent fixes for Ubuntu 26.04 / WirePlumber hosts surfaced together in #314:

1. **`bluez_output.{MAC_with_colons}` (raw MAC, no suffix)** is now a recognised sink pattern. WirePlumber publishes BT outputs with this shape on Ubuntu 26.04+ — the bridge previously missed it and silently routed audio to the default device. Added to `sink_names` in `configure_bluetooth_audio` as the *last* candidate so the more specific PipeWire / PulseAudio shapes still win when both forms exist.

2. **`a2dp-sink` (dash) accepted alongside `a2dp_sink` (underscore)** in `_switch_card_profile_to_a2dp` and `_cycle_card_profile_for_mac`. BlueZ 5.82 + PipeWire publishes the profile with a dash; the bridge hard-coded the underscore and logged `BlueZ card … has no a2dp_sink profile available` on cards that already exposed the dash variant and were active on it. New helper `_pick_a2dp_sink_profile()` resolves whichever spelling the card advertises and passes it through to `pactl set-card-profile` verbatim (pactl accepts both).

## Why

Reporter #314 attached this single repeating warning from the bridge log:
```
BlueZ card bluez_card.01_3A_C7_03_C9_91 has no a2dp_sink profile available
  (active=a2dp-sink, profiles=off,a2dp-sink,a2dp-sink-sbc_xq,…)
```
The card was already active on the right profile — but the bridge's auto-switch couldn't see it and reported a false negative. The same setup ALSO missed sink discovery because WirePlumber published `bluez_output.11:BC:93:1C:0C:EC` (raw colons, no suffix), so the user had been working around with manual `LAST_SINKS` mappings.

## Test plan

- [x] `pytest tests/unit/bluetooth/test_bt_manager.py tests/unit/services/audio/test_pulse.py` — 140 passed (the only failure is the pre-existing `test_monitor_dbus_raises_when_device_path_unavailable`, an asyncio-marker env issue unrelated to this PR).
- [x] Two new parametrized test cases on the existing autoswitch + skip tests cover both `a2dp_sink` and `a2dp-sink` spellings.
- [x] One new test `test_configure_bluetooth_audio_pipewire_raw_mac_pattern` covers the new sink pattern.
- [x] `python scripts/lint_changelog.py CHANGELOG.md` — clean.
- [x] `ruff check` on touched files — clean.
- [ ] Manual on Ubuntu 26.04 + WirePlumber: confirm `pactl list sinks short` shows `bluez_output.{MAC_with_colons}`, add device through the bridge UI, observe `✓ Found audio sink: bluez_output.XX:XX:XX:XX:XX:XX` instead of "Audio may play from default device".

Fixes #314