### PR TITLE
fix(#341): cover sendspin sync-settle window with startup mute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Bluetooth scan now runs on — and labels results with — the adapter actually selected in the UI.** On hosts with several adapters where the kernel's hci numbering differs from BlueZ's registration order (typically after USB hotplug), selecting an adapter for a scan could silently scan a different physical adapter and show discovered devices under the wrong adapter name. Adapter selection now resolves through the same kernel mapping the adapter list uses, and per-adapter device attribution runs in dedicated sessions so discovery notifications can no longer corrupt it. ([#340](https://github.com/trudenboy/sendspin-bt-bridge/issues/340))
+- **Crackling / "sandy" noise in the first seconds after starting playback is no longer audible.** Every fresh stream start triggers the sendspin sync corrector, which drops or duplicates frames for up to two seconds while converging on the DAC anchor — audible as a brief burst of crackle. The startup mute window now covers that entire settle window (raised from 1.5 s to 2.5 s), so the correction burst stays inaudible. Gapless track-to-track transitions were never affected. ([#341](https://github.com/trudenboy/sendspin-bt-bridge/issues/341))
 
 ### Security
 

--- a/src/sendspin_bridge/services/ipc/daemon_process.py
+++ b/src/sendspin_bridge/services/ipc/daemon_process.py
@@ -294,8 +294,15 @@ async def _reanchor_watcher(status: dict, on_status_change, stop_event: asyncio.
                         logger.debug("reanchor auto-clear callback failed: %s", exc)
 
 
-# Seconds after audio_streaming=True before unmuting the sink
-_STARTUP_UNMUTE_DELAY_S = 1.5
+# Seconds after audio_streaming=True before unmuting the sink.
+# Must cover sendspin's sync-settle window: on every fresh stream start
+# AudioPlayer re-anchors and its proportional drop/insert corrector
+# converges within _CORRECTION_TARGET_SECONDS (2.0 s in sendspin 7.3).
+# The repeated frame drops/duplications during that window are audible
+# as crackling, so unmuting earlier leaks the tail of the burst to the
+# speaker (issue #341).  0.5 s headroom because convergence is
+# asymptotic — guarded by test_startup_unmute_covers_sync_settle.
+_STARTUP_UNMUTE_DELAY_S = 2.5
 
 # Issue #269: maximum time to wait for BlueZ MediaTransport1 to leave the
 # 'idle' state before muting anyway. Most BlueZ stacks move to 'pending'

--- a/tests/unit/services/ipc/test_startup_unmute_covers_sync_settle.py
+++ b/tests/unit/services/ipc/test_startup_unmute_covers_sync_settle.py
@@ -1,0 +1,55 @@
+"""Startup-mute window must cover sendspin's sync-settle window (issue #341).
+
+On every fresh stream start sendspin's ``AudioPlayer`` re-anchors and
+runs a proportional drop/insert corrector that converges within
+``_CORRECTION_TARGET_SECONDS``.  The repeated frame drops/duplications
+during that window are audible as crackling / "sandy" noise.  The
+daemon mutes the sink at startup and unmutes after
+``_STARTUP_UNMUTE_DELAY_S`` — if that delay is shorter than the settle
+window, the tail of the correction burst reaches the speaker.
+
+The constant is read from the installed sendspin *source* via AST
+rather than imported: sibling test modules stub ``sendspin.audio`` in
+``sys.modules`` for the whole worker process, so a live import could
+silently hand us a MagicMock instead of the real number.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.metadata
+from pathlib import Path
+
+from sendspin_bridge.services.ipc import daemon_process
+
+# Headroom above the corrector's convergence target: convergence is
+# asymptotic (the corrector aims to fix the error *within* the target,
+# small residual corrections continue slightly past it).
+_SETTLE_HEADROOM_S = 0.5
+
+
+def _read_sendspin_correction_target_seconds() -> float:
+    audio_py = Path(str(importlib.metadata.distribution("sendspin").locate_file("sendspin/audio.py")))
+    tree = ast.parse(audio_py.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign) and getattr(node.target, "id", "") == "_CORRECTION_TARGET_SECONDS":
+            assert node.value is not None
+            return float(ast.literal_eval(node.value))
+        if isinstance(node, ast.Assign) and any(
+            getattr(t, "id", "") == "_CORRECTION_TARGET_SECONDS" for t in node.targets
+        ):
+            return float(ast.literal_eval(node.value))
+    raise AssertionError(
+        "sendspin renamed AudioPlayer._CORRECTION_TARGET_SECONDS — re-verify "
+        "the sync-settle window and update this test (issue #341)"
+    )
+
+
+def test_startup_unmute_delay_covers_sendspin_correction_window():
+    correction_target = _read_sendspin_correction_target_seconds()
+    assert daemon_process._STARTUP_UNMUTE_DELAY_S >= correction_target + _SETTLE_HEADROOM_S, (
+        "Startup unmute fires before sendspin's sync corrector settles: "
+        f"unmute at {daemon_process._STARTUP_UNMUTE_DELAY_S}s, corrector "
+        f"converges within {correction_target}s "
+        "(issue #341 — crackling in the first seconds of playback)"
+    )

--- a/tests/unit/services/ipc/test_startup_unmute_covers_sync_settle.py
+++ b/tests/unit/services/ipc/test_startup_unmute_covers_sync_settle.py
@@ -47,9 +47,10 @@ def _read_sendspin_correction_target_seconds() -> float:
 
 def test_startup_unmute_delay_covers_sendspin_correction_window():
     correction_target = _read_sendspin_correction_target_seconds()
-    assert daemon_process._STARTUP_UNMUTE_DELAY_S >= correction_target + _SETTLE_HEADROOM_S, (
+    unmute_delay = daemon_process._STARTUP_UNMUTE_DELAY_S
+    assert unmute_delay >= correction_target + _SETTLE_HEADROOM_S, (
         "Startup unmute fires before sendspin's sync corrector settles: "
-        f"unmute at {daemon_process._STARTUP_UNMUTE_DELAY_S}s, corrector "
+        f"unmute at {unmute_delay}s, corrector "
         f"converges within {correction_target}s "
         "(issue #341 — crackling in the first seconds of playback)"
     )


### PR DESCRIPTION
Addresses the audible part of #341.

## Root cause (verified against sendspin 7.3.1 source)
Every fresh `set_format()` re-arms the AudioPlayer DAC re-anchor; its proportional drop/insert corrector (up to 4% of frames) converges within `_CORRECTION_TARGET_SECONDS = 2.0 s`. The repeated frame drops/duplications are the "sandy" crackle: present in the sink-monitor PCM before any BT encoding, heavy in the first seconds of a manual start, absent on gapless A→B transitions (which skip `set_format`). This matches the reporter's observations exactly.

## Fix
The daemon's startup mute released after **1.5 s — inside the settle window** — leaking the tail of the correction burst to the speaker. `_STARTUP_UNMUTE_DELAY_S` raised to **2.5 s** (target + 0.5 s asymptotic headroom).

The guard test reads `_CORRECTION_TARGET_SECONDS` from the installed sendspin source via AST (sibling ipc tests stub `sendspin.audio` in `sys.modules` process-wide, so a live import can return a MagicMock).

## Scope note
This masks the burst at the speaker. The PCM corruption itself is upstream sendspin corrector behaviour — will be reported upstream with instrumentation data (also relevant to #323).

## Tests
Red→green `test_startup_unmute_covers_sync_settle.py`; full suite 2671 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)