### PR TITLE
Fix Bluetooth volume control for active sink inputs

### DIFF
--- a/src/sendspin_bridge/services/audio/pulse.py
+++ b/src/sendspin_bridge/services/audio/pulse.py
@@ -157,6 +157,26 @@ async def aset_sink_volume(sink_name: str, volume_pct: int) -> bool:
                     logger.warning("aset_sink_volume: sink %s not found", sink_name)
                     return False
                 await pulse.volume_set_all_chans(sink, volume_pct / 100.0)
+
+                # Playback may use an independent sink-input volume. In that
+                # case changing only the Bluetooth sink updates the reported
+                # volume but does not change the audible stream volume.
+                sink_inputs = await pulse.sink_input_list()
+                for sink_input in sink_inputs:
+                    if sink_input.sink != sink.index:
+                        continue
+
+                    await pulse.volume_set_all_chans(
+                        sink_input,
+                        volume_pct / 100.0,
+                    )
+                    logger.info(
+                        "Set sink-input %d volume to %d%% for sink %s",
+                        sink_input.index,
+                        volume_pct,
+                        sink_name,
+                    )
+
                 return True
     except Exception as exc:
         logger.debug(


### PR DESCRIPTION
## Summary

Fix Bluetooth volume control when playback uses a PulseAudio/PipeWire sink-input.

Previously the bridge only changed the Bluetooth sink volume. On some systems, the actual audible playback volume is controlled by the active sink-input, so the UI volume changed while the real speaker volume did not.

This change updates both:

- the Bluetooth sink volume;
- active sink-input volumes routed to that sink.

## Tested

- Ubuntu 22.04
- PipeWire / PulseAudio compatibility layer
- Music Assistant 2.9.6
- Sendspin BT Bridge 2.72.1

Verified with:

- Mifa F10
- Groove Cube

Volume control works from:

- Music Assistant
- Home Assistant
- Sendspin Web UI