### PR TITLE
fix: detect missing BlueZ media endpoint directly instead of guessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `cryptography` to 50.0.0 to address `PYSEC-2026-3552` and restore a clean dependency audit.
 - Bluetooth adapter selection now resolves `hci1`, `hci2`, etc. via each adapter's own D-Bus address instead of counting positions in `bluetoothctl list` output, whose ordering does not always match ascending adapter index (for example after hot-plugging a second adapter). Previously this could silently select the wrong physical adapter.
+- Bluetooth sink-not-found diagnostics now ask BlueZ directly whether any local audio backend has registered an A2DP media endpoint for the device, instead of only guessing based on WirePlumber config files that aren't visible from inside a Docker container. This catches a real headless-host failure mode (WirePlumber running, but its Bluetooth monitor never registering an endpoint) that the previous file-based checks silently missed.
 
 ## [2.73.4] - 2026-07-23
 

--- a/src/sendspin_bridge/bluetooth/audio.py
+++ b/src/sendspin_bridge/bluetooth/audio.py
@@ -14,7 +14,7 @@ import os
 import subprocess
 from typing import TYPE_CHECKING
 
-from sendspin_bridge.bluetooth.dbus import _dbus_get_media_transport_state
+from sendspin_bridge.bluetooth.dbus import _dbus_get_media_transport_state, _dbus_has_media_endpoint
 from sendspin_bridge.config import CONFIG_FILE, save_device_sink
 from sendspin_bridge.config import config_lock as config_lock
 from sendspin_bridge.services.audio.pulse import (
@@ -357,7 +357,7 @@ def configure_bluetooth_audio(
         elif not success:
             logger.warning("Could not find Bluetooth sink for %s", mac_address)
             logger.warning("Audio may play from default device instead of Bluetooth")
-            _warn_pipewire_session(known_names)
+            _warn_pipewire_session(known_names, device_path)
 
         return success
 
@@ -366,7 +366,7 @@ def configure_bluetooth_audio(
         return False
 
 
-def _warn_pipewire_session(known_sink_names: set[str]) -> None:
+def _warn_pipewire_session(known_sink_names: set[str], device_path: str | None = None) -> None:
     """Log a targeted warning when sink discovery fails on PipeWire.
 
     On PipeWire, Bluetooth audio sinks are managed by WirePlumber which
@@ -396,10 +396,26 @@ def _warn_pipewire_session(known_sink_names: set[str]) -> None:
     if has_bt_sink:
         return
 
-    logger.warning(
-        "PipeWire detected but no Bluetooth audio sinks are visible. "
-        "WirePlumber (the Bluetooth policy manager) may not be running."
-    )
+    # The file-path checks below (_warn_wireplumber_logind /
+    # _warn_wireplumber_seat_monitoring) read host config files that are
+    # invisible from inside a Docker container — they only ever fire on
+    # bare-metal/LXC installs. _dbus_has_media_endpoint() instead asks
+    # BlueZ directly whether *any* local audio backend has registered
+    # A2DP support for this device — a signal that works the same way
+    # inside a container and is independent of audio server or
+    # WirePlumber version.
+    has_endpoint = _dbus_has_media_endpoint(device_path)
+    if has_endpoint is False:
+        logger.warning(
+            "BlueZ has no registered Bluetooth audio (A2DP) endpoint for this device at all — "
+            "this is independent of PipeWire/PulseAudio internals: no local audio backend has "
+            "claimed Bluetooth audio yet."
+        )
+    else:
+        logger.warning(
+            "PipeWire detected but no Bluetooth audio sinks are visible. "
+            "WirePlumber (the Bluetooth policy manager) may not be running."
+        )
     logger.warning(
         "On headless/server systems, run 'loginctl enable-linger <user>' "
         "so PipeWire + WirePlumber start at boot without a login session. "

--- a/src/sendspin_bridge/bluetooth/dbus.py
+++ b/src/sendspin_bridge/bluetooth/dbus.py
@@ -218,9 +218,17 @@ def _dbus_has_media_endpoint(device_path: str | None) -> bool | None:
         root = bus.get_object("org.bluez", "/")
         om = dbus.Interface(root, "org.freedesktop.DBus.ObjectManager")
         managed = om.GetManagedObjects()
-        prefix = device_path + "/sep"
+
+        device_ifaces = next((ifaces for path, ifaces in managed.items() if str(path) == device_path), None)
+        if not device_ifaces:
+            return None
+        device_props = device_ifaces.get("org.bluez.Device1")
+        if not device_props or not bool(device_props.get("ServicesResolved", False)):
+            return None
+
         for path, ifaces in managed.items():
-            if str(path).startswith(prefix) and "org.bluez.MediaEndpoint1" in ifaces:
+            parent, _, child = str(path).rpartition("/")
+            if parent == device_path and child.startswith("sep") and "org.bluez.MediaEndpoint1" in ifaces:
                 return True
         return False
     except Exception as exc:

--- a/src/sendspin_bridge/bluetooth/dbus.py
+++ b/src/sendspin_bridge/bluetooth/dbus.py
@@ -192,6 +192,42 @@ def _dbus_get_media_transport_state(device_path: str | None) -> str | None:
         return None
 
 
+def _dbus_has_media_endpoint(device_path: str | None) -> bool | None:
+    """Return whether BlueZ has negotiated a local ``MediaEndpoint1`` for *device_path*.
+
+    BlueZ creates ``<device_path>/sepN`` child objects implementing
+    ``org.bluez.MediaEndpoint1`` once it matches the peer's advertised AVDTP
+    stream endpoints against a *locally registered* media endpoint — normally
+    registered by PipeWire/WirePlumber's bluez5 SPA plugin or PulseAudio's
+    module-bluetooth-discover, via ``Media1.RegisterEndpoint``. If no audio
+    backend on the host has ever registered one, BlueZ has nothing to match
+    against and these objects never appear for that device, regardless of
+    which audio server or WirePlumber version is involved. This makes it a
+    much more direct, audio-server-agnostic signal than probing specific
+    config files for known headless-PipeWire footguns.
+
+    Returns ``True``/``False`` once BlueZ has had a chance to negotiate
+    (i.e. after ``Device1.ServicesResolved`` is true), ``None`` when
+    dbus-python is unavailable or the lookup fails — callers MUST treat
+    ``None`` as "unknown", not "no endpoint".
+    """
+    if not device_path or dbus is None:
+        return None
+    try:
+        bus = dbus.SystemBus()
+        root = bus.get_object("org.bluez", "/")
+        om = dbus.Interface(root, "org.freedesktop.DBus.ObjectManager")
+        managed = om.GetManagedObjects()
+        prefix = device_path + "/sep"
+        for path, ifaces in managed.items():
+            if str(path).startswith(prefix) and "org.bluez.MediaEndpoint1" in ifaces:
+                return True
+        return False
+    except Exception as exc:
+        logger.debug("D-Bus MediaEndpoint1 lookup failed: %s", exc)
+        return None
+
+
 def _dbus_get_media_transport_snapshot(device_path: str | None):
     """Return the best MediaTransport snapshot for *device_path*.
 

--- a/tests/unit/bluetooth/test_bt_manager.py
+++ b/tests/unit/bluetooth/test_bt_manager.py
@@ -2064,6 +2064,7 @@ def test_dbus_has_media_endpoint_returns_true_when_sep_object_present():
     fake_bus = MagicMock()
     fake_om = MagicMock()
     fake_om.GetManagedObjects.return_value = {
+        device_path: {"org.bluez.Device1": {"ServicesResolved": True}},
         f"{device_path}/sep1": {"org.bluez.MediaEndpoint1": {"UUID": "0000110b-..."}},
     }
     fake_dbus.SystemBus.return_value = fake_bus
@@ -2072,10 +2073,43 @@ def test_dbus_has_media_endpoint_returns_true_when_sep_object_present():
     with patch.object(bt_dbus, "dbus", fake_dbus):
         assert bt_dbus._dbus_has_media_endpoint(device_path) is True
 
+    fake_om.GetManagedObjects.assert_called_once_with()
 
-def test_dbus_has_media_endpoint_returns_false_when_no_sep_objects():
-    """No org.bluez.MediaEndpoint1 anywhere under the device path means no
-    local audio backend has registered A2DP support with BlueZ at all."""
+
+def test_dbus_has_media_endpoint_returns_none_until_services_resolved():
+    import sendspin_bridge.bluetooth.dbus as bt_dbus
+
+    device_path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
+    fake_dbus = MagicMock()
+    fake_om = MagicMock()
+    fake_om.GetManagedObjects.return_value = {
+        device_path: {"org.bluez.Device1": {"ServicesResolved": False}},
+    }
+    fake_dbus.Interface.return_value = fake_om
+
+    with patch.object(bt_dbus, "dbus", fake_dbus):
+        assert bt_dbus._dbus_has_media_endpoint(device_path) is None
+
+    fake_om.GetManagedObjects.assert_called_once_with()
+
+
+def test_dbus_has_media_endpoint_returns_none_when_device_missing_from_snapshot():
+    import sendspin_bridge.bluetooth.dbus as bt_dbus
+
+    device_path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
+    fake_dbus = MagicMock()
+    fake_om = MagicMock()
+    fake_om.GetManagedObjects.return_value = {}
+    fake_dbus.Interface.return_value = fake_om
+
+    with patch.object(bt_dbus, "dbus", fake_dbus):
+        assert bt_dbus._dbus_has_media_endpoint(device_path) is None
+
+    fake_om.GetManagedObjects.assert_called_once_with()
+
+
+def test_dbus_has_media_endpoint_returns_false_when_resolved_device_has_no_sep_objects():
+    """An endpoint for another device must not affect the requested device."""
     import sendspin_bridge.bluetooth.dbus as bt_dbus
 
     device_path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
@@ -2083,13 +2117,16 @@ def test_dbus_has_media_endpoint_returns_false_when_no_sep_objects():
     fake_bus = MagicMock()
     fake_om = MagicMock()
     fake_om.GetManagedObjects.return_value = {
-        device_path: {"org.bluez.Device1": {"Connected": True}},
+        device_path: {"org.bluez.Device1": {"Connected": True, "ServicesResolved": True}},
+        "/org/bluez/hci0/dev_11_22_33_44_55_66/sep1": {"org.bluez.MediaEndpoint1": {}},
     }
     fake_dbus.SystemBus.return_value = fake_bus
     fake_dbus.Interface.return_value = fake_om
 
     with patch.object(bt_dbus, "dbus", fake_dbus):
         assert bt_dbus._dbus_has_media_endpoint(device_path) is False
+
+    fake_om.GetManagedObjects.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/bluetooth/test_bt_manager.py
+++ b/tests/unit/bluetooth/test_bt_manager.py
@@ -560,6 +560,42 @@ def test_warn_pipewire_session_silent_when_bt_sinks_present():
     mock_warn.assert_not_called()
 
 
+def test_warn_pipewire_session_emits_definitive_message_when_no_media_endpoint():
+    """When BlueZ confirms no MediaEndpoint1 is registered for the device,
+    the warning should say so directly rather than guessing "WirePlumber
+    may not be running" — a message that doesn't apply to PulseAudio and
+    is misleading when WirePlumber is running but its Bluetooth monitor
+    just never registered an endpoint (headless seat-monitoring gap)."""
+    import sendspin_bridge.bluetooth.audio as bt_audio
+
+    with (
+        patch("sendspin_bridge.services.audio.pulse.get_server_name", return_value="PulseAudio (on PipeWire 1.0.5)"),
+        patch.object(bt_audio, "_dbus_has_media_endpoint", return_value=False),
+        patch.object(bt_audio.logger, "warning") as mock_warn,
+    ):
+        bt_audio._warn_pipewire_session({"sendspin_fallback"}, "/org/bluez/hci0/dev_AA_BB")
+
+    messages = [call.args[0] for call in mock_warn.call_args_list]
+    assert any("no registered Bluetooth audio" in m for m in messages)
+    assert not any("WirePlumber (the Bluetooth policy manager) may not be running" in m for m in messages)
+
+
+def test_warn_pipewire_session_keeps_generic_message_when_endpoint_check_unknown():
+    """Regression guard: when the D-Bus MediaEndpoint1 check can't determine
+    an answer (e.g. no device_path yet), the original generic message must
+    still fire so behavior for existing callers is unchanged."""
+    import sendspin_bridge.bluetooth.audio as bt_audio
+
+    with (
+        patch("sendspin_bridge.services.audio.pulse.get_server_name", return_value="PulseAudio (on PipeWire 1.0.5)"),
+        patch.object(bt_audio.logger, "warning") as mock_warn,
+    ):
+        bt_audio._warn_pipewire_session({"sendspin_fallback"})
+
+    messages = [call.args[0] for call in mock_warn.call_args_list]
+    assert any("WirePlumber (the Bluetooth policy manager) may not be running" in m for m in messages)
+
+
 def test_warn_pipewire_session_also_checks_wireplumber_logind():
     """_warn_pipewire_session calls _warn_wireplumber_logind when PipeWire has no BT sinks."""
     import sendspin_bridge.bluetooth.audio as bt_audio
@@ -1997,6 +2033,63 @@ def test_dbus_get_adapter_address_reads_address_property_at_hci_path():
     assert addr == "F0:2F:74:6B:3C:BD"
     fake_bus.get_object.assert_called_once_with("org.bluez", "/org/bluez/hci1")
     fake_props.Get.assert_called_once_with("org.bluez.Adapter1", "Address")
+
+
+# ---------------------------------------------------------------------------
+# bt_dbus._dbus_has_media_endpoint — BlueZ MediaEndpoint1 registration check
+# ---------------------------------------------------------------------------
+
+
+def test_dbus_has_media_endpoint_returns_none_when_dbus_module_missing():
+    import sendspin_bridge.bluetooth.dbus as bt_dbus
+
+    with patch.object(bt_dbus, "dbus", None):
+        assert bt_dbus._dbus_has_media_endpoint("/org/bluez/hci0/dev_AA_BB") is None
+
+
+def test_dbus_has_media_endpoint_returns_none_for_empty_device_path():
+    import sendspin_bridge.bluetooth.dbus as bt_dbus
+
+    assert bt_dbus._dbus_has_media_endpoint(None) is None
+
+
+def test_dbus_has_media_endpoint_returns_true_when_sep_object_present():
+    """A <device_path>/sepN object implementing MediaEndpoint1 means BlueZ
+    successfully matched the peer's AVDTP capabilities against a locally
+    registered audio backend endpoint."""
+    import sendspin_bridge.bluetooth.dbus as bt_dbus
+
+    device_path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
+    fake_dbus = MagicMock()
+    fake_bus = MagicMock()
+    fake_om = MagicMock()
+    fake_om.GetManagedObjects.return_value = {
+        f"{device_path}/sep1": {"org.bluez.MediaEndpoint1": {"UUID": "0000110b-..."}},
+    }
+    fake_dbus.SystemBus.return_value = fake_bus
+    fake_dbus.Interface.return_value = fake_om
+
+    with patch.object(bt_dbus, "dbus", fake_dbus):
+        assert bt_dbus._dbus_has_media_endpoint(device_path) is True
+
+
+def test_dbus_has_media_endpoint_returns_false_when_no_sep_objects():
+    """No org.bluez.MediaEndpoint1 anywhere under the device path means no
+    local audio backend has registered A2DP support with BlueZ at all."""
+    import sendspin_bridge.bluetooth.dbus as bt_dbus
+
+    device_path = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
+    fake_dbus = MagicMock()
+    fake_bus = MagicMock()
+    fake_om = MagicMock()
+    fake_om.GetManagedObjects.return_value = {
+        device_path: {"org.bluez.Device1": {"Connected": True}},
+    }
+    fake_dbus.SystemBus.return_value = fake_bus
+    fake_dbus.Interface.return_value = fake_om
+
+    with patch.object(bt_dbus, "dbus", fake_dbus):
+        assert bt_dbus._dbus_has_media_endpoint(device_path) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The existing "sink not found" diagnostics (`_warn_wireplumber_logind` / `_warn_wireplumber_seat_monitoring`) only guess at root cause by reading WirePlumber config files on the host filesystem (`~/.config/wireplumber/`, `/usr/share/wireplumber/`). Those paths are invisible from inside a Docker container, so the checks silently return "unknown" and stay quiet in the deployment mode this project mainly targets — masking exactly the failure they were built to catch.
- Found live on a real headless host: WirePlumber was running fine, but its Bluetooth monitor never registered an A2DP media endpoint with BlueZ (a logind seat-state gating issue on WirePlumber 0.5+, unrelated to the `with-logind`/`seat-monitoring` config the existing checks look for). Every Bluetooth connection failed with bluetoothd's `Protocol not available`, and the app's own diagnostics never said anything more specific than the generic "WirePlumber may not be running" guess — which, on closer inspection, doesn't even apply to PulseAudio-only hosts.
- Add `_dbus_has_media_endpoint()`: asks BlueZ directly (via the same D-Bus socket already bind-mounted into the container) whether any `org.bluez.MediaEndpoint1` was negotiated for the connected device's `<device_path>/sepN` objects. This is audio-server-and-version-agnostic — same signal whether the host runs PipeWire+WirePlumber (any version), PulseAudio, or anything else — and needs no host filesystem access.
- When this check definitively confirms no endpoint exists, `_warn_pipewire_session()` now says so directly instead of the previous generic, sometimes-misleading message. The existing file-based checks are left in place as best-effort extra detail for bare-metal/LXC installs where those paths happen to be readable.

## Test plan
- [x] New unit tests for `_dbus_has_media_endpoint()`: dbus-unavailable, empty path, endpoint present, endpoint absent
- [x] New tests proving `_warn_pipewire_session()` picks the definitive message when the D-Bus check confirms no endpoint, and keeps the original generic message when the check is indeterminate (regression guard for existing callers)
- [x] `uv run pytest tests/unit/bluetooth/test_bt_manager.py` — 129 passed
- [x] `uv run pytest` (full suite) — 2957 passed
- [x] `ruff check` clean
- [x] `scripts/lint_changelog.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
