### PR TITLE
fix: resolve hciN adapters via D-Bus address, not bluetoothctl list order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated `cryptography` to 50.0.0 to address `PYSEC-2026-3552` and restore a clean dependency audit.
+- Bluetooth adapter selection now resolves `hci1`, `hci2`, etc. via each adapter's own D-Bus address instead of counting positions in `bluetoothctl list` output, whose ordering does not always match ascending adapter index (for example after hot-plugging a second adapter). Previously this could silently select the wrong physical adapter.
 
 ## [2.73.4] - 2026-07-23
 

--- a/src/sendspin_bridge/bluetooth/dbus.py
+++ b/src/sendspin_bridge/bluetooth/dbus.py
@@ -55,6 +55,27 @@ def _dbus_get_battery_level(device_path: str | None) -> int | None:
         return None
 
 
+def _dbus_get_adapter_address(hci_name: str) -> str | None:
+    """Read org.bluez.Adapter1.Address for a given hci name (e.g. "hci0").
+
+    The BlueZ object path for an adapter is always ``/org/bluez/<hci_name>``,
+    which matches the kernel hci index exactly — unlike ``bluetoothctl list``
+    output order, which reflects BlueZ's registration order and is not
+    guaranteed to match ascending hci-index order (e.g. after hot-plugging a
+    second adapter). This is the unambiguous way to resolve hciN -> MAC.
+    """
+    if not hci_name or dbus is None:
+        return None
+    try:
+        bus = dbus.SystemBus()
+        adapter = bus.get_object("org.bluez", f"/org/bluez/{hci_name}")
+        props = dbus.Interface(adapter, "org.freedesktop.DBus.Properties")
+        return str(props.Get("org.bluez.Adapter1", "Address"))
+    except Exception as exc:
+        logger.debug("D-Bus adapter address read failed for %s: %s", hci_name, exc)
+        return None
+
+
 def _dbus_call_device_method(device_path: str | None, method_name: str) -> bool:
     """Call a BlueZ Device1 method synchronously via dbus-python.
 

--- a/src/sendspin_bridge/bluetooth/manager.py
+++ b/src/sendspin_bridge/bluetooth/manager.py
@@ -27,6 +27,7 @@ from sendspin_bridge.bluetooth.dbus import (
     AUDIO_SINK_UUIDS,
     _dbus_call_device_method,
     _dbus_connect_profile,
+    _dbus_get_adapter_address,
     _dbus_get_device_property,
     _dbus_get_device_uuids,
     _dbus_wait_services_resolved,
@@ -447,6 +448,16 @@ class BluetoothManager:
         Falls back to the original name if resolution fails."""
         if not adapter or not adapter.startswith("hci"):
             return adapter  # Already a MAC or empty string
+        # BlueZ's D-Bus object path for an adapter is always /org/bluez/<hciN>,
+        # which matches the kernel hci index unambiguously. Prefer this over
+        # counting lines in `bluetoothctl list`, whose ordering reflects
+        # BlueZ's adapter-registration order and is NOT guaranteed to match
+        # ascending hci-index order (e.g. after hot-plugging a second
+        # adapter, the newly-plugged one can be listed first).
+        dbus_addr = _dbus_get_adapter_address(adapter)
+        if dbus_addr:
+            logger.info("Resolved adapter %s → %s", adapter, dbus_addr)
+            return dbus_addr.upper()
         try:
             idx = int(adapter[3:])  # N from hciN
         except ValueError:

--- a/src/sendspin_bridge/bluetooth/manager.py
+++ b/src/sendspin_bridge/bluetooth/manager.py
@@ -448,6 +448,10 @@ class BluetoothManager:
         Falls back to the original name if resolution fails."""
         if not adapter or not adapter.startswith("hci"):
             return adapter  # Already a MAC or empty string
+        try:
+            idx = int(adapter[3:])  # N from hciN
+        except ValueError:
+            return adapter
         # BlueZ's D-Bus object path for an adapter is always /org/bluez/<hciN>,
         # which matches the kernel hci index unambiguously. Prefer this over
         # counting lines in `bluetoothctl list`, whose ordering reflects
@@ -458,10 +462,6 @@ class BluetoothManager:
         if dbus_addr:
             logger.info("Resolved adapter %s → %s", adapter, dbus_addr)
             return dbus_addr.upper()
-        try:
-            idx = int(adapter[3:])  # N from hciN
-        except ValueError:
-            return adapter
         try:
             result = subprocess.run(
                 ["bluetoothctl", "list"],

--- a/tests/unit/bluetooth/test_bt_manager.py
+++ b/tests/unit/bluetooth/test_bt_manager.py
@@ -110,6 +110,64 @@ def bt_manager():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# BluetoothManager._resolve_adapter_select — hciN -> MAC resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_adapter_select_prefers_dbus_over_bluetoothctl_list_order():
+    """Regression: bluetoothctl list ordering does not always match ascending
+    hci-index order (e.g. after hot-plugging a second adapter, the newer one
+    can be listed first). Resolution must use D-Bus's /org/bluez/<hciN>
+    object path, which matches the kernel index unambiguously, not the
+    position of a MAC within `bluetoothctl list` output."""
+    from sendspin_bridge.bluetooth.manager import BluetoothManager
+
+    # bluetoothctl list would (misleadingly) list hci1's real adapter first,
+    # so the old position-counting logic would resolve "hci1" -> hci0's MAC.
+    misleading_bluetoothctl_list = (
+        "Controller F0:2F:74:6B:3C:BD mass #2 [default]\nController 1C:79:2D:E5:AD:68 localhost \n"
+    )
+
+    def fake_dbus_get_adapter_address(hci_name):
+        return {"hci0": "1C:79:2D:E5:AD:68", "hci1": "F0:2F:74:6B:3C:BD"}.get(hci_name)
+
+    with (
+        patch("subprocess.check_output", return_value=""),
+        patch("subprocess.run", return_value=MagicMock(stdout=misleading_bluetoothctl_list)),
+        patch(
+            "sendspin_bridge.bluetooth.manager._dbus_get_adapter_address",
+            side_effect=fake_dbus_get_adapter_address,
+        ),
+    ):
+        mgr = BluetoothManager(
+            mac_address="AA:BB:CC:DD:EE:FF",
+            device_name="TestSpeaker",
+            adapter="hci1",
+        )
+
+    assert mgr._adapter_select == "F0:2F:74:6B:3C:BD"
+
+
+def test_resolve_adapter_select_falls_back_to_bluetoothctl_list_when_dbus_unavailable():
+    from sendspin_bridge.bluetooth.manager import BluetoothManager
+
+    bluetoothctl_list = "Controller AA:AA:AA:AA:AA:AA first [default]\nController BB:BB:BB:BB:BB:BB second \n"
+
+    with (
+        patch("subprocess.check_output", return_value=""),
+        patch("subprocess.run", return_value=MagicMock(stdout=bluetoothctl_list)),
+        patch("sendspin_bridge.bluetooth.manager._dbus_get_adapter_address", return_value=None),
+    ):
+        mgr = BluetoothManager(
+            mac_address="AA:BB:CC:DD:EE:FF",
+            device_name="TestSpeaker",
+            adapter="hci1",
+        )
+
+    assert mgr._adapter_select == "BB:BB:BB:BB:BB:BB"
+
+
 def test_bt_executor_pool_size():
     """The module-level thread pool must have at least 4 workers."""
     from sendspin_bridge.bluetooth.manager import _bt_executor
@@ -1888,6 +1946,46 @@ def test_dbus_connect_profile_returns_false_for_empty_device_path():
     ok, reason = bt_dbus._dbus_connect_profile(None, bt_dbus.A2DP_SINK_UUID)
     assert ok is False
     assert reason
+
+
+# ---------------------------------------------------------------------------
+# bt_dbus._dbus_get_adapter_address — hciN -> MAC resolution
+# ---------------------------------------------------------------------------
+
+
+def test_dbus_get_adapter_address_returns_none_when_dbus_module_missing():
+    import sendspin_bridge.bluetooth.dbus as bt_dbus
+
+    with patch.object(bt_dbus, "dbus", None):
+        assert bt_dbus._dbus_get_adapter_address("hci1") is None
+
+
+def test_dbus_get_adapter_address_returns_none_for_empty_name():
+    import sendspin_bridge.bluetooth.dbus as bt_dbus
+
+    assert bt_dbus._dbus_get_adapter_address("") is None
+
+
+def test_dbus_get_adapter_address_reads_address_property_at_hci_path():
+    """The BlueZ object path /org/bluez/<hciN> matches the kernel hci index
+    exactly, unlike bluetoothctl list's registration-order output."""
+    import sendspin_bridge.bluetooth.dbus as bt_dbus
+
+    fake_dbus = MagicMock()
+    fake_bus = MagicMock()
+    fake_adapter_obj = MagicMock()
+    fake_props = MagicMock()
+    fake_props.Get.return_value = "F0:2F:74:6B:3C:BD"
+    fake_dbus.SystemBus.return_value = fake_bus
+    fake_bus.get_object.return_value = fake_adapter_obj
+    fake_dbus.Interface.return_value = fake_props
+
+    with patch.object(bt_dbus, "dbus", fake_dbus):
+        addr = bt_dbus._dbus_get_adapter_address("hci1")
+
+    assert addr == "F0:2F:74:6B:3C:BD"
+    fake_bus.get_object.assert_called_once_with("org.bluez", "/org/bluez/hci1")
+    fake_props.Get.assert_called_once_with("org.bluez.Adapter1", "Address")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/bluetooth/test_bt_manager.py
+++ b/tests/unit/bluetooth/test_bt_manager.py
@@ -168,6 +168,17 @@ def test_resolve_adapter_select_falls_back_to_bluetoothctl_list_when_dbus_unavai
     assert mgr._adapter_select == "BB:BB:BB:BB:BB:BB"
 
 
+def test_resolve_adapter_select_skips_dbus_for_malformed_hci_name():
+    from sendspin_bridge.bluetooth.manager import BluetoothManager
+
+    manager = BluetoothManager.__new__(BluetoothManager)
+    with patch("sendspin_bridge.bluetooth.manager._dbus_get_adapter_address") as get_address:
+        resolved = manager._resolve_adapter_select("hci-not-an-index")
+
+    assert resolved == "hci-not-an-index"
+    get_address.assert_not_called()
+
+
 def test_bt_executor_pool_size():
     """The module-level thread pool must have at least 4 workers."""
     from sendspin_bridge.bluetooth.manager import _bt_executor


### PR DESCRIPTION
## Summary
- `BluetoothManager._resolve_adapter_select()` mapped `hciN` -> a MAC address by counting lines in `bluetoothctl list` output, assuming the Nth line always corresponds to `hciN`. That ordering reflects BlueZ's adapter-registration order, not ascending hci index, and can invert after hot-plugging a second adapter — silently selecting the wrong physical controller for a configured device.
- Resolve via BlueZ's `Adapter1.Address` D-Bus property at `/org/bluez/<hciN>` instead, since that object path matches the kernel hci index unambiguously. Falls back to the previous `bluetoothctl list`-based resolution only when `dbus-python` is unavailable.
- Found and confirmed live on a two-adapter host: selecting `hci1` in the UI kept silently reconnecting through the old `hci0` adapter instead.

## Test plan
- [x] New regression test proving resolution is correct even when `bluetoothctl list` output order is reversed relative to hci index (`test_resolve_adapter_select_prefers_dbus_over_bluetoothctl_list_order`)
- [x] New test for the dbus-unavailable fallback path (`test_resolve_adapter_select_falls_back_to_bluetoothctl_list_when_dbus_unavailable`)
- [x] New low-level tests for the new `_dbus_get_adapter_address()` helper
- [x] `uv run pytest tests/unit/bluetooth/test_bt_manager.py` — 128 passed
- [x] `ruff check` clean
- [x] `scripts/lint_changelog.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)