### PR TITLE
feat(#349,#350): auto-reclaim BT management on external reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-released speakers now reclaim themselves when they reconnect on their own.** Previously, once a device hit the auto-release threshold ("N consecutive failed reconnects") or the churn guard, it stayed released until someone pressed Reclaim in the web UI — so a speaker that was simply switched off overnight needed a manual click every morning. The bridge now watches released devices: when the speaker itself re-establishes the Bluetooth link, management is reclaimed automatically, audio is configured and the player restarts. Only automatic releases are eligible — a release made by the operator stays released, including across restarts. A one-minute quiet period after each auto-release prevents management flapping on speakers that are still bouncing. ([#349](https://github.com/trudenboy/sendspin-bt-bridge/issues/349), [#350](https://github.com/trudenboy/sendspin-bt-bridge/issues/350))
+
 ### Changed
 
 - **Routine Bluetooth dependency bumps refreshed in the frozen lockfile.** `bluetooth-adapters` 2.1.1 → 2.4.0 and `usb-devices` 0.4.5 → 0.5.1 (both on the Linux Bluetooth-recovery path), plus `pyobjc-core` 12.1 → 12.2.1 (macOS-only, no effect on Raspberry Pi / Home Assistant / LXC deployments). ([#334](https://github.com/trudenboy/sendspin-bt-bridge/pull/334), [#335](https://github.com/trudenboy/sendspin-bt-bridge/pull/335), [#337](https://github.com/trudenboy/sendspin-bt-bridge/pull/337))

--- a/src/sendspin_bridge/bluetooth/manager.py
+++ b/src/sendspin_bridge/bluetooth/manager.py
@@ -77,6 +77,12 @@ _PAIRING_SCAN_DURATION = 12  # seconds to scan before pairing
 _PAIRING_WAIT_DURATION = 10  # seconds to wait for pairing to complete
 _MAX_RECONNECT_DELAY_S = 300.0  # max backoff for reconnect attempts (5 min)
 _CONNECT_CHECK_RETRIES = 5  # status checks after connect before giving up
+# Minimum time a device must stay auto-released before an external
+# connect may reclaim management (issues #349/#350).  Keeps a
+# churn-released speaker from flapping management on/off while it is
+# still bouncing: each reclaim needs the speaker to hold a link past
+# this window.
+_AUTO_RECLAIM_QUIET_S = 60.0
 # Strips ANSI colour codes from bluetoothctl stdout before excerpting it
 # into the connect-failure warning line.
 _BCTL_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -208,6 +214,11 @@ class BluetoothManager:
         self.last_check: float = 0
         self.check_interval = check_interval
         self.max_reconnect_fails = max_reconnect_fails
+        # Monotonic timestamp of the last auto-release; gates the
+        # auto-reclaim quiet period (issues #349/#350).  None = never
+        # auto-released this run (a release persisted from a previous
+        # run may reclaim immediately once the speaker connects).
+        self._auto_released_at: float | None = None
         # Experimental sink-recovery flags (off by default; enabled per-bridge via config)
         self._enable_a2dp_dance = bool(enable_a2dp_dance)
         self._enable_pa_module_reload = bool(enable_pa_module_reload)
@@ -1329,6 +1340,7 @@ class BluetoothManager:
             self._CHURN_WINDOW,
         )
         self.management_enabled = False
+        self._auto_released_at = time.monotonic()
         if self.host:
             self.host.bt_management_enabled = False
             self.host.update_status(
@@ -1343,7 +1355,7 @@ class BluetoothManager:
         try:
             from sendspin_bridge.services.bluetooth import persist_device_released
 
-            persist_device_released(self.device_name, True)
+            persist_device_released(self.device_name, True, released_by="auto")
         except Exception as _e:
             logger.debug("persist_device_released failed: %s", _e)
         return True
@@ -1389,6 +1401,7 @@ class BluetoothManager:
             self.max_reconnect_fails,
         )
         self.management_enabled = False
+        self._auto_released_at = time.monotonic()
         if self.host:
             self.host.bt_management_enabled = False
             self.host.update_status(
@@ -1403,7 +1416,70 @@ class BluetoothManager:
         try:
             from sendspin_bridge.services.bluetooth import persist_device_released
 
-            persist_device_released(self.device_name, True)
+            persist_device_released(self.device_name, True, released_by="auto")
+        except Exception as _e:
+            logger.debug("persist_device_released failed: %s", _e)
+        return True
+
+    def maybe_auto_reclaim(self, connected: bool | None = None) -> bool:
+        """Reclaim BT management after an auto-release once the speaker
+        re-establishes the link on its own (issues #349/#350).
+
+        The speaker initiating a connection is the churn-safe signal: a
+        device stuck in a reconnect loop never presents a stable
+        ``Connected=yes`` link.  Manual (operator) releases are never
+        reclaimed automatically — only ``bt_released_by == "auto"``.
+        ``_AUTO_RECLAIM_QUIET_S`` damps flapping after a churn release.
+
+        ``connected`` overrides ``self.connected`` for the polling
+        monitor, which passes its live poll result (the cached attribute
+        is only maintained by the D-Bus PropertiesChanged path).
+
+        Returns True when management was reclaimed; the caller is
+        responsible for configuring audio and starting the player.
+        """
+        if self.management_enabled or not self._running:
+            return False
+        host = self.host
+        if host is None or host.get_status_value("bt_released_by") != "auto":
+            return False
+        if connected is None:
+            connected = self.connected
+        if not connected:
+            return False
+        released_at = self._auto_released_at
+        if released_at is not None and time.monotonic() - released_at < _AUTO_RECLAIM_QUIET_S:
+            return False
+        logger.info(
+            "[%s] Speaker reconnected on its own after auto-release — reclaiming BT management",
+            self.device_name,
+        )
+        with self._reconnect_lock:
+            # Fresh churn window: the reconnects that led to the release
+            # must not count against the reclaimed session.
+            self._reconnect_timestamps = []
+        self._auto_released_at = None
+        self.allow_reconnect()
+        host.bt_management_enabled = True
+        host.update_status(
+            {
+                "bt_management_enabled": True,
+                "bt_released_by": None,
+                "reconnecting": False,
+                "reconnect_attempt": 0,
+                "last_error": None,
+            }
+        )
+        from sendspin_bridge.services.diagnostics.internal_events import DeviceEventType
+
+        self._publish_client_event(
+            DeviceEventType.BT_MANAGEMENT_RECLAIMED,
+            message="Speaker reconnected on its own — BT management reclaimed",
+        )
+        try:
+            from sendspin_bridge.services.bluetooth import persist_device_released
+
+            persist_device_released(self.device_name, False)
         except Exception as _e:
             logger.debug("persist_device_released failed: %s", _e)
         return True

--- a/src/sendspin_bridge/bluetooth/monitor.py
+++ b/src/sendspin_bridge/bluetooth/monitor.py
@@ -74,6 +74,56 @@ async def _correct_other_devices_routing(triggering_mgr: BluetoothManager) -> No
             logger.debug("[%s] Sink routing correction failed: %s", client.player_name, exc)
 
 
+async def _finish_auto_reclaim(mgr: BluetoothManager, loop, *, connected: bool | None = None) -> bool:
+    """Reclaim after auto-release and bring the player back up (#349/#350).
+
+    ``BluetoothManager.maybe_auto_reclaim`` performs the state flip
+    (gated on ``bt_released_by == "auto"``, an established link and the
+    quiet period); this helper then mirrors the external-reconnect path:
+    configure audio, restart the player subprocess and correct sink
+    routing for the other devices.
+    """
+    if not mgr.maybe_auto_reclaim(connected=connected):
+        return False
+    from sendspin_bridge.bluetooth.manager import _bt_executor
+
+    await loop.run_in_executor(_bt_executor, mgr.configure_bluetooth_audio)
+    mgr._record_reconnect()
+    if mgr.host:
+        mgr.host.update_status(
+            {
+                "bluetooth_connected": True,
+                "bluetooth_connected_at": datetime.now(tz=UTC).isoformat(),
+            }
+        )
+        logger.info("BT management reclaimed for %s, starting sendspin...", mgr.device_name)
+        await mgr.host.start_subprocess()
+    asyncio.ensure_future(_correct_other_devices_routing(mgr))
+    return True
+
+
+async def _poll_auto_reclaim(mgr: BluetoothManager, loop) -> bool:
+    """Polling-monitor variant of the auto-reclaim check.
+
+    The polling path has no PropertiesChanged handler keeping
+    ``mgr.connected`` fresh while management is released, so poll the
+    live state — rate-limited to the regular ``check_interval`` cadence
+    via ``mgr.last_check`` (idle while released, so it's free to reuse).
+    """
+    if mgr.host is None or mgr.host.get_status_value("bt_released_by") != "auto":
+        return False
+    now = time.time()
+    if now - mgr.last_check < mgr.check_interval:
+        return False
+    mgr.last_check = now
+    from sendspin_bridge.bluetooth.manager import _bt_executor
+
+    connected = await loop.run_in_executor(_bt_executor, mgr.is_device_connected)
+    if not connected:
+        return False
+    return await _finish_auto_reclaim(mgr, loop, connected=True)
+
+
 async def monitor_and_reconnect(mgr: BluetoothManager) -> None:
     """Continuously monitor BT connection and reconnect if needed.
 
@@ -105,6 +155,8 @@ async def _monitor_polling(mgr: BluetoothManager) -> None:
         iteration += 1
         try:
             if not mgr.management_enabled:
+                if await _poll_auto_reclaim(mgr, loop):
+                    continue
                 await asyncio.sleep(5)
                 continue
 
@@ -369,6 +421,12 @@ async def _inner_dbus_monitor(
     reconnect_attempt = 0
     while mgr._running:
         if not mgr.management_enabled:
+            # ``mgr.connected`` stays fresh here even while released —
+            # the PropertiesChanged handler keeps applying state — so an
+            # auto-released speaker that reconnects on its own can be
+            # reclaimed without polling (#349/#350).
+            if await _finish_auto_reclaim(mgr, loop):
+                continue
             await asyncio.sleep(5)
             continue
 

--- a/src/sendspin_bridge/services/bluetooth/__init__.py
+++ b/src/sendspin_bridge/services/bluetooth/__init__.py
@@ -490,8 +490,14 @@ def persist_device_enabled(player_name: str, enabled: bool) -> None:
             logger.debug("Could not sync enabled flag to options.json: %s", e)
 
 
-def persist_device_released(player_name: str, released: bool) -> None:
-    """Persist the released (bt_management_enabled=False) flag to config.json."""
+def persist_device_released(player_name: str, released: bool, *, released_by: str | None = None) -> None:
+    """Persist the released (bt_management_enabled=False) flag to config.json.
+
+    ``released_by`` records who initiated the release ("auto" / "user") so
+    the auto-reclaim gate (issues #349/#350) can distinguish an operator's
+    deliberate release from an automatic one across a bridge restart.
+    Cleared whenever the device is un-released.
+    """
     if not _CONFIG_FILE.exists():
         return
 
@@ -499,6 +505,10 @@ def persist_device_released(player_name: str, released: bool) -> None:
         for dev in cfg.get("BLUETOOTH_DEVICES", []):
             if _match_player_name(dev.get("player_name", ""), player_name):
                 dev["released"] = released
+                if released and released_by:
+                    dev["released_by"] = released_by
+                else:
+                    dev.pop("released_by", None)
                 break
 
     try:
@@ -514,6 +524,10 @@ def persist_device_released(player_name: str, released: bool) -> None:
                 for dev in opts.get("bluetooth_devices", []):
                     if _match_player_name(dev.get("player_name", ""), player_name):
                         dev["released"] = released
+                        if released and released_by:
+                            dev["released_by"] = released_by
+                        else:
+                            dev.pop("released_by", None)
                         break
                 tmp = str(_OPTIONS_FILE) + ".tmp"
                 with open(tmp, "w") as f:

--- a/src/sendspin_bridge/services/bluetooth/device_activation.py
+++ b/src/sendspin_bridge/services/bluetooth/device_activation.py
@@ -648,7 +648,13 @@ def activate_device(
 
     if device.get("released", False):
         client.set_bt_management_enabled(False)
-        logger.info("  Player '%s': restored released state", player_name)
+        # set_bt_management_enabled stamps bt_released_by="user"; restore
+        # the persisted originator so an auto-released device stays
+        # eligible for auto-reclaim across restarts (#349/#350).
+        released_by = device.get("released_by")
+        if released_by == "auto":
+            client._update_status({"bt_released_by": "auto"})
+        logger.info("  Player '%s': restored released state (released_by=%s)", player_name, released_by or "user")
 
     return ActivationResult(
         client=client,

--- a/src/sendspin_bridge/services/diagnostics/internal_events.py
+++ b/src/sendspin_bridge/services/diagnostics/internal_events.py
@@ -35,6 +35,7 @@ class DeviceEventType(str, Enum):
     RUNTIME_ERROR = "runtime-error"
     RUNTIME_ERROR_CLEARED = "runtime-error-cleared"
     BT_MANAGEMENT_DISABLED = "bt-management-disabled"
+    BT_MANAGEMENT_RECLAIMED = "bt-management-reclaimed"
     MA_MONITOR_STALE = "ma-monitor-stale"
     BLUETOOTH_STANDBY_ENTERED = "bluetooth-standby-entered"
     BLUETOOTH_STANDBY_EXITED = "bluetooth-standby-exited"
@@ -58,6 +59,7 @@ _DEFAULT_EVENT_LEVELS: dict[str, str] = {
     DeviceEventType.RUNTIME_ERROR.value: "error",
     DeviceEventType.RUNTIME_ERROR_CLEARED.value: "info",
     DeviceEventType.BT_MANAGEMENT_DISABLED.value: "warning",
+    DeviceEventType.BT_MANAGEMENT_RECLAIMED.value: "info",
     DeviceEventType.MA_MONITOR_STALE.value: "warning",
     DeviceEventType.BLUETOOTH_STANDBY_ENTERED.value: "info",
     DeviceEventType.BLUETOOTH_STANDBY_EXITED.value: "info",

--- a/src/sendspin_bridge/web/routes/api_bt.py
+++ b/src/sendspin_bridge/web/routes/api_bt.py
@@ -250,7 +250,9 @@ def api_bt_management():
         return jsonify({"success": False, "error": "No client found"}), 503
     enabled = bool(enabled)
     threading.Thread(target=client.set_bt_management_enabled, args=(enabled,), daemon=True).start()
-    _persist_device_released(str(player_name), not enabled)
+    # An operator's release must never be auto-reclaimed (#349/#350) —
+    # record who released so the distinction survives a bridge restart.
+    _persist_device_released(str(player_name), not enabled, released_by=None if enabled else "user")
     # Sync enabled state to HA Supervisor so the Configuration page reflects it
     try:
         with config_lock, open(CONFIG_FILE) as _f:

--- a/tests/unit/bluetooth/test_auto_reclaim.py
+++ b/tests/unit/bluetooth/test_auto_reclaim.py
@@ -1,0 +1,149 @@
+"""Auto-reclaim after auto-release (issues #349/#350).
+
+When a device is auto-released ("N consecutive failed reconnects" or BT
+churn), the speaker later re-establishing the link on its own is a safe
+signal to reclaim management: a device stuck in a reconnect loop never
+presents a stable Connected=yes.  Manual (operator) releases must stay
+released.  A quiet period after the release keeps a churn-released
+speaker from flapping management on/off while it is still bouncing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(tmp_path, monkeypatch):
+    """Redirect config to a temp directory."""
+    import sendspin_bridge.config as config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+
+
+@pytest.fixture()
+def released_manager():
+    """A manager in the auto-released state with a connected speaker."""
+    from sendspin_bridge.bluetooth.manager import BluetoothManager
+
+    with patch("subprocess.check_output", return_value=""):
+        mgr = BluetoothManager(mac_address="AA:BB:CC:DD:EE:FF", device_name="TestSpeaker")
+    mgr.management_enabled = False
+    mgr.connected = True
+    mgr._auto_released_at = 0.0  # released long ago (monotonic origin)
+    mgr.host = MagicMock()
+    mgr.host.bt_management_enabled = False
+    mgr.host.get_status_value = lambda key: {"bt_released_by": "auto"}.get(key)
+    return mgr
+
+
+def test_reclaims_auto_released_device_on_external_connect(released_manager):
+    mgr = released_manager
+    with (
+        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1000.0),
+        patch("sendspin_bridge.services.bluetooth.persist_device_released") as persist_released,
+    ):
+        assert mgr.maybe_auto_reclaim() is True
+
+    assert mgr.management_enabled is True
+    assert mgr.host.bt_management_enabled is True
+    status_update = mgr.host.update_status.call_args[0][0]
+    assert status_update["bt_management_enabled"] is True
+    assert status_update["bt_released_by"] is None
+    persist_released.assert_called_once_with("TestSpeaker", False)
+
+
+def test_user_release_is_never_auto_reclaimed(released_manager):
+    mgr = released_manager
+    mgr.host.get_status_value = lambda key: {"bt_released_by": "user"}.get(key)
+    with patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1000.0):
+        assert mgr.maybe_auto_reclaim() is False
+    assert mgr.management_enabled is False
+
+
+def test_no_reclaim_while_disconnected(released_manager):
+    mgr = released_manager
+    mgr.connected = False
+    with patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1000.0):
+        assert mgr.maybe_auto_reclaim() is False
+    assert mgr.management_enabled is False
+
+
+def test_explicit_connected_argument_overrides_cached_state(released_manager):
+    mgr = released_manager
+    mgr.connected = False  # polling monitor passes live poll results instead
+    with (
+        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1000.0),
+        patch("sendspin_bridge.services.bluetooth.persist_device_released"),
+    ):
+        assert mgr.maybe_auto_reclaim(connected=True) is True
+
+
+def test_quiet_period_damps_churn_flapping(released_manager):
+    mgr = released_manager
+    mgr._auto_released_at = 990.0  # released 10 s ago
+    with patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1000.0):
+        assert mgr.maybe_auto_reclaim() is False
+    assert mgr.management_enabled is False
+
+    # …but reclaim works once the quiet period has elapsed.
+    with (
+        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1100.0),
+        patch("sendspin_bridge.services.bluetooth.persist_device_released"),
+    ):
+        assert mgr.maybe_auto_reclaim() is True
+
+
+def test_reclaim_resets_churn_window(released_manager):
+    mgr = released_manager
+    mgr._reconnect_timestamps = [1.0, 2.0, 3.0]
+    with (
+        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1000.0),
+        patch("sendspin_bridge.services.bluetooth.persist_device_released"),
+    ):
+        assert mgr.maybe_auto_reclaim() is True
+    assert mgr._reconnect_timestamps == []
+
+
+def test_no_reclaim_when_management_already_enabled(released_manager):
+    mgr = released_manager
+    mgr.management_enabled = True
+    assert mgr.maybe_auto_reclaim() is False
+
+
+def test_auto_release_stamps_quiet_period_origin(released_manager):
+    """Both auto-release paths must stamp _auto_released_at and persist
+    released_by="auto" so the reclaim gate can distinguish them from a
+    manual release across the round-trip."""
+    mgr = released_manager
+    mgr.management_enabled = True
+    mgr._auto_released_at = None
+    mgr.max_reconnect_fails = 2
+    mgr.paired = True
+    mgr._has_ever_paired_since_start = True
+    with (
+        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=555.0),
+        patch("sendspin_bridge.services.bluetooth.persist_device_released") as persist_released,
+    ):
+        assert mgr._handle_reconnect_failure(3) is True
+    assert mgr._auto_released_at == 555.0
+    persist_released.assert_called_once_with("TestSpeaker", True, released_by="auto")
+
+
+def test_churn_release_stamps_quiet_period_origin(released_manager):
+    mgr = released_manager
+    mgr.management_enabled = True
+    mgr._auto_released_at = None
+    mgr._CHURN_THRESHOLD = 2
+    mgr._CHURN_WINDOW = 30
+    mgr._reconnect_timestamps = [90.0, 99.0]
+    with (
+        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=100.0),
+        patch("sendspin_bridge.services.bluetooth.persist_device_released") as persist_released,
+    ):
+        assert mgr._check_reconnect_churn() is True
+    assert mgr._auto_released_at == 100.0
+    persist_released.assert_called_once_with("TestSpeaker", True, released_by="auto")

--- a/tests/unit/bluetooth/test_auto_reclaim_monitor.py
+++ b/tests/unit/bluetooth/test_auto_reclaim_monitor.py
@@ -1,0 +1,97 @@
+"""Monitor-side auto-reclaim flow (issues #349/#350).
+
+``_finish_auto_reclaim`` must mirror the external-reconnect path after
+the state flip: configure audio, restart the player subprocess.  The
+polling variant additionally polls the live connected state (the cached
+``mgr.connected`` is only maintained by the D-Bus handler) at the
+regular ``check_interval`` cadence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from sendspin_bridge.bluetooth.monitor import _finish_auto_reclaim, _poll_auto_reclaim
+
+
+def _make_mgr(*, reclaims: bool) -> MagicMock:
+    mgr = MagicMock()
+    mgr.device_name = "TestSpeaker"
+    mgr.maybe_auto_reclaim = MagicMock(return_value=reclaims)
+    mgr.configure_bluetooth_audio = MagicMock()
+    mgr.host = MagicMock()
+    mgr.host.start_subprocess = AsyncMock()
+    return mgr
+
+
+async def test_finish_auto_reclaim_configures_audio_and_starts_player():
+    mgr = _make_mgr(reclaims=True)
+    loop = asyncio.get_running_loop()
+
+    assert await _finish_auto_reclaim(mgr, loop) is True
+
+    mgr.configure_bluetooth_audio.assert_called_once()
+    mgr._record_reconnect.assert_called_once()
+    mgr.host.start_subprocess.assert_awaited_once()
+    status_update = mgr.host.update_status.call_args[0][0]
+    assert status_update["bluetooth_connected"] is True
+
+
+async def test_finish_auto_reclaim_noop_when_manager_declines():
+    mgr = _make_mgr(reclaims=False)
+    loop = asyncio.get_running_loop()
+
+    assert await _finish_auto_reclaim(mgr, loop) is False
+
+    mgr.configure_bluetooth_audio.assert_not_called()
+    mgr.host.start_subprocess.assert_not_awaited()
+
+
+async def test_poll_auto_reclaim_skips_user_released_without_polling():
+    mgr = _make_mgr(reclaims=True)
+    mgr.host.get_status_value = lambda key: {"bt_released_by": "user"}.get(key)
+    mgr.is_device_connected = MagicMock()
+    loop = asyncio.get_running_loop()
+
+    assert await _poll_auto_reclaim(mgr, loop) is False
+    mgr.is_device_connected.assert_not_called()
+
+
+async def test_poll_auto_reclaim_respects_check_interval_cadence():
+    import time as _time
+
+    mgr = _make_mgr(reclaims=True)
+    mgr.host.get_status_value = lambda key: {"bt_released_by": "auto"}.get(key)
+    mgr.check_interval = 15
+    mgr.last_check = _time.time()  # checked just now
+    mgr.is_device_connected = MagicMock(return_value=True)
+    loop = asyncio.get_running_loop()
+
+    assert await _poll_auto_reclaim(mgr, loop) is False
+    mgr.is_device_connected.assert_not_called()
+
+
+async def test_poll_auto_reclaim_reclaims_when_speaker_is_back():
+    mgr = _make_mgr(reclaims=True)
+    mgr.host.get_status_value = lambda key: {"bt_released_by": "auto"}.get(key)
+    mgr.check_interval = 15
+    mgr.last_check = 0.0  # long overdue
+    mgr.is_device_connected = MagicMock(return_value=True)
+    loop = asyncio.get_running_loop()
+
+    assert await _poll_auto_reclaim(mgr, loop) is True
+    mgr.maybe_auto_reclaim.assert_called_once_with(connected=True)
+    mgr.host.start_subprocess.assert_awaited_once()
+
+
+async def test_poll_auto_reclaim_stays_released_while_speaker_off():
+    mgr = _make_mgr(reclaims=True)
+    mgr.host.get_status_value = lambda key: {"bt_released_by": "auto"}.get(key)
+    mgr.check_interval = 15
+    mgr.last_check = 0.0
+    mgr.is_device_connected = MagicMock(return_value=False)
+    loop = asyncio.get_running_loop()
+
+    assert await _poll_auto_reclaim(mgr, loop) is False
+    mgr.maybe_auto_reclaim.assert_not_called()

--- a/tests/unit/bluetooth/test_bt_manager.py
+++ b/tests/unit/bluetooth/test_bt_manager.py
@@ -650,7 +650,8 @@ def test_check_reconnect_churn_disables_management(bt_manager):
     assert bt_manager.management_enabled is False
     assert bt_manager.host.bt_management_enabled is False
     bt_manager.host.update_status.assert_called_once()
-    persist_released.assert_called_once_with("TestSpeaker", True)
+    # released_by="auto" marks the release as auto-reclaim-eligible (#349/#350)
+    persist_released.assert_called_once_with("TestSpeaker", True, released_by="auto")
 
 
 def test_cancel_reconnect_clears_runtime_reconnect_status(bt_manager):


### PR DESCRIPTION
Fixes #350, fixes #349. Also the groundwork for #357 (the HA `BT management` switch now rarely needs manual toggling).

## Problem
After an auto-release ("N consecutive failed reconnects" / churn guard) the only way back is the manual **Reclaim** button. The #312 connect-event wake never reaches released devices — it sits behind the `if not mgr.management_enabled` gate in both monitor loops (verified in `monitor.py`). A speaker switched off overnight needs a manual click every morning; users are writing HA YAML loops to work around it (see #350 comments).

## Design
The speaker **initiating a connection is the churn-safe signal**: a device stuck in a reconnect loop never presents a stable `Connected=yes` link.

- `BluetoothManager.maybe_auto_reclaim()` — state flip, gated on:
  - `bt_released_by == "auto"` — **operator releases are never auto-reclaimed**, including across restarts (`released_by` is now persisted to config.json/options.json);
  - an established link (D-Bus path reads `mgr.connected`, kept fresh by the PropertiesChanged handler even while released; polling path polls live state at `check_interval` cadence);
  - a 60 s quiet period after the release, so a churn-released speaker can't flap management on/off while still bouncing. Reclaim resets the churn window.
- Monitor helpers then mirror the external-reconnect path: configure audio → restart player → correct sibling sink routing.
- New `BT_MANAGEMENT_RECLAIMED` (info) event for the diagnostics timeline.

## Tests
15 new tests (manager gate matrix: auto/user/disconnected/quiet-period/churn-reset; monitor: dedicated-session flow, poll cadence, user-release short-circuit). One existing churn test assert updated for the extended `persist_device_released` signature. Full suite: **2685 passed**.

## Manual verification plan
e2e on HAOS VM 104: power off a speaker until auto-release fires, power it back on, verify reclaim + playback without touching the UI (will run before the 2.72.0 rc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)