### PR TITLE
fix: six defects found by the architecture audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The live status stream no longer stops working after a monitoring probe or link preview touches it: such requests used to occupy a listener slot they never released, and four of them left the web UI and the Home Assistant integration silently frozen until the bridge restarted.
+- Saving settings while the configuration file is unreadable or corrupted now fails with an explanation instead of reporting success and replacing the file — which previously erased the web UI password, the session secret and the stored Music Assistant tokens.
+- The Bluetooth scan cooldown now starts when a scan finishes rather than when it begins, so the controller actually gets its rest period between scans.
+
+### Security
+- Login lockout is now counted per user behind a Home Assistant ingress or any reverse proxy given as an address range. Previously everyone behind such a proxy shared one lockout counter, so five failed logins by one person locked out the whole household.
+- Album art fetched through the bridge no longer carries the Music Assistant access token to a redirect target on a different host.
+
 ## [2.75.0-rc.1] - 2026-08-19
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ dev = [
     "pytest>=9.0.3,<10.0.0",
     "pytest-asyncio>=1.3.0,<2.0.0",
     "pytest-xdist>=3.6.0,<4.0",
+    # ``[tool.pytest.ini_options].timeout`` is inert without this plugin —
+    # pytest only warns ("Unknown config option: timeout"), so a hung test
+    # used to burn CI's 10-minute job budget without naming a culprit.
+    "pytest-timeout>=2.3,<3.0",
     # CI's _test.yml runs pytest with --cov; keep coverage opt-in via the
     # dev extra so contributors can `uv run pytest --cov=...` locally too.
     "pytest-cov>=5.0,<8.0",
@@ -131,6 +135,9 @@ known-first-party = ["sendspin_bridge"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 timeout = 60
+# ``thread`` works with pytest-xdist and does not need signal support;
+# ``signal`` would only fire on the main thread of each worker.
+timeout_method = "thread"
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/src/sendspin_bridge/web/routes/api_bt.py
+++ b/src/sendspin_bridge/web/routes/api_bt.py
@@ -1146,8 +1146,6 @@ def _annotate_scan_conflicts(devices: list[dict]) -> None:
 def _run_bt_scan(job_id: str, adapter: str = "", audio_only: bool = True) -> None:
     """Perform BT scan in a background thread and store result in state."""
     global _last_scan_completed
-    # Apply cooldown to every scan attempt, even if later enrichment fails.
-    _last_scan_completed = time.monotonic()
     try:
         adapter_macs = _resolve_scan_adapter_macs(adapter)
 
@@ -1217,6 +1215,13 @@ def _run_bt_scan(job_id: str, adapter: str = "", audio_only: bool = True) -> Non
     except Exception:
         logger.exception("BT scan failed")
         finish_scan_job(job_id, {"devices": [], "error": "Bluetooth scan failed"})
+    finally:
+        # The cooldown is the adapter's rest period, so it runs from the end
+        # of the scan window.  Stamping it on entry made it expire during the
+        # 15 s discovery window itself — the 10 s gate never held anyone back.
+        # The ``finally`` keeps the original intent that every attempt counts,
+        # even one that failed during enrichment.
+        _last_scan_completed = time.monotonic()
 
 
 # ---------------------------------------------------------------------------

--- a/src/sendspin_bridge/web/routes/api_config.py
+++ b/src/sendspin_bridge/web/routes/api_config.py
@@ -883,34 +883,49 @@ def api_config():
 
     CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
     with config_lock:
-        existing = {}
+        existing: dict = {}
         if CONFIG_FILE.exists():
+            # The preserve loop below is the only thing carrying the password
+            # hash, the session secret and the MA tokens across a settings
+            # save, and ``write_config_file`` replaces the file wholesale.  A
+            # swallowed read error therefore used to mean "silently erase the
+            # operator's credentials and answer 200" — fail the request
+            # instead and leave the file untouched.
             try:
                 with open(CONFIG_FILE) as f:
-                    existing = json.load(f)
-                # Preserve keys that are never submitted via the form
-                for key in (
-                    "LAST_VOLUMES",
-                    "LAST_SINKS",
-                    "HA_ADAPTER_AREA_MAP",
-                    "AUTH_PASSWORD_HASH",
-                    "SECRET_KEY",
-                    "MA_AUTH_PROVIDER",
-                    "MA_TOKEN_INSTANCE_HOSTNAME",
-                    "MA_TOKEN_LABEL",
-                    "MA_ACCESS_TOKEN",
-                    "MA_REFRESH_TOKEN",
-                ):
-                    if key in existing and key not in config:
-                        config[key] = existing[key]
-                # The form pre-fills MA_API_TOKEN with the stored value.
-                # Empty string = user explicitly cleared it → do NOT restore.
-                # (No implicit preserve needed — the field is always submitted.)
-                # Preserve MA_USERNAME if not submitted
-                if not config.get("MA_USERNAME") and existing.get("MA_USERNAME"):
-                    config["MA_USERNAME"] = existing["MA_USERNAME"]
-            except Exception as _exc:
-                logger.debug("Could not read existing config for merge: %s", _exc)
+                    loaded = json.load(f)
+            except OSError as exc:
+                logger.error("Refusing to save config: %s is unreadable (%s)", CONFIG_FILE, exc)
+                return _error_response("Cannot read the existing configuration; refusing to overwrite it", 500)
+            except ValueError as exc:
+                logger.error("Refusing to save config: %s is not valid JSON (%s)", CONFIG_FILE, exc)
+                return _error_response("The existing configuration is corrupted; refusing to overwrite it", 500)
+            if not isinstance(loaded, dict):
+                logger.error("Refusing to save config: %s does not contain a JSON object", CONFIG_FILE)
+                return _error_response("The existing configuration is corrupted; refusing to overwrite it", 500)
+            existing = loaded
+
+            # Preserve keys that are never submitted via the form
+            for key in (
+                "LAST_VOLUMES",
+                "LAST_SINKS",
+                "HA_ADAPTER_AREA_MAP",
+                "AUTH_PASSWORD_HASH",
+                "SECRET_KEY",
+                "MA_AUTH_PROVIDER",
+                "MA_TOKEN_INSTANCE_HOSTNAME",
+                "MA_TOKEN_LABEL",
+                "MA_ACCESS_TOKEN",
+                "MA_REFRESH_TOKEN",
+            ):
+                if key in existing and key not in config:
+                    config[key] = existing[key]
+            # The form pre-fills MA_API_TOKEN with the stored value.
+            # Empty string = user explicitly cleared it → do NOT restore.
+            # (No implicit preserve needed — the field is always submitted.)
+            # Preserve MA_USERNAME if not submitted
+            if not config.get("MA_USERNAME") and existing.get("MA_USERNAME"):
+                config["MA_USERNAME"] = existing["MA_USERNAME"]
 
         # HA_INTEGRATION password round-trip semantics — under the lock so a
         # parallel ``POST /api/config`` from another Waitress thread can't

--- a/src/sendspin_bridge/web/routes/api_status.py
+++ b/src/sendspin_bridge/web/routes/api_status.py
@@ -571,14 +571,26 @@ def api_status_stream():
     ``notify_status_changed()`` call either happens before we start waiting
     (so ``wait_for`` returns immediately) or wakes us up cleanly.
     """
-    global _sse_count
     with _sse_lock:
         if _sse_count >= _MAX_SSE:
             return 'data: {"error": "too many listeners"}\n\n', 503, {"Content-Type": "text/event-stream"}
-        _sse_count += 1
 
     def _generate():
+        # The listener slot is claimed *inside* the generator, not in the
+        # view.  Flask auto-registers HEAD for every GET rule and Werkzeug
+        # closes a HEAD response's generator without ever iterating it, so a
+        # slot reserved in the view would never reach the ``finally`` below —
+        # ``_MAX_SSE`` HEAD requests used to disable live status permanently.
+        # The check above stays for the 503 status code, which can only be
+        # set before the response body starts.
         global _sse_count
+        with _sse_lock:
+            accepted = _sse_count < _MAX_SSE
+            if accepted:
+                _sse_count += 1
+        if not accepted:
+            yield 'data: {"error": "too many listeners"}\n\n'
+            return
         try:
 
             def _build_snapshot():

--- a/src/sendspin_bridge/web/routes/auth.py
+++ b/src/sendspin_bridge/web/routes/auth.py
@@ -180,7 +180,11 @@ def _get_forwarded_client_ip() -> str:
 def _get_rate_limit_client_id() -> str:
     """Return the best-available brute-force bucket key for this request."""
     peer = (request.remote_addr or "").strip()
-    if peer and peer in _get_trusted_proxies():
+    # CIDR-aware: the HA ingress peer lives somewhere in 172.30.32.0/23 and
+    # never equals a trust-set entry literally.  An exact-string test bucketed
+    # every ingress user under the proxy's own IP, so one user's five failed
+    # logins locked out everyone behind the proxy.
+    if peer and _peer_in_trust_set(peer, _get_trusted_proxies()):
         forwarded_ip = _get_forwarded_client_ip()
         if forwarded_ip:
             return forwarded_ip

--- a/src/sendspin_bridge/web/routes/ma_playback.py
+++ b/src/sendspin_bridge/web/routes/ma_playback.py
@@ -16,6 +16,7 @@ import uuid
 from flask import Response, jsonify, request
 
 from sendspin_bridge.services.bluetooth.device_registry import get_device_registry_snapshot
+from sendspin_bridge.services.infrastructure.url_safety import safe_build_opener
 from sendspin_bridge.services.lifecycle.async_job_state import create_async_job, finish_async_job, get_async_job
 from sendspin_bridge.services.lifecycle.bridge_runtime_state import get_main_loop
 from sendspin_bridge.services.lifecycle.status_snapshot import build_device_snapshot_pairs
@@ -144,6 +145,36 @@ def _build_ma_prediction_patch(action: str, value) -> dict:
         except (TypeError, ValueError):
             return {}
     return {}
+
+
+class _ArtworkRedirectHandler(_ur.HTTPRedirectHandler):
+    """Follow artwork redirects, but never carry the MA token off-origin.
+
+    ``urllib``'s default handler copies request headers onto the redirected
+    request, and the artwork HMAC only covers the *initial* URL — so a
+    MA-origin URL that 302s to a provider CDN used to deliver the bridge's
+    bearer token to that CDN.  Redirects still work; the credential simply
+    stops at the origin it was issued for.
+    """
+
+    def __init__(self, ma_url: str):
+        self._origin = _origin_of(ma_url)
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is None:
+            return None
+        if _origin_of(newurl) != self._origin:
+            new_req.remove_header("Authorization")
+            # ``Request`` lowercases unredirected headers separately.
+            new_req.unredirected_hdrs.pop("Authorization", None)
+        return new_req
+
+
+def _origin_of(url: str) -> tuple[str, str]:
+    """Return the ``(scheme, netloc)`` origin of *url*, case-folded."""
+    parsed = _up.urlparse(url)
+    return (parsed.scheme.lower(), parsed.netloc.lower())
 
 
 def _resolve_ma_artwork_url(raw_url: str) -> tuple[str, bool]:
@@ -319,8 +350,10 @@ def api_ma_artwork():
 
     _ARTWORK_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
 
+    opener = safe_build_opener(_ArtworkRedirectHandler(_ma_url or ""))
+
     try:
-        with _ur.urlopen(req, timeout=15) as resp:
+        with opener.open(req, timeout=15) as resp:
             cl = resp.headers.get("Content-Length")
             if cl and int(cl) > _ARTWORK_MAX_BYTES:
                 return Response("Artwork too large", status=413)

--- a/tests/unit/web/routes/test_api_config_preserve_secrets.py
+++ b/tests/unit/web/routes/test_api_config_preserve_secrets.py
@@ -1,0 +1,101 @@
+"""``POST /api/config`` must never trade an unreadable config for lost secrets.
+
+The merge step reads the on-disk config to carry forward the keys the settings
+form never submits — the password hash, the session secret, the MA tokens, the
+per-device volumes.  When that read failed the handler used to log at DEBUG and
+continue with an empty ``existing``, then overwrite the file wholesale: one
+truncated or unreadable ``config.json`` and the operator's credentials were
+gone, with the endpoint still answering ``{"success": true}``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+from flask import Flask
+
+_MAC = "AA:BB:CC:DD:EE:FF"
+
+_SECRETS = {
+    "AUTH_PASSWORD_HASH": "v1:600000:aa:bb",
+    "SECRET_KEY": "0123456789abcdef",
+    "MA_ACCESS_TOKEN": "access-token-value",
+    "MA_REFRESH_TOKEN": "refresh-token-value",
+}
+
+_DEVICE = {"mac": _MAC, "player_name": "Speaker", "enabled": True}
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "BRIDGE_NAME": "TestBridge",
+                "BLUETOOTH_DEVICES": [_DEVICE],
+                "BLUETOOTH_ADAPTERS": [],
+                "LAST_VOLUMES": {_MAC: 42},
+                **_SECRETS,
+            }
+        )
+    )
+
+    import sendspin_bridge.config as config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", cfg_file)
+
+    for mod_name in ("sendspin_bridge.web.routes.api_config",):
+        if mod_name in sys.modules and getattr(sys.modules[mod_name], "__file__", None) is None:
+            sys.modules.pop(mod_name)
+
+    import sendspin_bridge.web.routes.api_config as api_config_module
+
+    monkeypatch.setattr(api_config_module, "CONFIG_FILE", cfg_file)
+
+    from sendspin_bridge.web.routes.api_config import config_bp
+
+    app = Flask(__name__)
+    app.secret_key = "testing"
+    app.config["TESTING"] = True
+    app.register_blueprint(config_bp)
+    return app.test_client(), cfg_file, api_config_module
+
+
+def test_corrupt_existing_config_fails_the_request(client):
+    """A truncated config.json must abort the save, not wipe the secrets."""
+    cl, cfg_file, _ = client
+    cfg_file.write_text('{"BRIDGE_NAME": "TestBridge", "SECRET_KEY": "0123456')
+    before = cfg_file.read_text()
+
+    resp = cl.post("/api/config", json={"BRIDGE_NAME": "Renamed", "BLUETOOTH_DEVICES": [_DEVICE]})
+
+    assert resp.status_code == 500
+    assert (resp.get_json() or {}).get("success") is not True
+    assert cfg_file.read_text() == before
+
+
+def test_successful_save_preserves_never_submitted_secrets(client):
+    cl, cfg_file, _ = client
+
+    resp = cl.post("/api/config", json={"BRIDGE_NAME": "Renamed", "BLUETOOTH_DEVICES": [_DEVICE]})
+
+    assert resp.status_code == 200
+    saved = json.loads(cfg_file.read_text())
+    assert saved["BRIDGE_NAME"] == "Renamed"
+    for key, value in _SECRETS.items():
+        assert saved[key] == value
+    assert saved["LAST_VOLUMES"] == {_MAC: 42}
+
+
+def test_first_run_without_a_config_file_still_saves(client):
+    cl, cfg_file, _ = client
+    cfg_file.unlink()
+
+    resp = cl.post("/api/config", json={"BRIDGE_NAME": "FreshInstall"})
+
+    assert resp.status_code == 200
+    assert json.loads(cfg_file.read_text())["BRIDGE_NAME"] == "FreshInstall"

--- a/tests/unit/web/routes/test_api_endpoints.py
+++ b/tests/unit/web/routes/test_api_endpoints.py
@@ -3863,14 +3863,19 @@ def test_ma_artwork_proxy_fetches_same_origin_ma_artwork(client):
             raw_url = "/api/image/123"
             signature = sign_artwork_url(raw_url)
 
-            def _fake_urlopen(req, timeout=0):
-                opened["url"] = req.full_url
-                opened["auth"] = req.headers.get("Authorization")
-                opened["accept"] = req.headers.get("Accept")
-                opened["timeout"] = timeout
-                return _FakeResponse()
+            class _FakeOpener:
+                def open(self, req, timeout=0):
+                    opened["url"] = req.full_url
+                    opened["auth"] = req.headers.get("Authorization")
+                    opened["accept"] = req.headers.get("Accept")
+                    opened["timeout"] = timeout
+                    return _FakeResponse()
 
-            mp.setattr(ma_playback_mod._ur, "urlopen", _fake_urlopen)
+            # The proxy fetches through ``safe_build_opener`` (SSRF re-check
+            # per hop + a redirect handler that strips the MA bearer token
+            # when the origin changes), so the seam is the opener, not
+            # ``urllib.request.urlopen``.
+            mp.setattr(ma_playback_mod, "safe_build_opener", lambda *h, **kw: _FakeOpener())
             resp = client.get(f"/api/ma/artwork?url=%2Fapi%2Fimage%2F123&sig={signature}")
 
         assert resp.status_code == 200
@@ -3923,7 +3928,14 @@ def test_ma_artwork_proxy_fetches_signed_external_provider_artwork_without_ma_to
     try:
         fake_resp = io.BytesIO(b"\x89PNG\r\n\x1a\n")
         fake_resp.headers = {"Content-Type": "image/png", "Content-Length": "8"}
-        with patch("sendspin_bridge.web.routes.ma_playback._ur.urlopen", return_value=fake_resp) as mock_open:
+        opened_reqs = []
+
+        class _FakeOpener:
+            def open(self, req, timeout=0):
+                opened_reqs.append(req)
+                return fake_resp
+
+        with patch("sendspin_bridge.web.routes.ma_playback.safe_build_opener", lambda *h, **kw: _FakeOpener()):
             resp = client.get(
                 "/api/ma/artwork?url="
                 "https%3A%2F%2Favatars.yandex.net%2Fget-music-content%2F49876%2Fab027f9c.a.37173-2%2F1000x1000"
@@ -3931,7 +3943,7 @@ def test_ma_artwork_proxy_fetches_signed_external_provider_artwork_without_ma_to
             )
             assert resp.status_code == 200
             # Should NOT include Authorization header for external URLs
-            called_req = mock_open.call_args[0][0]
+            called_req = opened_reqs[0]
             assert "Authorization" not in called_req.headers
     finally:
         state.set_ma_api_credentials("", "")

--- a/tests/unit/web/routes/test_api_status_sse_slots.py
+++ b/tests/unit/web/routes/test_api_status_sse_slots.py
@@ -1,0 +1,76 @@
+"""SSE listener-slot accounting for ``/api/status/stream``.
+
+Flask auto-registers ``HEAD`` for every ``GET`` rule, and Werkzeug discards
+the body of a HEAD response without iterating the generator.  A slot that is
+reserved in the view but released in the generator's ``finally`` therefore
+leaks on every HEAD request, and ``_MAX_SSE`` such requests disable live
+status for the rest of the process lifetime.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(tmp_path, monkeypatch):
+    import sendspin_bridge.config as config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    (tmp_path / "config.json").write_text(json.dumps({}))
+
+
+@pytest.fixture()
+def status_mod(monkeypatch):
+    # test_ingress_middleware.py installs module stubs at collection time;
+    # drop one if it is still in place so we import the real module.
+    if "sendspin_bridge.web.routes.api_status" in sys.modules:
+        stub = sys.modules["sendspin_bridge.web.routes.api_status"]
+        if getattr(stub, "__file__", None) is None:
+            sys.modules.pop("sendspin_bridge.web.routes.api_status")
+
+    import sendspin_bridge.web.routes.api_status as mod
+
+    monkeypatch.setattr(mod, "_sse_count", 0)
+    return mod
+
+
+@pytest.fixture()
+def client(status_mod):
+    app = Flask(__name__)
+    app.register_blueprint(status_mod.status_bp)
+    return app.test_client()
+
+
+def test_head_requests_do_not_consume_listener_slots(client, status_mod):
+    for _ in range(status_mod._MAX_SSE):
+        response = client.head("/api/status/stream")
+        response.close()
+        assert response.status_code == 200
+
+    assert status_mod._sse_count == 0
+
+
+def test_stream_still_available_after_head_requests(client, status_mod):
+    for _ in range(status_mod._MAX_SSE):
+        client.head("/api/status/stream").close()
+
+    response = client.get("/api/status/stream", buffered=False)
+    try:
+        assert response.status_code == 200
+    finally:
+        response.close()
+
+
+def test_slot_is_released_when_the_stream_closes(client, status_mod):
+    response = client.get("/api/status/stream", buffered=False)
+    next(response.response)  # start the generator so the slot is taken
+    assert status_mod._sse_count == 1
+    response.close()
+
+    assert status_mod._sse_count == 0

--- a/tests/unit/web/routes/test_ma_artwork_proxy_redirects.py
+++ b/tests/unit/web/routes/test_ma_artwork_proxy_redirects.py
@@ -1,0 +1,112 @@
+"""The artwork proxy must not hand the MA bearer token to a redirect target.
+
+``urllib``'s default redirect handler copies request headers onto the
+redirected request, so a signed MA-origin URL that 302s off-origin used to
+ship ``Authorization: Bearer <MA token>`` to whatever host the redirect named
+— the HMAC gate only ever validates the *initial* URL.  The fetch also has to
+go through the SSRF-safe opener so every hop re-verifies the peer address.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request as _ur
+
+import pytest
+from flask import Flask
+
+_MA_URL = "http://192.168.10.20:8095"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(tmp_path, monkeypatch):
+    import sendspin_bridge.config as config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    (tmp_path / "config.json").write_text(json.dumps({}))
+
+
+@pytest.fixture()
+def ma_playback(monkeypatch):
+    for name in ("sendspin_bridge.web.routes.ma_playback",):
+        if name in sys.modules and getattr(sys.modules[name], "__file__", None) is None:
+            sys.modules.pop(name)
+
+    import sendspin_bridge.web.routes.ma_playback as mod
+
+    monkeypatch.setattr(mod, "get_ma_api_credentials", lambda: (_MA_URL, "ma-secret-token"))
+    return mod
+
+
+@pytest.fixture()
+def client(ma_playback):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(ma_playback.ma_bp)
+    return app.test_client()
+
+
+class _FakeResponse:
+    headers = {"Content-Type": "image/png", "Content-Length": "3"}
+
+    def read(self, _n):
+        return b"png"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_artwork_fetch_goes_through_the_ssrf_safe_opener(client, ma_playback, monkeypatch):
+    from sendspin_bridge.services.music_assistant.ma_artwork import sign_artwork_url
+
+    opened: list[object] = []
+
+    class _FakeOpener:
+        def open(self, req, timeout=None):
+            opened.append(req)
+            return _FakeResponse()
+
+    built: list[tuple] = []
+
+    def _fake_build_opener(*handlers, **kwargs):
+        built.append(handlers)
+        return _FakeOpener()
+
+    monkeypatch.setattr(ma_playback, "safe_build_opener", _fake_build_opener, raising=False)
+
+    raw = "/imageproxy/cover.png"
+    resp = client.get(f"/api/ma/artwork?url={raw}&sig={sign_artwork_url(raw)}")
+
+    assert resp.status_code == 200
+    assert resp.data == b"png"
+    assert built, "artwork proxy did not use the SSRF-safe opener"
+    assert opened and opened[0].get_header("Authorization") == "Bearer ma-secret-token"
+
+
+def test_cross_origin_redirect_drops_the_bearer_token(ma_playback):
+    handler = ma_playback._ArtworkRedirectHandler(_MA_URL)
+    req = _ur.Request(f"{_MA_URL}/imageproxy/cover.png", headers={"Authorization": "Bearer ma-secret-token"})
+
+    redirected = handler.redirect_request(
+        req, None, 302, "Found", {"location": "http://cdn.example.com/cover.png"}, "http://cdn.example.com/cover.png"
+    )
+
+    assert redirected is not None
+    assert redirected.get_header("Authorization") is None
+
+
+def test_same_origin_redirect_keeps_the_bearer_token(ma_playback):
+    handler = ma_playback._ArtworkRedirectHandler(_MA_URL)
+    req = _ur.Request(f"{_MA_URL}/imageproxy/cover.png", headers={"Authorization": "Bearer ma-secret-token"})
+
+    redirected = handler.redirect_request(
+        req, None, 302, "Found", {"location": f"{_MA_URL}/imageproxy/cover-2.png"}, f"{_MA_URL}/imageproxy/cover-2.png"
+    )
+
+    assert redirected is not None
+    assert redirected.get_header("Authorization") == "Bearer ma-secret-token"

--- a/tests/unit/web/test_auth.py
+++ b/tests/unit/web/test_auth.py
@@ -133,6 +133,46 @@ def test_rate_limit_client_id_ignores_forwarded_for_from_untrusted_proxy():
         assert _get_rate_limit_client_id() == "10.0.0.10"
 
 
+def test_rate_limit_client_id_honours_cidr_trusted_proxy():
+    """A peer inside a trusted CIDR must not become the lockout bucket key.
+
+    Under HA Supervisor ingress the peer is somewhere in 172.30.32.0/23 —
+    trusted by CIDR, but never equal to the CIDR string itself.  Bucketing by
+    the proxy's own IP puts every ingress user in one bucket, so five failed
+    logins by anyone lock out the whole household.
+    """
+    with (
+        patch(
+            "sendspin_bridge.web.routes.auth.load_config",
+            return_value={"TRUSTED_PROXIES": ["172.30.32.0/23"]},
+        ),
+        _app.test_request_context(
+            "/login",
+            method="POST",
+            data={"username": "alice"},
+            environ_base={"REMOTE_ADDR": "172.30.33.7"},
+            headers={"X-Forwarded-For": "192.168.10.55"},
+        ),
+    ):
+        assert _get_rate_limit_client_id() == "192.168.10.55"
+
+
+def test_rate_limit_client_id_falls_back_to_username_for_cidr_proxy_without_client_ip():
+    with (
+        patch(
+            "sendspin_bridge.web.routes.auth.load_config",
+            return_value={"TRUSTED_PROXIES": ["172.30.32.0/23"]},
+        ),
+        _app.test_request_context(
+            "/login",
+            method="POST",
+            data={"username": "Alice"},
+            environ_base={"REMOTE_ADDR": "172.30.33.7"},
+        ),
+    ):
+        assert _get_rate_limit_client_id() == "proxy-login:alice"
+
+
 def test_rate_limit_client_id_falls_back_to_username_for_trusted_proxy_without_client_ip():
     with (
         patch("sendspin_bridge.web.routes.auth.load_config", return_value={"TRUSTED_PROXIES": ["10.0.0.10"]}),

--- a/tests/unit/web/test_scan_cooldown_completion.py
+++ b/tests/unit/web/test_scan_cooldown_completion.py
@@ -1,0 +1,80 @@
+"""The scan cooldown must run from the end of a scan, not from its start.
+
+``_SCAN_BASE_DURATION`` (15 s) is longer than ``_SCAN_COOLDOWN`` (10 s), so
+stamping the completion timestamp when the worker *starts* means the cooldown
+has always elapsed by the time the scan finishes — the adapter never gets the
+rest period the gate exists to give it.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture()
+def api_bt(monkeypatch):
+    if "sendspin_bridge.web.routes.api_bt" in sys.modules:
+        stub = sys.modules["sendspin_bridge.web.routes.api_bt"]
+        if getattr(stub, "__file__", None) is None:
+            sys.modules.pop("sendspin_bridge.web.routes.api_bt")
+
+    import sendspin_bridge.web.routes.api_bt as mod
+
+    monkeypatch.setattr(mod, "_last_scan_completed", 0.0)
+    return mod
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_cooldown_starts_when_the_scan_finishes(api_bt, monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(api_bt.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(api_bt, "_resolve_scan_adapter_macs", lambda adapter: [])
+    monkeypatch.setattr(api_bt, "finish_scan_job", lambda *a, **kw: None)
+
+    def _scan(adapter_macs, window_s=0.0):
+        clock.advance(window_s)
+        return types.SimpleNamespace(
+            names={},
+            device_adapter={},
+            rssi_by_mac={},
+            discovery_errors=[],
+            seen_macs=set(),
+            active_macs=set(),
+        )
+
+    monkeypatch.setattr(api_bt, "get_bluez", lambda: types.SimpleNamespace(scan=_scan))
+
+    started_at = clock.now
+    api_bt._run_bt_scan("job-1")
+
+    assert api_bt._last_scan_completed == started_at + api_bt._SCAN_BASE_DURATION
+
+
+def test_cooldown_is_stamped_even_when_the_scan_raises(api_bt, monkeypatch):
+    clock = _Clock()
+    monkeypatch.setattr(api_bt.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(api_bt, "finish_scan_job", lambda *a, **kw: None)
+
+    def _boom(adapter):
+        clock.advance(3.0)
+        raise RuntimeError("adapter wedged")
+
+    monkeypatch.setattr(api_bt, "_resolve_scan_adapter_macs", _boom)
+
+    started_at = clock.now
+    api_bt._run_bt_scan("job-2")
+
+    assert api_bt._last_scan_completed == started_at + 3.0

--- a/uv.lock
+++ b/uv.lock
@@ -1690,6 +1690,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1838,6 +1850,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -1862,6 +1875,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<2.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0,<8.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3,<3.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0,<4.0" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.1" },


### PR DESCRIPTION
Six independent defects surfaced by an architecture audit of the codebase. Each is one commit, each starts with a failing test, and three were reproduced by running them before the fix.

## What was wrong

| Fix | Defect |
|---|---|
| SSE listener slots | The slot was reserved in the view but released in the streaming generator's `finally`. Flask auto-registers HEAD for every GET rule and Werkzeug closes a HEAD response's generator without ever iterating it, so four HEAD requests — an uptime probe, a link preview, a crawler — left every later client answered with 503 for the life of the process. The web UI and the HA integration silently stopped updating. **Reproduced.** |
| Login lockout bucket | The bucket key tested `peer in trusted_proxies` — an exact string match — while the default trust set holds the HA ingress network as a CIDR. An ingress peer is inside that range but never equal to it, so every user behind ingress shared one bucket: five failed logins by anyone locked out the household. The CIDR-aware matcher was already used by the two neighbouring trust checks. **Reproduced.** |
| Settings save | The merge step reads the stored config to carry forward the keys the form never submits — password hash, session secret, MA tokens. That read was wrapped in a bare `except Exception` logged at DEBUG, and the write that follows replaces the file wholesale. One unreadable or truncated `config.json` erased the operator's credentials while the endpoint answered `{"success": true}`. |
| pytest timeout | `[tool.pytest.ini_options].timeout = 60` was inert — the plugin was never installed, so pytest only warned and a hung test burned CI's 10-minute budget without naming a culprit. **Reproduced** (`PytestConfigWarning: Unknown config option: timeout`). |
| Scan cooldown | The completion timestamp was stamped when the worker started. The discovery window is 15 s and the cooldown is 10 s, so it had always expired by the time a scan ended — the adapter never got its rest period. |
| Artwork proxy | urllib's redirect handler copies request headers onto the redirected request and the artwork HMAC only covers the initial URL, so a signed MA-origin URL that 302s off-origin delivered the MA bearer token to that host. The fetch also bypassed the SSRF-safe opener used everywhere else. |

## Notes for review

- Two existing artwork tests patched `urllib.request.urlopen`, which the proxy no longer calls; they were retargeted at the opener seam with every assertion (URL, Authorization, Accept, timeout) preserved.
- `pytest-timeout` is dev-only, so `requirements.txt` (exported with `--no-dev`) is unchanged.

## Verification

```
uv run pytest -q            # 3134 passed, 1 skipped
uv run ruff check src tests
uv run mypy --config-file pyproject.toml src/sendspin_bridge
uv run python scripts/lint_changelog.py CHANGELOG.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)