### PR TITLE
fix: surface headless-socket guidance for the "unknown" audio state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `cryptography` to 50.0.0 to address `PYSEC-2026-3552` and restore a clean dependency audit.
 - Bluetooth adapter selection now resolves `hci1`, `hci2`, etc. via each adapter's own D-Bus address instead of counting positions in `bluetoothctl list` output, whose ordering does not always match ascending adapter index (for example after hot-plugging a second adapter). Previously this could silently select the wrong physical adapter.
 - Bluetooth sink-not-found diagnostics now ask BlueZ directly whether any local audio backend has registered an A2DP media endpoint for the device, instead of only guessing based on WirePlumber config files that aren't visible from inside a Docker container. This catches a real headless-host failure mode (WirePlumber running, but its Bluetooth monitor never registering an endpoint) that the previous file-based checks silently missed.
+- Onboarding and diagnostics now recognize a headless host where the PulseAudio/PipeWire socket was never created (not just refused), and surface the same `loginctl enable-linger` guidance for it.
 
 ## [2.73.4] - 2026-07-23
 

--- a/docs-site/src/content/docs/installation/docker.mdx
+++ b/docs-site/src/content/docs/installation/docker.mdx
@@ -284,7 +284,7 @@ pactl list sinks short | grep -i bluez
   The bridge logs a specific warning when it detects PipeWire but no Bluetooth sinks are visible: *"WirePlumber (the Bluetooth policy manager) may not be running"*. This is the most common cause of "sink not found" on headless PipeWire installations.
 </Aside>
 
-**Option B — disable WirePlumber's `with-logind`** if connections also drop on logout, or churn every ~10 s even with linger enabled. See [WirePlumber `with-logind` endpoint churn](#wireplumber-with-logind-endpoint-churn) below for the per-user override.
+**Option B — disable WirePlumber's logind integration** if connections also drop on logout, churn every ~10 s even with linger enabled, or Bluetooth never initializes at all (`wpctl status` shows no devices under `Audio`). See [WirePlumber `with-logind` endpoint churn](#wireplumber-with-logind-endpoint-churn) below — the exact fix depends on your WirePlumber version (0.4.x vs 0.5+), both are covered there.
 
 ### WirePlumber `with-logind` endpoint churn
 
@@ -313,7 +313,54 @@ sudo journalctl -u bluetooth --since '30 sec ago' | grep -i unregistered
 ```
 
 <Aside type="caution">
-  The `with-logind` option is only present in WirePlumber 0.4.x (Ubuntu 24.04, Fedora 39). WirePlumber 0.5+ uses a different configuration system. If you are on WirePlumber 0.5+, check the [WirePlumber documentation](https://pipewire.pages.freedesktop.org/wireplumber/) for the equivalent setting.
+  The `with-logind` option above is only present in WirePlumber 0.4.x (Ubuntu 24.04, Fedora 39). If you're on WirePlumber 0.5+ (Fedora 40+, newer Ubuntu/Debian), see the next section instead — the config system and the correct fix are both different.
+</Aside>
+
+### WirePlumber 0.5+: Bluetooth never initializes on headless hosts
+
+Check your version with `wireplumber --version`. WirePlumber 0.5's Bluetooth monitor script (`monitors/bluez.lua`) only creates the actual BlueZ device monitor when logind reports the session's seat state as `active`:
+
+```lua
+function startStopMonitor(seat_state)
+  if seat_state == "active" then
+    monitor = createMonitor()
+  elseif monitor then
+    monitor:deactivate(Feature.SpaDevice.ENABLED)
+  end
+end
+```
+
+A headless session kept alive via `loginctl enable-linger` (see Option A above) reaches seat state `online`, but **never** `active` — that state normally requires a focused console/display login, which a lingering background session never has. As a result `createMonitor()` is never called, BlueZ never gets an A2DP sink media endpoint registered, and every Bluetooth connection eventually fails.
+
+**Symptom:** `wpctl status` shows no devices at all under `Audio` (only a synthetic `Dummy Output` sink), even though `bluetoothctl` shows the speaker as paired and briefly `Connected: yes`. `sudo journalctl -u bluetooth` shows the connection failing with:
+
+```
+bluetoothd[...]: src/service.c:btd_service_connect() a2dp-sink profile connect failed for <MAC>: Protocol not available
+```
+
+**Fix:** disable BlueZ seat-monitoring for the profile WirePlumber actually runs (`main`, unless you've customized `WIREPLUMBER_PROFILE`):
+
+```bash
+mkdir -p ~/.config/wireplumber/wireplumber.conf.d
+cat > ~/.config/wireplumber/wireplumber.conf.d/99-headless-bluez-no-seat-monitoring.conf << 'EOF'
+wireplumber.profiles = {
+  main = {
+    monitor.bluez.seat-monitoring = disabled
+  }
+}
+EOF
+systemctl --user restart wireplumber
+```
+
+Verify Bluetooth devices now appear:
+
+```bash
+wpctl status
+# Should list a "bluez5" device under Audio > Devices once a speaker is paired/connected
+```
+
+<Aside type="tip">
+  Setting `support.logind = disabled` (as seen in some stock WirePlumber configs) does **not** fix this on its own — that property only applies to the `main-systemwide`/`main-embedded` profiles, not the default `main` profile most `systemd --user` installs actually run. Confirm your active profile with `WIREPLUMBER_DEBUG=3 wireplumber` (foreground, briefly) and check for `parsing & loading components for profile [...]` in the output before assuming a fix applies.
 </Aside>
 
 ## Applying configuration changes

--- a/src/sendspin_bridge/services/diagnostics/guidance_issue_registry.py
+++ b/src/sendspin_bridge/services/diagnostics/guidance_issue_registry.py
@@ -76,6 +76,13 @@ ISSUE_REGISTRY: dict[str, GuidanceIssueDefinition] = {
         severity="error",
         default_reason_codes=("pa_socket_refused",),
     ),
+    "pa_socket_missing": GuidanceIssueDefinition(
+        key="pa_socket_missing",
+        layer="audio",
+        priority=32,
+        severity="error",
+        default_reason_codes=("pa_socket_missing",),
+    ),
     "missing_sink": GuidanceIssueDefinition(
         key="missing_sink",
         layer="sink_verification",

--- a/src/sendspin_bridge/services/diagnostics/onboarding_assistant.py
+++ b/src/sendspin_bridge/services/diagnostics/onboarding_assistant.py
@@ -623,16 +623,40 @@ def build_onboarding_assistant_snapshot(
             )
         )
     elif audio_system == "unknown":
+        socket_path = str(audio.get("socket") or "")
+        socket_exists = bool(audio.get("socket_exists"))
+        details = {"sinks": audio_sinks, "socket": socket_path or None, "socket_exists": socket_exists}
+        if socket_path and not socket_exists:
+            details["reason_code"] = "pa_socket_missing"
+            summary = (
+                f"Audio socket {socket_path} is configured but does not exist on this host — "
+                "no PulseAudio/PipeWire server has ever bound it."
+            )
+            actions = [
+                "On headless hosts, PipeWire/PulseAudio only start on login. Run "
+                "`sudo loginctl enable-linger <user>` for the audio user so the socket exists at boot.",
+                "Reboot the host (or `systemctl --user start pipewire.socket pipewire-pulse.socket wireplumber.service`) and restart the container.",
+                "See docs: https://trudenboy.github.io/sendspin-bt-bridge/installation/docker/#headless-pipewire-bluetooth-sinks-not-appearing-after-reboot",
+            ]
+        elif not socket_path:
+            summary = "No PulseAudio or PipeWire server was detected — `PULSE_SERVER` is not set."
+            actions = [
+                "Set `PULSE_SERVER` to the host's PulseAudio/PipeWire socket path and mount that socket into the container.",
+                "See docs: https://trudenboy.github.io/sendspin-bt-bridge/installation/docker/#requirements for the required volume mounts and environment variables.",
+            ]
+        else:
+            summary = "No PulseAudio or PipeWire server was detected."
+            actions = [
+                "Open diagnostics to confirm the runtime can reach PulseAudio or PipeWire.",
+                "Verify the audio socket mount and `PULSE_SERVER` configuration.",
+            ]
         checks.append(
             OnboardingCheck(
                 key="audio",
                 status="error",
-                summary="No PulseAudio or PipeWire server was detected.",
-                details={"sinks": audio_sinks},
-                actions=[
-                    "Open diagnostics to confirm the runtime can reach PulseAudio or PipeWire.",
-                    "Verify the audio socket mount and `PULSE_SERVER` configuration.",
-                ],
+                summary=summary,
+                details=details,
+                actions=actions,
             )
         )
     elif audio_sinks == 0:

--- a/src/sendspin_bridge/services/diagnostics/operator_guidance.py
+++ b/src/sendspin_bridge/services/diagnostics/operator_guidance.py
@@ -484,7 +484,7 @@ def _audio_backend_issue(
             )
         actions = [
             "On the Docker host: `sudo loginctl enable-linger <user>` (the user whose UID matches AUDIO_UID).",
-            "Reboot the host, or restart the user session's audio units (`systemctl --user start pipewire.socket pipewire.service wireplumber.service`).",
+            "Reboot the host, or restart the user session's audio units (`systemctl --user start pipewire.socket pipewire-pulse.socket pipewire.service wireplumber.service`).",
             "Restart the bridge container once the server is up.",
             "Docs: https://trudenboy.github.io/sendspin-bt-bridge/installation/docker/#headless-pipewire-bluetooth-sinks-not-appearing-after-reboot",
         ]

--- a/src/sendspin_bridge/services/diagnostics/operator_guidance.py
+++ b/src/sendspin_bridge/services/diagnostics/operator_guidance.py
@@ -468,13 +468,20 @@ def _audio_backend_issue(
 
     # Headless PipeWire / PulseAudio — only relevant outside HA addon where
     # the operator can run `loginctl enable-linger` on the Docker host.
-    if reason_code == "pa_socket_refused" and not is_ha_addon_runtime():
+    if reason_code in ("pa_socket_refused", "pa_socket_missing") and not is_ha_addon_runtime():
         socket_path = str(details.get("socket") or "")
-        summary = (
-            f"The audio socket ({socket_path or 'configured path'}) is mounted into the container, "
-            "but the host's PipeWire/PulseAudio server refused the connection. This is the classic "
-            "symptom of a headless host without user-session lingering."
-        )
+        if reason_code == "pa_socket_refused":
+            summary = (
+                f"The audio socket ({socket_path or 'configured path'}) is mounted into the container, "
+                "but the host's PipeWire/PulseAudio server refused the connection. This is the classic "
+                "symptom of a headless host without user-session lingering."
+            )
+        else:
+            summary = (
+                f"The audio socket ({socket_path or 'configured path'}) is configured but does not exist "
+                "on the host yet — no PipeWire/PulseAudio server has ever bound it. This is the classic "
+                "symptom of a headless host without user-session lingering."
+            )
         actions = [
             "On the Docker host: `sudo loginctl enable-linger <user>` (the user whose UID matches AUDIO_UID).",
             "Reboot the host, or restart the user session's audio units (`systemctl --user start pipewire.socket pipewire.service wireplumber.service`).",
@@ -482,7 +489,7 @@ def _audio_backend_issue(
             "Docs: https://trudenboy.github.io/sendspin-bt-bridge/installation/docker/#headless-pipewire-bluetooth-sinks-not-appearing-after-reboot",
         ]
         return {
-            "key": "pa_socket_refused",
+            "key": reason_code,
             "title": "Audio server unreachable — enable user lingering",
             "summary": summary,
             "details": details,

--- a/tests/unit/services/diagnostics/test_guidance_issue_registry.py
+++ b/tests/unit/services/diagnostics/test_guidance_issue_registry.py
@@ -3,6 +3,15 @@ from __future__ import annotations
 from sendspin_bridge.services.diagnostics.guidance_issue_registry import ISSUE_REGISTRY
 
 
+def test_pa_socket_missing_is_classified_as_high_signal_audio_error():
+    definition = ISSUE_REGISTRY["pa_socket_missing"]
+
+    assert definition.layer == "audio"
+    assert definition.priority == 32
+    assert definition.severity == "error"
+    assert definition.default_reason_codes == ("pa_socket_missing",)
+
+
 def test_sink_system_muted_issue_definition_exists():
     assert "sink_system_muted" in ISSUE_REGISTRY
     defn = ISSUE_REGISTRY["sink_system_muted"]

--- a/tests/unit/services/diagnostics/test_onboarding_assistant.py
+++ b/tests/unit/services/diagnostics/test_onboarding_assistant.py
@@ -33,6 +33,52 @@ def test_onboarding_audio_unreachable_socket_emits_pa_socket_refused_reason_code
     assert "loginctl enable-linger" in joined_actions
 
 
+def test_onboarding_audio_unknown_socket_missing_emits_pa_socket_missing_reason_code():
+    snapshot = build_onboarding_assistant_snapshot(
+        config={"BLUETOOTH_DEVICES": [], "PULSE_LATENCY_MSEC": 200},
+        preflight={
+            "audio": {
+                "system": "unknown",
+                "sinks": 0,
+                "socket": "unix:/run/user/1000/pulse/native",
+                "socket_exists": False,
+            },
+            "bluetooth": {"controller": True, "paired_devices": 0},
+        },
+        devices=[],
+        ma_connected=False,
+        runtime_mode="production",
+    )
+
+    audio = next(check for check in snapshot.checks if check.key == "audio")
+    assert audio.status == "error"
+    assert audio.details["reason_code"] == "pa_socket_missing"
+    assert audio.details["socket"] == "unix:/run/user/1000/pulse/native"
+    assert "unix:/run/user/1000/pulse/native" in audio.summary
+    joined_actions = " ".join(audio.actions)
+    assert "loginctl enable-linger" in joined_actions
+
+
+def test_onboarding_audio_unknown_without_socket_skips_missing_reason_code():
+    snapshot = build_onboarding_assistant_snapshot(
+        config={"BLUETOOTH_DEVICES": [], "PULSE_LATENCY_MSEC": 200},
+        preflight={
+            "audio": {"system": "unknown", "sinks": 0},
+            "bluetooth": {"controller": True, "paired_devices": 0},
+        },
+        devices=[],
+        ma_connected=False,
+        runtime_mode="production",
+    )
+
+    audio = next(check for check in snapshot.checks if check.key == "audio")
+    assert audio.status == "error"
+    assert audio.details.get("reason_code") != "pa_socket_missing"
+    joined_actions = " ".join(audio.actions)
+    assert "loginctl enable-linger" not in joined_actions
+    assert "PULSE_SERVER" in joined_actions
+
+
 def test_onboarding_bluetooth_step_cross_references_audio_when_both_fail():
     """When BT preflight fails (no controller) AND the user-scoped audio socket is
     mounted but unreachable, both symptoms usually share one root cause: the

--- a/tests/unit/services/diagnostics/test_operator_guidance_pa_linger.py
+++ b/tests/unit/services/diagnostics/test_operator_guidance_pa_linger.py
@@ -66,6 +66,104 @@ def _audio_unreachable_onboarding() -> dict:
     }
 
 
+def _audio_unknown_socket_missing_onboarding() -> dict:
+    return {
+        "checks": [
+            {
+                "key": "audio",
+                "status": "error",
+                "summary": "Audio socket unix:/run/user/1000/pulse/native is configured but does not exist yet.",
+                "details": {
+                    "system": "unknown",
+                    "socket": "unix:/run/user/1000/pulse/native",
+                    "socket_exists": False,
+                    "reason_code": "pa_socket_missing",
+                },
+                "actions": ["existing action"],
+            }
+        ],
+        "checklist": {
+            "overall_status": "error",
+            "progress_percent": 28,
+            "headline": "Next recommended step: Verify audio backend",
+            "summary": "The bridge cannot reach its audio backend right now.",
+            "current_step_key": "audio",
+            "current_step_title": "Verify audio backend",
+            "primary_action": {"key": "open_diagnostics", "label": "Open diagnostics"},
+            "checkpoints": [],
+            "steps": [
+                {"key": "runtime_access", "title": "Verify runtime host access", "status": "ok", "stage": "complete"},
+                {"key": "bluetooth", "title": "Check Bluetooth access", "status": "ok", "stage": "complete"},
+                {
+                    "key": "audio",
+                    "title": "Verify audio backend",
+                    "status": "error",
+                    "stage": "current",
+                    "summary": "Audio socket does not exist yet.",
+                    "details": {"reason_code": "pa_socket_missing"},
+                    "actions": ["existing action"],
+                },
+                {
+                    "key": "bridge_control",
+                    "title": "Make a speaker available",
+                    "status": "warning",
+                    "stage": "upcoming",
+                },
+                {
+                    "key": "sink_verification",
+                    "title": "Attach your first speaker",
+                    "status": "warning",
+                    "stage": "upcoming",
+                },
+            ],
+        },
+        "counts": {"configured_devices": 1, "connected_devices": 0, "sink_ready_devices": 0},
+    }
+
+
+def test_pa_socket_missing_emits_linger_issue_in_standalone(monkeypatch):
+    import sendspin_bridge.services.diagnostics.operator_guidance as module
+    from sendspin_bridge.services.diagnostics.operator_guidance import build_operator_guidance_snapshot
+
+    monkeypatch.setattr(module, "is_ha_addon_runtime", lambda: False)
+
+    snapshot = build_operator_guidance_snapshot(
+        config={"BLUETOOTH_ADAPTERS": [{"id": "hci0"}], "BLUETOOTH_DEVICES": [{"mac": "AA"}]},
+        onboarding_assistant=_audio_unknown_socket_missing_onboarding(),
+        recovery_assistant={"summary": {"summary": "Audio backend unreachable."}},
+        startup_progress={"status": "complete"},
+        devices=[],
+    )
+
+    data = snapshot.to_dict()
+    audio_group = next((g for g in data["issue_groups"] if g["key"] == "pa_socket_missing"), None)
+    assert audio_group is not None, f"issue_groups lacked pa_socket_missing: {data['issue_groups']}"
+    assert audio_group["severity"] == "error"
+    assert "linger" in audio_group["title"].lower()
+    summary_text = audio_group["summary"].lower()
+    assert "socket" in summary_text
+    assert audio_group["primary_action"]["key"] == "open_diagnostics"
+
+
+def test_pa_socket_missing_suppressed_in_ha_addon(monkeypatch):
+    import sendspin_bridge.services.diagnostics.operator_guidance as module
+    from sendspin_bridge.services.diagnostics.operator_guidance import build_operator_guidance_snapshot
+
+    monkeypatch.setattr(module, "is_ha_addon_runtime", lambda: True)
+
+    snapshot = build_operator_guidance_snapshot(
+        config={"BLUETOOTH_ADAPTERS": [{"id": "hci0"}], "BLUETOOTH_DEVICES": [{"mac": "AA"}]},
+        onboarding_assistant=_audio_unknown_socket_missing_onboarding(),
+        recovery_assistant={"summary": {"summary": "Audio backend unreachable."}},
+        startup_progress={"status": "complete"},
+        devices=[],
+    )
+
+    data = snapshot.to_dict()
+    keys = [g["key"] for g in data["issue_groups"]]
+    assert "pa_socket_missing" not in keys, f"linger-specific issue must be suppressed in HA addon: {keys}"
+
+
 def test_pa_socket_refused_emits_linger_issue_in_standalone(monkeypatch):
     import sendspin_bridge.services.diagnostics.operator_guidance as module
     from sendspin_bridge.services.diagnostics.operator_guidance import build_operator_guidance_snapshot

--- a/tests/unit/services/diagnostics/test_operator_guidance_pa_linger.py
+++ b/tests/unit/services/diagnostics/test_operator_guidance_pa_linger.py
@@ -143,6 +143,14 @@ def test_pa_socket_missing_emits_linger_issue_in_standalone(monkeypatch):
     summary_text = audio_group["summary"].lower()
     assert "socket" in summary_text
     assert audio_group["primary_action"]["key"] == "open_diagnostics"
+    issue = module._audio_backend_issue(
+        _audio_unknown_socket_missing_onboarding(),
+        all_devices_globally_disabled=False,
+    )
+    assert issue is not None
+    actions = " ".join(issue["actions"])
+    for unit in ("pipewire.socket", "pipewire-pulse.socket", "pipewire.service", "wireplumber.service"):
+        assert unit in actions
 
 
 def test_pa_socket_missing_suppressed_in_ha_addon(monkeypatch):


### PR DESCRIPTION
## Summary
- The onboarding "Verify audio backend" check has three `audio_system` states: `pipewire`/`pulseaudio` (reachable), `unreachable` (a socket file exists but the connection was refused), and `unknown` (no socket was ever found at all — `PULSE_SERVER` unset, or its target path never came into existence).
- `unreachable` already surfaces the configured socket path plus `loginctl enable-linger` guidance, since a refused connection on a headless host is the classic symptom of a PipeWire/PulseAudio user session that only starts on login. `unknown` is arguably the *more common* headless symptom — it's what you get on a host that has never had an active login session at all, so the socket was never created in the first place — but it only showed a generic "Open diagnostics" message with no socket path and no linger hint. Reported live by a user stuck on exactly this screen.
- Split the `unknown` branch the same way `unreachable` already is: when a socket path was configured but doesn't exist, show that path and the linger remediation (`reason_code=pa_socket_missing`, now also recognized by `operator_guidance.py`'s linger banner); when no socket was configured at all, say so explicitly instead of implying a socket-mount problem that isn't actually present.
- Also documents the WirePlumber 0.5+ seat-monitoring fix (companion to #411, which fixes the underlying BlueZ media-endpoint detection) in the headless PipeWire troubleshooting section — previously it only covered the WirePlumber 0.4.x `with-logind` config and explicitly said the 0.5+ equivalent wasn't filled in yet.

## Test plan
- [x] New test: `unknown` + configured socket path that doesn't exist → `reason_code=pa_socket_missing`, socket path in summary, linger action present
- [x] New test: `unknown` + no socket configured at all → no `pa_socket_missing` reason code, no linger text, `PULSE_SERVER` mentioned instead
- [x] New `operator_guidance` tests mirroring the existing `pa_socket_refused` banner coverage for the new `pa_socket_missing` reason code, including HA-addon suppression
- [x] `uv run pytest tests/unit/services/diagnostics/test_onboarding_assistant.py tests/unit/services/diagnostics/test_operator_guidance_pa_linger.py` — 23 passed
- [x] `uv run pytest` (full suite) — 2951 passed
- [x] `ruff check` clean
- [x] `scripts/lint_changelog.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
