### PR TITLE
deps: bump pulsectl-asyncio to 1.3.2, idna to 3.18 in frozen lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Routine Bluetooth dependency bumps refreshed in the frozen lockfile.** `bluetooth-adapters` 2.1.1 → 2.4.0 and `usb-devices` 0.4.5 → 0.5.1 (both on the Linux Bluetooth-recovery path), plus `pyobjc-core` 12.1 → 12.2.1 (macOS-only, no effect on Raspberry Pi / Home Assistant / LXC deployments). ([#334](https://github.com/trudenboy/sendspin-bt-bridge/pull/334), [#335](https://github.com/trudenboy/sendspin-bt-bridge/pull/335), [#337](https://github.com/trudenboy/sendspin-bt-bridge/pull/337))
+- **PulseAudio client library updated to `pulsectl-asyncio` 1.3.2.** Brings official Python 3.13 support, a fix for leaked asyncio file-descriptor registrations on unclean loop shutdown, and a fix for a spurious assertion crash at teardown while event subscriptions are active — both directly relevant to the bridge's sink-state monitoring. Also bumps transitive `idna` 3.15 → 3.18. ([#358](https://github.com/trudenboy/sendspin-bt-bridge/pull/358), [#359](https://github.com/trudenboy/sendspin-bt-bridge/pull/359))
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "waitress==3.0.2",
     "dbus-python==1.4.0",
     "dbus-fast==5.0.17",
-    "pulsectl-asyncio==1.2.2",
+    "pulsectl-asyncio==1.3.2",
     "music-assistant-client==1.3.5",
     "websockets==16.0",
     "zeroconf==0.149.16",

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -21,7 +21,7 @@ aiosendspin[server]==5.3.0
 flask==3.1.3
 waitress==3.0.2
 dbus-fast==5.0.17
-pulsectl-asyncio==1.2.2
+pulsectl-asyncio==1.3.2
 music-assistant-client==1.3.5
 websockets==16.0
 zeroconf==0.149.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.15
+idna==3.18
     # via
     #   requests
     #   yarl
@@ -123,7 +123,7 @@ propcache==0.5.2
     #   yarl
 pulsectl==24.11.0
     # via pulsectl-asyncio
-pulsectl-asyncio==1.2.2
+pulsectl-asyncio==1.3.2
     # via
     #   sendspin
     #   sendspin-bt-bridge

--- a/uv.lock
+++ b/uv.lock
@@ -778,11 +778,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1493,14 +1493,14 @@ wheels = [
 
 [[package]]
 name = "pulsectl-asyncio"
-version = "1.2.2"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pulsectl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/6c/cf1c49abd874edd460d4c68d860d0dc2605b9fd5958a7ba925e3b0c1ec9b/pulsectl_asyncio-1.2.2.tar.gz", hash = "sha256:ee4c427a10f44d2e38065e480668a47316b5d93612ebe3d05d9318f0fe0d417f", size = 21963, upload-time = "2024-11-02T10:04:20.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/66/ea5b68261ff9c3f00a1499fe6acea0aa833b2080ac41978b09d1af01e61e/pulsectl_asyncio-1.3.2.tar.gz", hash = "sha256:89f6f0706e53e2492c0baebb13961acfedb1fadadda1dbcb7159572d3037d307", size = 22630, upload-time = "2026-06-27T11:27:59.458Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/aa/7eb363c7c8a697f6c97c2861f6699213a4418d11119198746142a8cce731/pulsectl_asyncio-1.2.2-py3-none-any.whl", hash = "sha256:21c47bcba63e01fe25e2326d73c85952e1aa59174bc51fe4f96bd1ffcc3a6850", size = 16694, upload-time = "2024-11-02T10:04:19.138Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ac/bef22729728727cf2314bd80563e834e3ab17bfb7b703e9e34f44ff44810/pulsectl_asyncio-1.3.2-py3-none-any.whl", hash = "sha256:aa3adf89fe91a80ec1a5c92de3dcfd17a8f171006a07a2ec59a4a13d031fc70d", size = 16725, upload-time = "2026-06-27T11:27:58.591Z" },
 ]
 
 [[package]]
@@ -1809,7 +1809,7 @@ requires-dist = [
     { name = "music-assistant-client", specifier = "==1.3.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.2,<3.0" },
     { name = "pillow", specifier = ">=12.2.0" },
-    { name = "pulsectl-asyncio", specifier = "==1.2.2" },
+    { name = "pulsectl-asyncio", specifier = "==1.3.2" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0.0" },


### PR DESCRIPTION
Batches two Dependabot pip bumps into one `uv.lock`-consistent commit (Dependabot doesn't update `uv.lock`, so #358 fails the `uv-export` lint hook and #359 would leave the lock stale against `pyproject.toml`).

Supersedes and closes:
- #359 — `pulsectl-asyncio` 1.2.2 → 1.3.2: official Python 3.13 support, fix for leaked asyncio fd registrations on unclean loop shutdown, fix for spurious assertion crash at teardown while `subscribe_events()` is active — both directly relevant to the bridge's sink-state monitoring. Pin updated in `pyproject.toml` + `requirements-demo.txt`.
- #358 — `idna` 3.15 → 3.18 (transitive)

### Verification
- `uv sync --frozen` — consistent
- `uv run pytest` — 2670 passed
- `pip-audit` (CI ignores) — no known vulnerabilities
- changelog lint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)