### PR TITLE
fix: HA custom_component self-recovery + release-script robustness (PR4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Saved per-speaker volumes are no longer lost when the stored address differs only in letter case** from the configured device.
 - **Unrecognised on/off payloads sent to a switch entity are now rejected instead of defaulting to "on".**
 - **Corrected Home Assistant entity categories and internal status labels** that an earlier refactor had mangled, so the custom component's configuration entities are categorised correctly again.
+- **The Home Assistant integration now recovers on its own after the bridge restarts** — it pulls a fresh snapshot as soon as the event stream reconnects and polls on a slow safety-net interval, instead of showing stale entity states until the next event.
+- **Rotating or invalidating the bridge's API token now prompts Home Assistant to re-authenticate** instead of the integration silently freezing until a restart.
+- **Adding the integration is more robust to a slow or unreachable bridge** — connection timeouts and non-JSON responses during setup now surface a clean error instead of an unhandled failure.
+- **A malformed or partially-written addon configuration can no longer prevent startup**: the option translator preserves prior settings on a best-effort basis and writes the generated configuration atomically, so an interrupted run can't leave a truncated file.
+- **A Bluetooth adapter's saved name is no longer lost (or duplicated) when its address is stored in a different letter case** than the detected hardware.
 
 ### Security
 

--- a/custom_components/sendspin_bridge/api.py
+++ b/custom_components/sendspin_bridge/api.py
@@ -43,12 +43,16 @@ async def post(
         ) as resp:
             try:
                 body = await resp.json(content_type=None)
-            except aiohttp.ContentTypeError:
+            except (aiohttp.ContentTypeError, ValueError):
+                body = {}
+            # Guard before ``.get`` — a non-dict body (list / string) would
+            # otherwise raise ``AttributeError`` on the error path below.
+            if not isinstance(body, dict):
                 body = {}
             if resp.status >= 400:
                 raise HomeAssistantError(f"Bridge {path} returned {resp.status}: {body.get('error') or body}")
-            return body if isinstance(body, dict) else {}
-    except aiohttp.ClientError as exc:
+            return body
+    except (TimeoutError, aiohttp.ClientError) as exc:
         raise HomeAssistantError(f"Bridge {path} request failed: {exc}") from exc
 
 

--- a/custom_components/sendspin_bridge/config_flow.py
+++ b/custom_components/sendspin_bridge/config_flow.py
@@ -64,7 +64,8 @@ async def _validate_token(
             if resp.status != 200:
                 return False, None
             return True, await resp.json()
-    except aiohttp.ClientError:
+    except (TimeoutError, aiohttp.ClientError, ValueError):
+        # Timeout, connection error, or a non-JSON / malformed body.
         return False, None
 
 
@@ -199,7 +200,8 @@ async def _attempt_supervisor_pair(hass, host: str, port: int, use_https: bool) 
                 return None
             body = await resp.json()
             return body.get("token") if isinstance(body, dict) else None
-    except aiohttp.ClientError:
+    except (TimeoutError, aiohttp.ClientError, ValueError):
+        # Timeout, connection error, or a non-JSON / malformed body.
         return None
 
 

--- a/custom_components/sendspin_bridge/coordinator.py
+++ b/custom_components/sendspin_bridge/coordinator.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
@@ -39,6 +40,10 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# SSE drives near-real-time updates; this slow poll is only a safety net so
+# entities still recover if the event stream wedges without erroring.
+_SLOW_POLL_INTERVAL = timedelta(minutes=5)
+
 
 class SendspinDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Pulls state from the bridge and pushes entity-state deltas to HA."""
@@ -48,7 +53,7 @@ class SendspinDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hass,
             _LOGGER,
             name=f"{DOMAIN}:{entry.entry_id[:8]}",
-            update_interval=None,  # SSE drives updates; polling kicks in only on drops
+            update_interval=_SLOW_POLL_INTERVAL,  # SSE drives updates; slow poll is a safety net
         )
         self.entry = entry
         self.host: str = entry.data[CONF_HOST]
@@ -135,6 +140,11 @@ class SendspinDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
                     backoff = DEFAULT_RECONNECT_BACKOFF_SECS  # reset on success
 
+                    # Pull a fresh snapshot on every (re)connect: after a bridge
+                    # restart the stream reconnects but no event may arrive for a
+                    # while, so without this the entities stay stale.
+                    self.hass.async_create_task(self.async_request_refresh())
+
                     async for raw in resp.content:
                         if self._stopped.is_set():
                             break
@@ -169,6 +179,11 @@ class SendspinDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _async_log_auth_failure(self) -> None:
         _LOGGER.error("Bearer token rejected by bridge — re-pair the integration in HA")
+        # Start HA's reauth flow so the user is prompted to re-pair (e.g. after
+        # the bridge rotates/invalidates tokens) instead of the integration
+        # silently freezing until a restart.  Idempotent if one is already open.
+        self.entry.async_start_reauth(self.hass)
+        self.async_update_listeners()
 
     # -- Convenience accessors used by entity platforms ----------------
 

--- a/scripts/lint_changelog.py
+++ b/scripts/lint_changelog.py
@@ -80,6 +80,8 @@ _PRIVATE_FUNC_RE = re.compile(r"\b_[a-z][a-z0-9_]+\b")
 # ``_FILE_PATH_RE`` so they get the more specific message.
 _DOTTED_PRIVATE_RE = re.compile(r"\b(?:[A-Z][A-Za-z0-9]*|[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*)\.[a-z_][a-z0-9_]*\b")
 _FILE_PATH_RE = re.compile(r"\b[\w/]+\.(?:py|yml|yaml|toml|sh)\b")
+# Common English abbreviations the dotted-symbol regex would otherwise flag.
+_R7_ABBREVIATIONS = frozenset({"e.g", "i.e", "etc", "vs"})
 
 # Heading regex compatible with scripts/generate_ha_addon_variants.py:264.
 # Trailing free-form text after the date is tolerated for legacy entries
@@ -378,15 +380,18 @@ def check_r7_no_private_identifiers(text: str, sections: list[Section]) -> list[
                     )
                 )
                 continue
-            dotted = _DOTTED_PRIVATE_RE.search(scrubbed)
-            if dotted:
+            for dotted in _DOTTED_PRIVATE_RE.finditer(scrubbed):
+                token = dotted.group(0)
+                if token.lower().rstrip(".") in _R7_ABBREVIATIONS:
+                    continue  # English abbreviation, not an internal symbol
                 violations.append(
                     Violation(
                         "R7",
                         line_no,
-                        f"Internal symbol {dotted.group(0)!r} in bullet — describe behaviour, not implementation.",
+                        f"Internal symbol {token!r} in bullet — describe behaviour, not implementation.",
                     )
                 )
+                break
     return violations
 
 

--- a/scripts/translate_ha_config.py
+++ b/scripts/translate_ha_config.py
@@ -83,26 +83,35 @@ def _detect_adapters() -> list[dict]:
 
 def _merge_adapters(detected: list[dict], raw_adapters: list[dict]) -> list[dict]:
     """Merge user-supplied adapter options with detected hardware adapters."""
-    existing_macs = {a["mac"]: a for a in detected if a.get("mac")}
+
+    def _mac_key(a: dict) -> str | None:
+        mac = a.get("mac")
+        return mac.upper() if isinstance(mac, str) and mac else None
+
+    # Key by UPPER(mac) so a user option whose MAC differs only in case still
+    # matches the detected adapter (else it's dropped AND appended as a dupe).
+    existing_macs = {key: a for a in detected if (key := _mac_key(a))}
     existing_ids = {a["id"]: a for a in detected if a.get("id")}
     for a in raw_adapters:
         opt_name = (a.get("name") or "").strip()
         opt_class = (a.get("device_class") or "").strip()
-        if a.get("mac") and a["mac"] in existing_macs:
+        mac_key = _mac_key(a)
+        if mac_key and mac_key in existing_macs:
             if opt_name:
-                existing_macs[a["mac"]]["name"] = opt_name
+                existing_macs[mac_key]["name"] = opt_name
             if opt_class:
-                existing_macs[a["mac"]]["device_class"] = opt_class
+                existing_macs[mac_key]["device_class"] = opt_class
         elif a.get("id") and a["id"] in existing_ids:
             if opt_name:
                 existing_ids[a["id"]]["name"] = opt_name
             if opt_class:
                 existing_ids[a["id"]]["device_class"] = opt_class
-        elif a.get("mac") and a["mac"] not in existing_macs:
+        elif mac_key and mac_key not in existing_macs:
             entry = {"id": a.get("id", ""), "mac": a["mac"], "name": opt_name or a.get("id", "")}
             if opt_class:
                 entry["device_class"] = opt_class
             detected.append(entry)
+            existing_macs[mac_key] = entry
         elif a.get("id") and a["id"] not in existing_ids:
             entry = {"id": a["id"], "mac": a.get("mac", ""), "name": opt_name or a["id"]}
             if opt_class:
@@ -333,11 +342,19 @@ def main() -> None:
                 ):
                     if field not in dev and field in existing_devs[mac]:
                         dev[field] = existing_devs[mac][field]
-    except (FileNotFoundError, json.JSONDecodeError) as exc:
-        logger.debug("preserve existing device settings failed: %s", exc)
+    except Exception as exc:
+        # Best-effort preservation: a malformed / partially-typed existing
+        # config.json (non-int numeric, non-string MAC, …) must NOT crash the
+        # translator — that would brick addon startup.  Proceed with the freshly
+        # translated config instead.
+        logger.warning("Skipping preservation of existing config settings: %s", exc)
 
-    with open(CONFIG_FILE, "w") as f:
+    # Write atomically so an interrupted run (power loss / OOM kill) can't leave
+    # a truncated config.json that fails to parse on the next startup.
+    tmp_path = f"{CONFIG_FILE}.tmp"
+    with open(tmp_path, "w") as f:
         json.dump(config, f, indent=2)
+    os.replace(tmp_path, CONFIG_FILE)
 
     print(
         f"[translate_ha_config] Generated {CONFIG_FILE} with "

--- a/tests/integration/test_lint_changelog.py
+++ b/tests/integration/test_lint_changelog.py
@@ -183,6 +183,18 @@ def test_r7_fires_on_internal_file_path():
     assert "R7" in _rules_fired(text)
 
 
+def test_r7_silent_on_common_abbreviations():
+    """``e.g.`` / ``i.e.`` are English abbreviations, not internal symbols."""
+    text = _doc("### Changed\n- The scan retries flaky adapters (e.g. USB dongles) automatically.\n")
+    assert "R7" not in _rules_fired(text)
+
+
+def test_r7_still_fires_on_symbol_after_abbreviation():
+    """Whitelisting the abbreviation must not mask a real symbol later in the bullet."""
+    text = _doc("### Changed\n- e.g. the module.private_helper path changed.\n")
+    assert "R7" in _rules_fired(text)
+
+
 def test_r7_silent_on_url_with_dotted_tld():
     """`astral.sh` inside a markdown link target must not be flagged."""
     text = _doc("### Changed\n- Migrated to [uv](https://docs.astral.sh/uv/).\n")

--- a/tests/integration/test_translate_ha_config.py
+++ b/tests/integration/test_translate_ha_config.py
@@ -694,3 +694,40 @@ def test_translate_script_runs_as_direct_file() -> None:
 
     assert result.returncode == 0
     assert "options.json not found" in result.stdout
+
+
+# ── #20: preservation must not brick startup; write must be atomic ────────
+
+
+def test_malformed_existing_config_does_not_crash(tmp_path):
+    """A previous config.json with a bad value in a preserved field (here a
+    non-string adapter MAC) must not crash the translator — that would brick
+    addon startup.  It falls back to the freshly translated config."""
+    _write_json(tmp_path / "options.json", _minimal_options())
+    # Non-string MAC → ``.upper()`` in the preservation block would raise.
+    _write_json(tmp_path / "config.json", {"BLUETOOTH_ADAPTERS": [{"mac": 12345}]})
+
+    with patch("scripts.translate_ha_config._detect_adapters", return_value=[]):
+        main()  # must not raise
+
+    cfg = _read_json(tmp_path / "config.json")
+    assert "BLUETOOTH_DEVICES" in cfg  # a valid config was still written
+
+
+def test_write_leaves_no_temp_file(tmp_path):
+    """The atomic write must os.replace the temp file, not leave it behind."""
+    _write_json(tmp_path / "options.json", _minimal_options())
+    with patch("scripts.translate_ha_config._detect_adapters", return_value=[]):
+        main()
+    assert not (tmp_path / "config.json.tmp").exists()
+    assert (tmp_path / "config.json").exists()
+
+
+def test_merge_adapters_matches_mac_case_insensitively():
+    """A user option whose MAC differs only in letter case from the detected
+    adapter must update it in place, not append a duplicate."""
+    detected = [{"id": "hci0", "mac": "FC:58:FA:EB:08:6C", "name": "hci0"}]
+    user = [{"mac": "fc:58:fa:eb:08:6c", "name": "Living Room"}]
+    result = _merge_adapters(detected, user)
+    assert len(result) == 1
+    assert result[0]["name"] == "Living Room"

--- a/tests/unit/custom_components/test_config_flow_cta_url.py
+++ b/tests/unit/custom_components/test_config_flow_cta_url.py
@@ -406,3 +406,46 @@ def test_lan_host_display_host_none_keeps_ip(monkeypatch):
     hass = MagicMock()
     url = asyncio.run(_resolve_user_facing_url(hass, "192.168.10.10", 8080, display_host=None))
     assert url == "http://192.168.10.10:8080/"
+
+
+# ---------------------------------------------------------------------------
+# _validate_token error handling (#19): a timeout or a non-JSON / malformed
+# body must yield (False, None), never propagate and crash the config flow.
+# ---------------------------------------------------------------------------
+
+
+class _JsonRaisingResponse:
+    status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return False
+
+    async def json(self):
+        raise ValueError("malformed JSON body")
+
+
+class _JsonRaisingSession:
+    def get(self, *_a, **_k):
+        return _JsonRaisingResponse()
+
+
+class _TimeoutSession:
+    def get(self, *_a, **_k):
+        raise TimeoutError("connect timed out")
+
+
+def test_validate_token_handles_non_json_body(monkeypatch):
+    monkeypatch.setattr(_cf, "async_get_clientsession", lambda _hass: _JsonRaisingSession())
+    ok, projection = asyncio.run(_cf._validate_token(MagicMock(), "192.168.1.10", 8080, "tok"))
+    assert ok is False
+    assert projection is None
+
+
+def test_validate_token_handles_timeout(monkeypatch):
+    monkeypatch.setattr(_cf, "async_get_clientsession", lambda _hass: _TimeoutSession())
+    ok, projection = asyncio.run(_cf._validate_token(MagicMock(), "192.168.1.10", 8080, "tok"))
+    assert ok is False
+    assert projection is None

--- a/tests/unit/custom_components/test_coordinator.py
+++ b/tests/unit/custom_components/test_coordinator.py
@@ -1,0 +1,165 @@
+"""Tests for the HACS coordinator's SSE reconnect + reauth behaviour.
+
+The custom_component imports the Home Assistant runtime, which isn't available
+in the bridge test env, so we stub the HA modules the coordinator touches and
+load ``coordinator.py`` standalone (same approach as the config-flow tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_coordinator():
+    package_names = {"homeassistant", "homeassistant.helpers"}
+    for mod_name in (
+        "homeassistant",
+        "homeassistant.config_entries",
+        "homeassistant.core",
+        "homeassistant.exceptions",
+        "homeassistant.helpers",
+        "homeassistant.helpers.aiohttp_client",
+        "homeassistant.helpers.update_coordinator",
+    ):
+        if mod_name not in sys.modules:
+            mod = types.ModuleType(mod_name)
+            if mod_name in package_names:
+                mod.__path__ = []
+            sys.modules[mod_name] = mod
+
+    class _ConfigEntryAuthFailed(Exception):
+        pass
+
+    class _UpdateFailed(Exception):
+        pass
+
+    class _DataUpdateCoordinator:
+        def __init__(self, hass, logger, *, name=None, update_interval=None):
+            self.hass = hass
+            self.logger = logger
+            self.name = name
+            self.update_interval = update_interval
+            self.last_update_success = True
+            self.data = None
+
+        def __class_getitem__(cls, _item):
+            return cls
+
+        async def async_request_refresh(self):
+            return None
+
+        def async_update_listeners(self):
+            return None
+
+    sys.modules["homeassistant.exceptions"].ConfigEntryAuthFailed = _ConfigEntryAuthFailed
+    sys.modules["homeassistant.helpers.update_coordinator"].DataUpdateCoordinator = _DataUpdateCoordinator
+    sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed = _UpdateFailed
+    sys.modules["homeassistant.helpers.aiohttp_client"].async_get_clientsession = MagicMock()
+
+    # Load .const directly (no HA imports there).
+    const_path = ROOT / "custom_components" / "sendspin_bridge" / "const.py"
+    spec = importlib.util.spec_from_file_location("cc_const_coord_test", const_path)
+    const_mod = importlib.util.module_from_spec(spec)
+    sys.modules["cc_const_coord_test"] = const_mod
+    spec.loader.exec_module(const_mod)
+
+    pkg = types.ModuleType("coord_test_pkg")
+    pkg.__path__ = []
+    pkg.const = const_mod
+    sys.modules["coord_test_pkg"] = pkg
+    sys.modules["coord_test_pkg.const"] = const_mod
+
+    path = ROOT / "custom_components" / "sendspin_bridge" / "coordinator.py"
+    src = path.read_text(encoding="utf-8").replace("from .const", "from coord_test_pkg.const")
+    spec = importlib.util.spec_from_loader("coord_test_module", loader=None)
+    module = importlib.util.module_from_spec(spec)
+    module.__file__ = str(path)
+    sys.modules["coord_test_module"] = module
+    exec(compile(src, str(path), "exec"), module.__dict__)
+    return module
+
+
+_mod = _load_coordinator()
+SendspinDataUpdateCoordinator = _mod.SendspinDataUpdateCoordinator
+
+
+def _make_coordinator():
+    scheduled = []
+
+    hass = MagicMock()
+
+    def _create_task(coro, *a, **k):
+        # Close the coroutine so we don't leak an un-awaited warning.
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        scheduled.append(coro)
+        return MagicMock()
+
+    hass.async_create_task.side_effect = _create_task
+
+    entry = MagicMock()
+    entry.entry_id = "abcd1234efgh"
+    entry.data = {"host": "192.168.1.10", "port": 8080, "token": "tok", "use_https": False}
+
+    coord = SendspinDataUpdateCoordinator(hass, entry)
+    return coord, entry, hass, scheduled
+
+
+def test_slow_poll_interval_is_set_as_safety_net():
+    coord, _entry, _hass, _scheduled = _make_coordinator()
+    assert coord.update_interval == _mod._SLOW_POLL_INTERVAL
+    assert coord.update_interval is not None
+
+
+def test_auth_failure_starts_reauth():
+    """A rejected bearer token must trigger HA's reauth flow, not a silent
+    freeze."""
+    coord, entry, hass, _scheduled = _make_coordinator()
+    coord._async_log_auth_failure()
+    entry.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_sse_connect_refreshes_even_without_events():
+    """After a (re)connect the coordinator must pull a fresh snapshot even if
+    no event arrives — otherwise entities stay stale after a bridge restart."""
+    coord, _entry, _hass, scheduled = _make_coordinator()
+
+    class _Content:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            # No events; end the stream and stop the loop so _run_sse returns.
+            coord._stopped.set()
+            raise StopAsyncIteration
+
+    class _Resp:
+        status = 200
+        content = _Content()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+    class _Session:
+        def get(self, *_a, **_k):
+            return _Resp()
+
+    _mod.async_get_clientsession = MagicMock(return_value=_Session())
+
+    await asyncio.wait_for(coord._run_sse(), timeout=2)
+
+    # A refresh coroutine was scheduled on connect, with zero events delivered.
+    assert scheduled, "no refresh scheduled on SSE (re)connect"


### PR DESCRIPTION
**PR 4 of 4** (final) from the full-codebase audit remediation (HA custom_component & release scripts). Each fix is TDD.

## Fixes
| # | Fix |
|---|-----|
| #17 | The HA integration recovers on its own after a bridge restart — the coordinator pulls a fresh snapshot as soon as the SSE stream reconnects, and a slow `update_interval` polling safety net covers a wedged stream. (Was: stale entities until the next event arrived.) |
| #18 | A rejected bearer token now calls `async_start_reauth` so Home Assistant prompts to re-pair (token rotation), instead of the integration silently freezing until a restart. |
| #19 | `config_flow._validate_token` / `_attempt_supervisor_pair` and `api.post` widen error handling: timeouts and non-JSON/malformed bodies during setup surface a clean error instead of an unhandled crash; a non-dict body can no longer `AttributeError` on the error path. |
| #20 | `translate_ha_config` no longer bricks addon startup on a malformed prior `config.json` (best-effort preservation under a broad guard, logged at warning) and writes the generated config **atomically** (`tmp` + `os.replace`) so an interrupted run can't leave a truncated file. |

**Minors included:** the changelog linter no longer flags English abbreviations (`e.g.` / `i.e.`) as internal symbols; adapter merge matches MACs case-insensitively so a saved adapter name isn't lost or duplicated on a case mismatch.

## Deferred minors
To keep this PR focused, a few remaining component/script minors are **not** here and can follow up: dynamic entity add without a reload (coordinator listener diffing player ids across all platform files), `release_notes.py` fuzzy-dedup threshold for short bullets, `translate_landing.py` import-time `sys.exit`, and `demo/__init__` gating.

## Notes for reviewers
- HA custom_component tests run without `homeassistant` installed by stubbing the HA modules and loading the component via importlib (same pattern as the existing config-flow tests).

## Gate
- `uv run pytest -q` → **2778 passed**
- `uv run --with pip-audit pip-audit` → **clean** (no dependency changes)
- `uv run python scripts/lint_changelog.py CHANGELOG.md` → **clean**
- `ruff check` + `ruff format --check` (incl. `custom_components/` + `scripts/`) → **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)