### PR TITLE
fix: keep BT_MAX_RECONNECT_FAILS=0 from reverting to 5 on save (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The auto-disable reconnect threshold no longer resets to 5 when you set it to 0.** Saving `0` (unlimited reconnects, opting out of auto-disable) from the settings form used to be silently reverted to the default on the next save/reload, because a one-time upgrade migration re-ran on every save. The setting now sticks. ([#332](https://github.com/trudenboy/sendspin-bt-bridge/issues/332))
+
 ## [2.72.0-rc.3] - 2026-07-13
 
 ### Changed

--- a/src/sendspin_bridge/web/routes/api_config.py
+++ b/src/sendspin_bridge/web/routes/api_config.py
@@ -699,6 +699,20 @@ def api_config():
     if not isinstance(config, dict):
         return _error_response("Invalid JSON body")
 
+    # The settings form submits a partial config that never includes
+    # CONFIG_SCHEMA_VERSION.  Carry the on-disk schema version into the payload
+    # so the one-shot schema migrations (e.g. the BT_MAX_RECONNECT_FAILS 0 → 5
+    # default flip) don't re-fire on every save and silently overwrite the
+    # operator's choice (#332).
+    if "CONFIG_SCHEMA_VERSION" not in config and CONFIG_FILE.exists():
+        try:
+            with config_lock, open(CONFIG_FILE) as _schema_fh:
+                existing_schema = json.load(_schema_fh).get("CONFIG_SCHEMA_VERSION")
+            if existing_schema is not None:
+                config["CONFIG_SCHEMA_VERSION"] = existing_schema
+        except (json.JSONDecodeError, OSError):
+            pass
+
     validation = validate_uploaded_config(config, default_base_listen_port=resolve_base_listen_port())
     warnings = [{"field": issue.field, "message": issue.message} for issue in validation.warnings]
     if not validation.is_valid:

--- a/tests/unit/web/routes/test_api_endpoints.py
+++ b/tests/unit/web/routes/test_api_endpoints.py
@@ -1953,6 +1953,44 @@ def test_api_config_post_accepts_empty_manual_port_overrides(client, tmp_path, m
     assert saved["BASE_LISTEN_PORT"] is None
 
 
+def test_config_post_preserves_zero_reconnect_threshold(client, tmp_path, monkeypatch):
+    """#332: saving BT_MAX_RECONNECT_FAILS=0 from the settings form must stick.
+
+    The one-shot 0→5 migration must not re-fire just because the form payload
+    omits CONFIG_SCHEMA_VERSION — the handler carries the on-disk schema version
+    into the payload so migration sees the already-upgraded config.
+    """
+    import sendspin_bridge.web.routes.api_config as api_config_mod
+    from sendspin_bridge.config import CONFIG_SCHEMA_VERSION
+
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(api_config_mod, "CONFIG_FILE", cfg_file)
+    # Existing config is already schema-stamped (migration long since ran).
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "CONFIG_SCHEMA_VERSION": CONFIG_SCHEMA_VERSION,
+                "BT_MAX_RECONNECT_FAILS": 5,
+                "BLUETOOTH_DEVICES": [],
+            }
+        )
+    )
+    payload = {
+        "SENDSPIN_SERVER": "auto",
+        "BLUETOOTH_DEVICES": [],
+        "BLUETOOTH_ADAPTERS": [],
+        "TZ": "UTC",
+        "BT_MAX_RECONNECT_FAILS": 0,  # operator opts out of auto-disable
+        "AUTH_ENABLED": False,
+    }
+    resp = client.post("/api/config", data=json.dumps(payload), content_type="application/json")
+
+    assert resp.status_code == 200
+    saved = json.loads(cfg_file.read_text())
+    assert saved["BT_MAX_RECONNECT_FAILS"] == 0
+    assert saved["CONFIG_SCHEMA_VERSION"] == CONFIG_SCHEMA_VERSION
+
+
 def test_sync_ha_options_omits_manual_ports_when_unset(monkeypatch):
     import sendspin_bridge.web.routes.api_config as api_config_mod
 


### PR DESCRIPTION
Fixes #332.

## Root cause
`POST /api/config` (the settings form) runs full schema migration on the submitted payload via `validate_uploaded_config` → `migrate_config_payload`. The form payload **never includes `CONFIG_SCHEMA_VERSION`**, so the migration treated every save as a legacy (`<schema 3`) config and re-fired the *one-shot* `BT_MAX_RECONNECT_FAILS 0 → 5` default flip (the #263 auto-disable migration). An operator who set `0` (unlimited reconnects, opt out of auto-disable) had it silently reverted to `5` on the next save/reload.

Confirmed by reproducing locally: `migrate_config_payload({"BT_MAX_RECONNECT_FAILS": 0})` → warns *"Migrated … from 0 … to 5"* and returns 5.

## Fix
Carry the on-disk `CONFIG_SCHEMA_VERSION` into the payload before validation, so migration sees the already-upgraded config and skips the one-shot flip. The genuine legacy-upgrade path (loading an unstamped config from disk) is untouched and still one-shot — the migration unit tests all stay green.

## Test
`test_config_post_preserves_zero_reconnect_threshold` — pre-writes a schema-stamped config with value 5, POSTs 0, asserts the saved value stays 0. Fails before the fix (reverts to 5), passes after.

## Gate
`uv run pytest -q` → **2772 passed** · `ruff` + `lint_changelog` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)