### PR TITLE
refactor(bluetooth): reconnect decisions and the MPRIS export lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Entering standby, waking a speaker and the connect at startup no longer freeze the web UI and the status stream for several seconds, and no longer collide with a scan or pairing that is already running.
 - A speaker's controller is now identified through the kernel's own numbering, with a retry if the Bluetooth service starts after the bridge. A bridge that started first used to run without the faster Bluetooth path until it was restarted, and a controller that could not be identified could be addressed by position — which on multi-adapter hosts is a different controller.
 - Bluetooth status reads from different parts of the bridge no longer share one connection to the system service, which was an unguarded source of the intermittent errors above.
+- A speaker that reconnects repeatedly no longer leaks a system connection and an orphaned media registration on every bounce. Bluetooth kept routing the speaker's hard-key presses at a player that no longer existed, and the leak grew until the bridge was restarted.
+- The media controls of a speaker whose link flaps are no longer left registered after it disconnects, which previously made its buttons appear to work while nothing was listening.
 
 ### Security
 - Login lockout is now counted per user behind a Home Assistant ingress or any reverse proxy given as an address range. Previously everyone behind such a proxy shared one lockout counter, so five failed logins by one person locked out the whole household.

--- a/src/sendspin_bridge/bluetooth/manager.py
+++ b/src/sendspin_bridge/bluetooth/manager.py
@@ -179,6 +179,12 @@ class BluetoothManager:
         # this both could observe the pre-transition state and fire
         # ``on_connected`` twice — duplicate MprisPlayer registrations.
         self._connected_state_lock = threading.Lock()
+        # Transition ordering: the sequence number is taken under the state
+        # lock, the callbacks run under the dispatch lock, so they arrive in
+        # the order the state actually changed.
+        self._transition_dispatch_lock = threading.Lock()
+        self._transition_seq = 0
+        self._transition_dispatched = 0
         self.last_check: float = 0
         # Experimental sink-recovery flags (off by default; enabled per-bridge via config)
         self._enable_a2dp_dance = bool(enable_a2dp_dance)
@@ -928,21 +934,40 @@ class BluetoothManager:
         ``_connected_state_lock`` so the asyncio D-Bus monitor thread
         and the BT executor thread can't both pass the check, both
         write True, and both fire ``on_connected`` (would surface as
-        duplicate MprisPlayer D-Bus exports).  The callback itself
-        runs OUTSIDE the lock so a slow callback can't block a
-        concurrent disconnect handler from updating state.
+        duplicate MprisPlayer D-Bus exports).  The callback runs outside
+        that lock, so a slow callback never blocks a concurrent handler
+        from updating state.
+
+        Ordered: each transition takes a sequence number under the state
+        lock and dispatches under a second lock, so the callbacks arrive
+        in the order the state changed.  Firing them unordered let a slow
+        ``on_connected`` land after a later disconnect and leave an MPRIS
+        player registered for a speaker that was already gone — the
+        inverse of the duplicate-registration bug the state lock fixed.
+        A transition another one has already overtaken is dropped.
         """
         with self._connected_state_lock:
             if value == self.connected:
                 return
             self.connected = value
+            self._transition_seq += 1
+            sequence = self._transition_seq
         # #260, #263 — a successful Connected=True transition is the canonical
         # "this device exists in BlueZ and works" signal. Flip the session
         # flag and clear the never_paired status push so the recovery banner
         # returns to its normal state and the auto-disable gate stops firing.
-        if value:
-            self._clear_never_paired_evidence()
-        self._fire_connection_transition(value)
+        with self._transition_dispatch_lock:
+            if sequence < self._transition_dispatched:
+                logger.debug(
+                    "[%s] Connection transition #%d overtaken — not dispatching",
+                    self.device_name,
+                    sequence,
+                )
+                return
+            self._transition_dispatched = sequence
+            if value:
+                self._clear_never_paired_evidence()
+            self._fire_connection_transition(value)
 
     def _clear_never_paired_evidence(self) -> None:
         """Mark this session as having had a working BlueZ record and clear the

--- a/src/sendspin_bridge/bluetooth/manager.py
+++ b/src/sendspin_bridge/bluetooth/manager.py
@@ -271,6 +271,48 @@ class BluetoothManager:
             )
         self.battery_level: int | None = None
 
+    # ------------------------------------------------------------------
+    # The monitor-facing interface
+    #
+    # ``bluetooth.monitor`` runs the reconnect loops on this manager's behalf.
+    # Everything it needs is stated here, so the loop is a caller rather than
+    # a friend class reaching into private state.
+    # ------------------------------------------------------------------
+
+    @property
+    def running(self) -> bool:
+        """False once :meth:`shutdown` has been called — loops must exit."""
+        return self._running
+
+    @property
+    def dbus_device_path(self) -> str | None:
+        """BlueZ object path for this device, once the controller resolves."""
+        return self._dbus_device_path
+
+    def attach_standby_wake_event(self, event: asyncio.Event) -> None:
+        """Register the event :meth:`signal_standby_wake` fires."""
+        self._standby_wake_event = event
+
+    @property
+    def standby_wake_event(self) -> asyncio.Event | None:
+        return self._standby_wake_event
+
+    def reconnect_cancelled(self) -> bool:
+        """True when a reconnect in flight should stop."""
+        return self._reconnect_cancelled()
+
+    def apply_connected_state(self, connected: bool) -> None:
+        """Record a confirmed link transition and fire the callbacks."""
+        self._apply_connected_state(connected)
+
+    def handle_reconnect_failure(self, attempt: int) -> bool:
+        """Execute the policy's verdict; True means stop reconnecting."""
+        return self._handle_reconnect_failure(attempt)
+
+    def publish_client_event(self, *args, **kwargs) -> None:
+        """Publish a device event on this manager's behalf."""
+        self._publish_client_event(*args, **kwargs)
+
     @property
     def check_interval(self) -> float:
         """Seconds between connection polls — also the backoff base."""

--- a/src/sendspin_bridge/bluetooth/manager.py
+++ b/src/sendspin_bridge/bluetooth/manager.py
@@ -32,6 +32,14 @@ from sendspin_bridge.bluetooth.dbus import (
     _dbus_wait_services_resolved,
 )
 from sendspin_bridge.bluetooth.pairing import PairOptions, PairSession, PairTimings
+from sendspin_bridge.bluetooth.reconnect_policy import (
+    Churned,
+    DisableNeverPaired,
+    KeepTrying,
+    ReconnectPolicy,
+    ReleaseManagement,
+    TryAdapterRecovery,
+)
 from sendspin_bridge.services.bluetooth import COMMON_BT_PAIR_PINS, bt_rssi_mgmt
 
 # v2.63.0-rc.7 — RSSI background refresh restored via the kernel mgmt
@@ -172,13 +180,6 @@ class BluetoothManager:
         # ``on_connected`` twice — duplicate MprisPlayer registrations.
         self._connected_state_lock = threading.Lock()
         self.last_check: float = 0
-        self.check_interval = check_interval
-        self.max_reconnect_fails = max_reconnect_fails
-        # Monotonic timestamp of the last auto-release; gates the
-        # auto-reclaim quiet period (issues #349/#350).  None = never
-        # auto-released this run (a release persisted from a previous
-        # run may reclaim immediately once the speaker connects).
-        self._auto_released_at: float | None = None
         # Experimental sink-recovery flags (off by default; enabled per-bridge via config)
         self._enable_a2dp_dance = bool(enable_a2dp_dance)
         self._enable_pa_module_reload = bool(enable_pa_module_reload)
@@ -225,7 +226,6 @@ class BluetoothManager:
         self._connect_lock = threading.Lock()  # prevents concurrent connect_device() calls
         self._cancel_reconnect = threading.Event()
         self._standby_wake_event: asyncio.Event | None = None  # set by _wake_from_standby to unblock monitor
-        self._reconnect_timestamps: list[float] = []  # monotonic timestamps of recent reconnects
         # Counts consecutive connect_device() failures where BlueZ has no
         # current device object (is_device_paired() returns None). After
         # _PAIRED_UNKNOWN_THRESHOLD consecutive observations we force-remove
@@ -247,11 +247,15 @@ class BluetoothManager:
         # upstream BlueZ 5.86 regression (bluez/bluez#1922) leaves no A2DP sink
         # exposed no matter how many times we retry.
         self._a2dp_dance_remaining = 1
-        # Guard churn tracking because reconnect decisions can be touched from
-        # multiple execution contexts (polling loop, D-Bus reconnect path).
-        self._reconnect_lock = threading.Lock()
-        self._CHURN_WINDOW = churn_window  # seconds; 0 threshold = disabled
-        self._CHURN_THRESHOLD = churn_threshold  # 0 = disabled
+        # Reconnect decisions — backoff, churn, the release ladder and the
+        # reclaim quiet period — belong to the policy; what stays here is the
+        # execution: status updates, events and persistence.
+        self.policy = ReconnectPolicy(
+            check_interval=check_interval,
+            max_fails=max_reconnect_fails,
+            churn_threshold=churn_threshold,
+            churn_window=churn_window,
+        )
 
         # Resolve effective adapter MAC for display (handles empty/default adapter case)
         self.effective_adapter_mac = self._adapter_handle.adapter_mac or self._detect_default_adapter_mac()
@@ -266,6 +270,24 @@ class BluetoothManager:
                 self.effective_adapter_mac or "unknown",
             )
         self.battery_level: int | None = None
+
+    @property
+    def check_interval(self) -> float:
+        """Seconds between connection polls — also the backoff base."""
+        return self.policy.check_interval
+
+    @check_interval.setter
+    def check_interval(self, value: float) -> None:
+        self.policy.check_interval = value
+
+    @property
+    def max_reconnect_fails(self) -> int:
+        """Consecutive failures before the adapter is handed back (0 = never)."""
+        return self.policy.max_fails
+
+    @max_reconnect_fails.setter
+    def max_reconnect_fails(self, value: int) -> None:
+        self.policy.max_fails = value
 
     @property
     def adapter_handle(self) -> AdapterHandle:
@@ -1020,47 +1042,17 @@ class BluetoothManager:
         return False
 
     def _reconnect_delay(self, attempt: int) -> float:
-        """Exponential backoff delay after a failed reconnect attempt.
-
-        Attempts 1-3 use check_interval; doubles every attempt thereafter,
-        capped at 5 minutes. Reduces BT radio activity (and audio disruption
-        on other devices sharing the same adapter) as failure count grows.
-        """
-        return min(self.check_interval * (2 ** max(0, attempt - 3)), _MAX_RECONNECT_DELAY_S)
+        """Backoff for the next attempt — the policy's arithmetic."""
+        return self.policy.delay_for(attempt)
 
     def _record_reconnect(self) -> None:
-        """Record a BT reconnect event for churn detection."""
-        now = time.monotonic()
-        with self._reconnect_lock:
-            self._reconnect_timestamps.append(now)
-            # Prune old entries while still under the same lock so callers
-            # never observe a partially updated churn window.
-            cutoff = now - self._CHURN_WINDOW
-            self._reconnect_timestamps = [t for t in self._reconnect_timestamps if t > cutoff]
+        """Note a reconnect so the policy can spot churn."""
+        self.policy.record_reconnect()
 
-    def _check_reconnect_churn(self) -> bool:
-        """Auto-release device if too many reconnects in the time window.
-
-        Returns True if management was released. Released when threshold <= 0.
-        """
-        if self._CHURN_THRESHOLD <= 0:
-            return False
-        now = time.monotonic()
-        with self._reconnect_lock:
-            cutoff = now - self._CHURN_WINDOW
-            self._reconnect_timestamps = [t for t in self._reconnect_timestamps if t > cutoff]
-            reconnect_count = len(self._reconnect_timestamps)
-            if reconnect_count < self._CHURN_THRESHOLD:
-                return False
-
-        logger.warning(
-            "[%s] BT churn detected: %d reconnects in %.0fs — auto-releasing to protect group",
-            self.device_name,
-            reconnect_count,
-            self._CHURN_WINDOW,
-        )
+    def _release_management(self, reason: str) -> None:
+        """Hand the adapter back to the host and persist that decision."""
         self.management_enabled = False
-        self._auto_released_at = time.monotonic()
+        self.policy.mark_released()
         if self.host:
             self.host.bt_management_enabled = False
             self.host.update_status(
@@ -1068,7 +1060,7 @@ class BluetoothManager:
                     "bt_management_enabled": False,
                     "bt_released_by": "auto",
                     "reconnecting": False,
-                    "last_error": f"Auto-released: {reconnect_count} reconnects in {int(self._CHURN_WINDOW)}s",
+                    "last_error": reason,
                     "last_error_at": datetime.now(tz=UTC).isoformat(),
                 }
             )
@@ -1078,68 +1070,68 @@ class BluetoothManager:
             persist_device_released(self.device_name, True, released_by="auto")
         except Exception as _e:
             logger.debug("persist_device_released failed: %s", _e)
-        return True
 
     def _handle_reconnect_failure(self, attempt: int) -> bool:
-        """Release BT management after too many consecutive failed reconnects.
+        """Execute the policy's verdict on a failed reconnect.
 
-        Returns True if management was released (caller should stop reconnecting).
-        Side-effects: sets self.management_enabled=False, updates client status,
-        calls persist_device_released().
+        Returns True when the caller should stop reconnecting.  The decision
+        is the policy's; the status writes, the event and the persistence are
+        this method's.
         """
-        # Also check time-windowed churn (many successful-then-failed cycles)
-        if self._check_reconnect_churn():
-            return True
-        if self.max_reconnect_fails <= 0 or attempt < self.max_reconnect_fails:
-            return False
-        # Last-ditch adapter recovery before either auto-disable or auto-release.
-        # Gated by the compatibility flag because a USB reset is disruptive.
-        # Needs both the resolved adapter MAC and an hci index to hand to
-        # the bluetooth-auto-recovery library.
-        if self._enable_adapter_auto_recovery and self._try_adapter_auto_recovery():
-            logger.info(
-                "[%s] adapter recovery succeeded after %d failed reconnects — keeping management enabled",
-                self.device_name,
+        recovery_attempted = False
+        while True:
+            decision = self.policy.on_failure(
                 attempt,
+                paired=self.paired,
+                ever_paired=self._has_ever_paired_since_start,
+                recovery_available=self._enable_adapter_auto_recovery,
+                recovery_attempted=recovery_attempted,
             )
-            return False
-        # v2.70.0-rc.2 (#263) — Never-paired auto-disable.
-        # After adapter recovery has had its shot, if BlueZ still has no
-        # record of this device AND we never observed a successful
-        # Connected=True transition in this bridge session, the device is
-        # most likely misconfigured or out of range from the start. Stop
-        # the reconnect storm by flipping enabled=False; the recovery banner
-        # then surfaces a "Re-enable" action so the operator can retry
-        # pairing on their schedule.
-        if self.paired is None and not self._has_ever_paired_since_start:
-            self._auto_disable_never_paired(attempt)
-            return True
-        logger.warning(
-            "[%s] %d consecutive failed reconnects (threshold=%d) — auto-releasing BT management",
-            self.device_name,
-            attempt,
-            self.max_reconnect_fails,
-        )
-        self.management_enabled = False
-        self._auto_released_at = time.monotonic()
-        if self.host:
-            self.host.bt_management_enabled = False
-            self.host.update_status(
-                {
-                    "bt_management_enabled": False,
-                    "bt_released_by": "auto",
-                    "reconnecting": False,
-                    "last_error": f"Auto-released after {attempt} reconnect attempts",
-                    "last_error_at": datetime.now(tz=UTC).isoformat(),
-                }
-            )
-        try:
-            from sendspin_bridge.services.bluetooth import persist_device_released
 
-            persist_device_released(self.device_name, True, released_by="auto")
-        except Exception as _e:
-            logger.debug("persist_device_released failed: %s", _e)
-        return True
+            if isinstance(decision, KeepTrying):
+                return False
+
+            if isinstance(decision, Churned):
+                logger.warning(
+                    "[%s] BT churn detected: %d reconnects in %.0fs — auto-releasing to protect group",
+                    self.device_name,
+                    decision.reconnect_count,
+                    decision.window_s,
+                )
+                self._release_management(
+                    f"Auto-released: {decision.reconnect_count} reconnects in {int(decision.window_s)}s"
+                )
+                return True
+
+            if isinstance(decision, TryAdapterRecovery):
+                # A USB reset is disruptive, so the policy offers it exactly
+                # once before the release ladder continues.
+                if self._try_adapter_auto_recovery():
+                    logger.info(
+                        "[%s] adapter recovery succeeded after %d failed reconnects — keeping management enabled",
+                        self.device_name,
+                        decision.attempt,
+                    )
+                    return False
+                recovery_attempted = True
+                continue
+
+            if isinstance(decision, DisableNeverPaired):
+                self._auto_disable_never_paired(decision.attempt)
+                return True
+
+            if isinstance(decision, ReleaseManagement):
+                logger.warning(
+                    "[%s] %d consecutive failed reconnects (threshold=%d) — auto-releasing BT management",
+                    self.device_name,
+                    decision.attempt,
+                    decision.threshold,
+                )
+                self._release_management(f"Auto-released after {decision.attempt} reconnect attempts")
+                return True
+
+            logger.error("[%s] Unhandled reconnect decision %r", self.device_name, decision)
+            return False
 
     def maybe_auto_reclaim(self, connected: bool | None = None) -> bool:
         """Reclaim BT management after an auto-release once the speaker
@@ -1165,20 +1157,15 @@ class BluetoothManager:
             return False
         if connected is None:
             connected = self.connected
-        if not connected:
-            return False
-        released_at = self._auto_released_at
-        if released_at is not None and time.monotonic() - released_at < _AUTO_RECLAIM_QUIET_S:
+        if not self.policy.may_reclaim(connected=connected):
             return False
         logger.info(
             "[%s] Speaker reconnected on its own after auto-release — reclaiming BT management",
             self.device_name,
         )
-        with self._reconnect_lock:
-            # Fresh churn window: the reconnects that led to the release
-            # must not count against the reclaimed session.
-            self._reconnect_timestamps = []
-        self._auto_released_at = None
+        # Fresh churn window: the reconnects that led to the release must not
+        # count against the reclaimed session.
+        self.policy.mark_reclaimed()
         self.allow_reconnect()
         host.bt_management_enabled = True
         host.update_status(

--- a/src/sendspin_bridge/bluetooth/monitor.py
+++ b/src/sendspin_bridge/bluetooth/monitor.py
@@ -61,7 +61,7 @@ def _log_reconnect_attempt(device_name: str, attempt: int) -> None:
 
 async def _standby_sleep(mgr: BluetoothManager, seconds: float = 5) -> None:
     """Sleep interruptibly — returns early when ``signal_standby_wake()`` fires."""
-    evt = mgr._standby_wake_event
+    evt = mgr.standby_wake_event
     if evt is None:
         await asyncio.sleep(seconds)
         return
@@ -117,7 +117,7 @@ async def _finish_auto_reclaim(mgr: BluetoothManager, loop, *, connected: bool |
     if not mgr.maybe_auto_reclaim(connected=connected):
         return False
     await loop.run_in_executor(bt_executor(), mgr.configure_bluetooth_audio)
-    mgr._record_reconnect()
+    mgr.policy.record_reconnect()
     if mgr.host:
         mgr.host.update_status(
             {
@@ -160,7 +160,7 @@ async def monitor_and_reconnect(mgr: BluetoothManager) -> None:
     """
     logger.info("[%s] monitor_and_reconnect task started", mgr.device_name)
     # Create an asyncio.Event in the running loop for standby-wake signaling.
-    mgr._standby_wake_event = asyncio.Event()
+    mgr.attach_standby_wake_event(asyncio.Event())
     try:
         from dbus_fast import BusType
         from dbus_fast.aio import MessageBus
@@ -176,7 +176,7 @@ async def _monitor_polling(mgr: BluetoothManager) -> None:
     loop = asyncio.get_running_loop()
     iteration = 0
     reconnect_attempt = 0
-    while mgr._running:
+    while mgr.running:
         iteration += 1
         try:
             if not mgr.management_enabled:
@@ -237,7 +237,7 @@ async def _monitor_polling(mgr: BluetoothManager) -> None:
                             # (including a possible USB reset) and a config write — never inline
                             # on the loop.
                             if await loop.run_in_executor(
-                                bt_executor(), mgr._handle_reconnect_failure, reconnect_attempt
+                                bt_executor(), mgr.handle_reconnect_failure, reconnect_attempt
                             ):
                                 reconnect_attempt = 0
                                 continue
@@ -254,15 +254,15 @@ async def _monitor_polling(mgr: BluetoothManager) -> None:
                             success = await loop.run_in_executor(bt_executor(), mgr.connect_device)
                         finally:
                             lease.release()
-                        if mgr._reconnect_cancelled():
+                        if mgr.reconnect_cancelled():
                             reconnect_attempt = 0
                             continue
                         if success and mgr.host:
                             completed_attempt = reconnect_attempt
                             reconnect_attempt = 0
-                            mgr._record_reconnect()
+                            mgr.policy.record_reconnect()
                             mgr.host.update_status({"reconnecting": False, "reconnect_attempt": 0})
-                            mgr._publish_client_event(
+                            mgr.publish_client_event(
                                 DeviceEventType.BLUETOOTH_RECONNECTED,
                                 message="Bluetooth reconnect succeeded",
                                 details={"attempt": completed_attempt},
@@ -271,8 +271,8 @@ async def _monitor_polling(mgr: BluetoothManager) -> None:
                             await mgr.host.start_subprocess()
                             _spawn_background(_correct_other_devices_routing(mgr))
                         else:
-                            delay = mgr._reconnect_delay(reconnect_attempt)
-                            mgr._publish_client_event(
+                            delay = mgr.policy.delay_for(reconnect_attempt)
+                            mgr.publish_client_event(
                                 DeviceEventType.BLUETOOTH_RECONNECT_FAILED,
                                 level="warning",
                                 message="Bluetooth reconnect attempt failed",
@@ -292,7 +292,7 @@ async def _monitor_polling(mgr: BluetoothManager) -> None:
                             mgr.device_name,
                         )
                         await loop.run_in_executor(bt_executor(), mgr.configure_bluetooth_audio)
-                        mgr._record_reconnect()
+                        mgr.policy.record_reconnect()
                         if mgr.host.bluetooth_sink_name:
                             logger.info("[%s] Auto-reconnect: starting player", mgr.device_name)
                             await mgr.host.start_subprocess()
@@ -300,7 +300,7 @@ async def _monitor_polling(mgr: BluetoothManager) -> None:
 
                     # Read battery level (None if device doesn't support it).
                     # Synchronous D-Bus round-trip → run off the loop.
-                    mgr.battery_level = await loop.run_in_executor(None, _dbus_get_battery_level, mgr._dbus_device_path)
+                    mgr.battery_level = await loop.run_in_executor(None, _dbus_get_battery_level, mgr.dbus_device_path)
 
             await asyncio.sleep(5)
         except Exception:
@@ -314,16 +314,16 @@ async def _monitor_dbus(mgr: BluetoothManager, MessageBus, BusType) -> None:
     Raises RuntimeError after 3 consecutive connection failures so
     monitor_and_reconnect() can fall back to bluetoothctl polling.
     """
-    if not mgr._dbus_device_path:
+    if not mgr.dbus_device_path:
         raise RuntimeError("D-Bus device path unavailable because adapter resolution failed")
     loop = asyncio.get_running_loop()
     connect_failures = 0
     _MAX_CONNECT_FAILURES = 3
-    logger.info("[%s] D-Bus monitor started (path=%s)", mgr.device_name, mgr._dbus_device_path)
+    logger.info("[%s] D-Bus monitor started (path=%s)", mgr.device_name, mgr.dbus_device_path)
 
     bus = None
 
-    while mgr._running:
+    while mgr.running:
         bus_needs_reconnect = bus is None or not bus.connected
         try:
             if bus_needs_reconnect:
@@ -337,8 +337,8 @@ async def _monitor_dbus(mgr: BluetoothManager, MessageBus, BusType) -> None:
             # Introspect the device object
             try:
                 assert bus is not None  # guaranteed by reconnect block above
-                introspection = await bus.introspect("org.bluez", mgr._dbus_device_path)
-                proxy = bus.get_proxy_object("org.bluez", mgr._dbus_device_path, introspection)
+                introspection = await bus.introspect("org.bluez", mgr.dbus_device_path)
+                proxy = bus.get_proxy_object("org.bluez", mgr.dbus_device_path, introspection)
                 device_iface = proxy.get_interface("org.bluez.Device1")
                 props_iface = proxy.get_interface("org.freedesktop.DBus.Properties")
             except Exception as e:
@@ -363,10 +363,10 @@ async def _monitor_dbus(mgr: BluetoothManager, MessageBus, BusType) -> None:
             # (and any other transition-driven hook) lands on the
             # initial D-Bus monitor startup, not just polling cycles.
             try:
-                mgr._apply_connected_state(bool(await device_iface.get_connected()))
+                mgr.apply_connected_state(bool(await device_iface.get_connected()))
             except Exception as exc:
                 logger.debug("get_connected() failed: %s", exc)
-                mgr._apply_connected_state(False)
+                mgr.apply_connected_state(False)
             if mgr.host:
                 mgr.host.update_status(
                     {
@@ -397,7 +397,7 @@ async def _monitor_dbus(mgr: BluetoothManager, MessageBus, BusType) -> None:
                     # callback fire — the primary path that reaches the
                     # MprisPlayer registration on Linux hosts where D-Bus
                     # PropertiesChanged drives the connect detection.
-                    mgr._apply_connected_state(new_connected)
+                    mgr.apply_connected_state(new_connected)
                     ts = datetime.now(tz=UTC).isoformat()
                     if mgr.host:
                         mgr.host.update_status(
@@ -476,7 +476,7 @@ async def _inner_dbus_monitor(
     the link is back. Issue #312.
     """
     reconnect_attempt = 0
-    while mgr._running:
+    while mgr.running:
         if not mgr.management_enabled:
             # ``mgr.connected`` stays fresh here even while released —
             # the PropertiesChanged handler keeps applying state — so an
@@ -511,7 +511,7 @@ async def _inner_dbus_monitor(
                     current_val = bool(await device_iface.get_connected())
                     if not current_val and mgr.connected:
                         logger.warning("[%s] Heartbeat: missed disconnect signal", mgr.device_name)
-                        mgr._apply_connected_state(False)
+                        mgr.apply_connected_state(False)
                         if mgr.host:
                             mgr.host.update_status(
                                 {
@@ -523,7 +523,7 @@ async def _inner_dbus_monitor(
                 except Exception as exc:
                     logger.debug("heartbeat connected-state check failed: %s", exc)
                 # Read battery level during heartbeat
-                mgr.battery_level = await loop.run_in_executor(None, _dbus_get_battery_level, mgr._dbus_device_path)
+                mgr.battery_level = await loop.run_in_executor(None, _dbus_get_battery_level, mgr.dbus_device_path)
         else:
             # Device is disconnected — attempt reconnect
             mgr.battery_level = None
@@ -566,7 +566,7 @@ async def _inner_dbus_monitor(
 
                 # Auto-disable after too many failures.  Offload: may run the
                 # adapter-recovery ladder + a config write — never on the loop.
-                if await loop.run_in_executor(bt_executor(), mgr._handle_reconnect_failure, reconnect_attempt):
+                if await loop.run_in_executor(bt_executor(), mgr.handle_reconnect_failure, reconnect_attempt):
                     return
 
                 # Stop sendspin (BT sink is gone — would flood PortAudioErrors)
@@ -584,14 +584,14 @@ async def _inner_dbus_monitor(
                 success = await loop.run_in_executor(bt_executor(), mgr.connect_device)
             finally:
                 lease.release()
-            if mgr._reconnect_cancelled():
+            if mgr.reconnect_cancelled():
                 reconnect_attempt = 0
                 continue
 
             if success:
                 reconnect_attempt = 0
-                mgr._record_reconnect()
-                mgr._apply_connected_state(True)
+                mgr.policy.record_reconnect()
+                mgr.apply_connected_state(True)
                 if mgr.host:
                     mgr.host.update_status(
                         {
@@ -613,7 +613,7 @@ async def _inner_dbus_monitor(
                 # external PropertiesChanged: Connected interrupts the
                 # sleep so we don't waste the remainder of a saturated
                 # backoff window on a speaker that's already back (#312).
-                delay = mgr._reconnect_delay(reconnect_attempt)
+                delay = mgr.policy.delay_for(reconnect_attempt)
                 logger.debug("[%s] Backoff: next attempt in %.0fs", mgr.device_name, delay)
                 try:
                     await asyncio.wait_for(connect_event.wait(), timeout=delay)
@@ -626,14 +626,14 @@ async def _inner_dbus_monitor(
                 connect_event.clear()
                 # Re-read state in case external reconnect happened
                 try:
-                    mgr._apply_connected_state(bool(await device_iface.get_connected()))
+                    mgr.apply_connected_state(bool(await device_iface.get_connected()))
                 except Exception as exc:
                     logger.debug("re-read connected state failed: %s", exc)
                 if mgr.connected:
                     logger.info("[%s] External reconnect detected, configuring audio...", mgr.device_name)
                     await loop.run_in_executor(bt_executor(), mgr.configure_bluetooth_audio)
                     reconnect_attempt = 0
-                    mgr._record_reconnect()
+                    mgr.policy.record_reconnect()
                     if mgr.host:
                         mgr.host.update_status(
                             {

--- a/src/sendspin_bridge/bluetooth/reconnect_policy.py
+++ b/src/sendspin_bridge/bluetooth/reconnect_policy.py
@@ -187,12 +187,16 @@ class ReconnectPolicy:
     def may_reclaim(self, *, connected: bool | None) -> bool:
         """True when an established link may reclaim management.
 
-        Requires an actual link (``None`` — "BlueZ could not say" — is not
-        one) and a quiet period since the automatic release, so a speaker
-        that is still bouncing cannot flap management on and off.
+        Requires an actual link — ``None`` ("BlueZ could not say") is not one
+        — and a quiet period since *this run's* automatic release, so a
+        speaker that is still bouncing cannot flap management on and off.
+
+        A release carried over from a previous run has no quiet period to
+        observe: the speaker connecting is the only evidence available, and
+        the churn that caused the release ended with the process.
         """
-        if self._released_at is None:
-            return False
         if connected is not True:
             return False
+        if self._released_at is None:
+            return True
         return (self._clock() - self._released_at) >= AUTO_RECLAIM_QUIET_S

--- a/src/sendspin_bridge/services/bluetooth/device_activation.py
+++ b/src/sendspin_bridge/services/bluetooth/device_activation.py
@@ -20,11 +20,11 @@ from typing import TYPE_CHECKING, Any
 
 from sendspin_bridge.services.audio.mpris_player import (
     MprisPlayer,
-    _build_player_iface,
     get_registry,
     resolve_avrcp_source_client,
 )
 from sendspin_bridge.services.bluetooth.avrcp_source_tracker import get_tracker as _get_avrcp_source_tracker
+from sendspin_bridge.services.bluetooth.mpris_export import MPRIS_PATH_PREFIX, MprisExport
 from sendspin_bridge.services.diagnostics.sendspin_compat import filter_supported_call_kwargs
 
 if TYPE_CHECKING:
@@ -129,7 +129,11 @@ def _resolve_adapter_device_class(device_adapter: str, adapters: list[dict[str, 
 # step is what BlueZ uses for AVRCP forwarding — system-bus name
 # requests are blocked by default ACL anyway, and BlueZ doesn't scan
 # bus names; it only routes to paths handed to it via Media1.
-_MPRIS_PATH_PREFIX = "/org/sendspin/players/"
+_MPRIS_PATH_PREFIX = MPRIS_PATH_PREFIX
+
+#: One export per MAC, so connect and disconnect act on the same resource
+#: instead of two hooks racing over attributes hung off the player object.
+_EXPORTS: dict[str, MprisExport] = {}
 
 
 def _mpris_dbus_path(mac: str) -> str:
@@ -316,94 +320,25 @@ def _make_mpris_connected_hook(
             logger.debug("MprisPlayer for %s registered without D-Bus export (no main loop)", mac)
             return
 
-        async def _export() -> None:
+        stale = _EXPORTS.pop(mac, None)
+        if stale is not None:
+            # A connect without an intervening disconnect (BlueZ can repeat the
+            # transition on a flapping link): tear the old export down rather
+            # than orphaning its connection and its BlueZ registration.
             try:
-                from dbus_fast import BusType  # type: ignore[import-untyped]
-                from dbus_fast.aio import MessageBus  # type: ignore[import-untyped]
-                from dbus_fast.signature import Variant  # type: ignore[import-untyped]
+                asyncio.run_coroutine_threadsafe(stale.ensure_unexported(), loop)
             except Exception as exc:
-                logger.debug("dbus_fast unavailable, skipping MPRIS export for %s: %s", mac, exc)
-                return
-            path = _mpris_dbus_path(mac)
-            adapter_path = _bluez_adapter_path(client.bt_manager) if client.bt_manager else None
-            try:
-                iface = _build_player_iface(player)
-                bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
-                bus.export(path, iface)
-                player._dbus_bus = bus  # type: ignore[attr-defined]
-                player._dbus_iface = iface  # type: ignore[attr-defined]
-                player._dbus_adapter_path = adapter_path  # type: ignore[attr-defined]
-                if adapter_path is None:
-                    logger.warning(
-                        "MPRIS player for %s exported at %s but adapter unknown — AVRCP forwarding inactive",
-                        mac,
-                        path,
-                    )
-                    return
-                # Register with BlueZ Media1 so AVRCP passthrough commands
-                # from the speaker (Play / Pause / Next / Previous / volume)
-                # are routed to our exported player object.  Properties are
-                # the minimum AVRCP advertisement; the speaker reads them
-                # via ``org.bluez.MediaPlayer1`` from BlueZ.
-                props = {
-                    "PlaybackStatus": Variant("s", "Stopped"),
-                    "LoopStatus": Variant("s", "None"),
-                    "Rate": Variant("d", 1.0),
-                    "Shuffle": Variant("b", False),
-                    "Volume": Variant("d", 1.0),
-                    "Position": Variant("x", 0),
-                    "MinimumRate": Variant("d", 1.0),
-                    "MaximumRate": Variant("d", 1.0),
-                    "CanGoNext": Variant("b", True),
-                    "CanGoPrevious": Variant("b", True),
-                    "CanPlay": Variant("b", True),
-                    "CanPause": Variant("b", True),
-                    "CanSeek": Variant("b", False),
-                    "CanControl": Variant("b", True),
-                    "Metadata": Variant(
-                        "a{sv}",
-                        {
-                            "xesam:title": Variant("s", "Sendspin Bridge"),
-                            "xesam:artist": Variant("as", [""]),
-                            "mpris:length": Variant("x", 0),
-                        },
-                    ),
-                }
-                introspect = await bus.introspect("org.bluez", adapter_path)
-                proxy = bus.get_proxy_object("org.bluez", adapter_path, introspect)
-                try:
-                    media = proxy.get_interface("org.bluez.Media1")
-                except Exception as exc:
-                    logger.warning(
-                        "MPRIS register: org.bluez.Media1 not on %s for %s: %s",
-                        adapter_path,
-                        mac,
-                        exc,
-                    )
-                    return
-                try:
-                    await media.call_register_player(path, props)  # type: ignore[attr-defined]
-                    player._dbus_registered = True  # type: ignore[attr-defined]
-                    logger.info(
-                        "MPRIS player registered with BlueZ Media1 for %s at %s on %s",
-                        mac,
-                        path,
-                        adapter_path,
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        "MPRIS register: Media1.RegisterPlayer(%s) on %s failed for %s: %s",
-                        path,
-                        adapter_path,
-                        mac,
-                        exc,
-                    )
+                logger.debug("Failed to retire the previous MPRIS export for %s: %s", mac, exc)
 
-            except Exception as exc:
-                logger.warning("MPRIS D-Bus export for %s failed: %s", mac, exc)
+        export = MprisExport(
+            mac=mac,
+            player=player,
+            adapter_path_provider=lambda: _bluez_adapter_path(client.bt_manager) if client.bt_manager else None,
+        )
+        _EXPORTS[mac] = export
 
         try:
-            asyncio.run_coroutine_threadsafe(_export(), loop)
+            asyncio.run_coroutine_threadsafe(export.ensure_exported(), loop)
         except Exception as exc:
             logger.debug("Failed to schedule MPRIS export for %s: %s", mac, exc)
 
@@ -427,43 +362,16 @@ def _make_mpris_disconnected_hook(mac: str) -> Callable[[], None]:
         _get_avrcp_source_tracker().clear(mac)
 
         registry = get_registry()
-        player = registry.unregister(mac)
-        if player is None:
+        registry.unregister(mac)
+        export = _EXPORTS.pop(mac, None)
+        if export is None:
             return
         loop = get_main_loop()
         if loop is None:
             return
-        bus = getattr(player, "_dbus_bus", None)
-        path = _mpris_dbus_path(mac)
-        if bus is None:
-            return
-        adapter_path = getattr(player, "_dbus_adapter_path", None)
-        was_registered = getattr(player, "_dbus_registered", False)
-
-        async def _unexport() -> None:
-            # Tell BlueZ to drop the AVRCP forwarding registration
-            # before we unexport the path — otherwise BlueZ keeps the
-            # cached pointer and the next forwarded command races a
-            # gone object.
-            if was_registered and adapter_path is not None:
-                try:
-                    introspect = await bus.introspect("org.bluez", adapter_path)
-                    proxy = bus.get_proxy_object("org.bluez", adapter_path, introspect)
-                    media = proxy.get_interface("org.bluez.Media1")
-                    await media.call_unregister_player(path)
-                except Exception as exc:
-                    logger.debug("MPRIS Media1.UnregisterPlayer(%s) failed: %s", path, exc)
-            try:
-                bus.unexport(path)
-            except Exception as exc:
-                logger.debug("MPRIS unexport for %s failed: %s", mac, exc)
-            try:
-                bus.disconnect()
-            except Exception:
-                pass
 
         try:
-            asyncio.run_coroutine_threadsafe(_unexport(), loop)
+            asyncio.run_coroutine_threadsafe(export.ensure_unexported(), loop)
         except Exception as exc:
             logger.debug("Failed to schedule MPRIS unexport for %s: %s", mac, exc)
 

--- a/src/sendspin_bridge/services/bluetooth/mpris_export.py
+++ b/src/sendspin_bridge/services/bluetooth/mpris_export.py
@@ -1,0 +1,237 @@
+"""The D-Bus side of a device's MPRIS player, as one owned resource.
+
+Exporting an MPRIS player means three things that must be undone in order: a
+system-bus connection, an exported object path, and a ``Media1.RegisterPlayer``
+pointer BlueZ keeps until it is told otherwise.  Connect and disconnect used
+to schedule those steps as two independent fire-and-forget coroutines, with
+the state kept as attributes on the player object.  Nothing ordered them, so
+on a reconnect bounce the unexport read a bus attribute the in-flight export
+had not written yet, decided there was nothing to undo, and returned — and
+the export then completed, leaving one leaked socket and one registration for
+a player already dropped from the registry.  A speaker that reconnect-loops
+repeats that until the process restarts.
+
+Here the three steps belong to one object with one lock, so an unexport
+either waits for the export it overlaps or finds nothing to undo, and a
+generation counter makes a late export abandon a run that has been
+superseded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["MPRIS_PATH_PREFIX", "MprisExport", "mpris_dbus_path"]
+
+MPRIS_PATH_PREFIX = "/org/sendspin/players/"
+
+
+def mpris_dbus_path(mac: str) -> str:
+    """The object path this bridge exports a device's player at."""
+    return MPRIS_PATH_PREFIX + mac.upper().replace(":", "_")
+
+
+def _default_bus_factory():
+    from dbus_fast import BusType
+    from dbus_fast.aio import MessageBus
+
+    return MessageBus(bus_type=BusType.SYSTEM)
+
+
+def _default_player_props() -> dict:
+    from dbus_fast.signature import Variant
+
+    return {
+        "PlaybackStatus": Variant("s", "Stopped"),
+        "LoopStatus": Variant("s", "None"),
+        "Rate": Variant("d", 1.0),
+        "Shuffle": Variant("b", False),
+        "Volume": Variant("d", 1.0),
+        "Position": Variant("x", 0),
+        "MinimumRate": Variant("d", 1.0),
+        "MaximumRate": Variant("d", 1.0),
+        "CanGoNext": Variant("b", True),
+        "CanGoPrevious": Variant("b", True),
+        "CanPlay": Variant("b", True),
+        "CanPause": Variant("b", True),
+        "CanSeek": Variant("b", False),
+        "CanControl": Variant("b", True),
+        "Metadata": Variant(
+            "a{sv}",
+            {
+                "xesam:title": Variant("s", "Sendspin Bridge"),
+                "xesam:artist": Variant("as", [""]),
+                "mpris:length": Variant("x", 0),
+            },
+        ),
+    }
+
+
+class MprisExport:
+    """One device's MPRIS player on the system bus.
+
+    ``ensure_exported`` and ``ensure_unexported`` are idempotent and
+    serialised against each other.  Both answer without raising: an export
+    that fails is a degraded but working device (the in-process registry
+    still serves the web UI and the MA bridge), never a broken connect.
+    """
+
+    def __init__(
+        self,
+        *,
+        mac: str,
+        player: Any,
+        adapter_path_provider: Callable[[], str | None],
+        bus_factory: Callable[[], Any] | None = None,
+        iface_builder: Callable[[Any], Any] | None = None,
+        props_factory: Callable[[], dict] | None = None,
+    ):
+        self.mac = mac
+        self.path = mpris_dbus_path(mac)
+        self._player = player
+        self._adapter_path_provider = adapter_path_provider
+        self._bus_factory = bus_factory or _default_bus_factory
+        self._iface_builder = iface_builder
+        self._props_factory = props_factory or _default_player_props
+        self._lock = asyncio.Lock()
+        self._generation = 0
+        self._bus: Any | None = None
+        self._adapter_path: str | None = None
+        self._registered = False
+
+    @property
+    def exported(self) -> bool:
+        return self._bus is not None
+
+    @property
+    def registered(self) -> bool:
+        """True once BlueZ holds a player pointer for this path."""
+        return self._registered
+
+    async def ensure_exported(self) -> bool:
+        """Export the player and register it with BlueZ. True when exported."""
+        async with self._lock:
+            if self._bus is not None:
+                return True
+            generation = self._generation
+            try:
+                iface = self._build_iface()
+                bus = await self._bus_factory().connect()
+            except Exception as exc:
+                logger.warning("MPRIS D-Bus export for %s failed: %s", self.mac, exc)
+                return False
+
+            if generation != self._generation:
+                # An unexport landed while we were connecting: this run has
+                # been superseded, so undo it instead of publishing it.
+                await self._close_bus(bus)
+                return False
+
+            try:
+                bus.export(self.path, iface)
+            except Exception as exc:
+                logger.warning("MPRIS D-Bus export for %s failed: %s", self.mac, exc)
+                await self._close_bus(bus)
+                return False
+
+            self._bus = bus
+            self._adapter_path = self._resolve_adapter_path()
+            if self._adapter_path is None:
+                logger.warning(
+                    "MPRIS player for %s exported at %s but adapter unknown — AVRCP forwarding inactive",
+                    self.mac,
+                    self.path,
+                )
+                return True
+
+            self._registered = await self._register(bus, self._adapter_path)
+            return True
+
+    async def ensure_unexported(self) -> None:
+        """Unregister from BlueZ, unexport the path and drop the connection."""
+        self._generation += 1
+        async with self._lock:
+            bus, self._bus = self._bus, None
+            adapter_path, self._adapter_path = self._adapter_path, None
+            registered, self._registered = self._registered, False
+            if bus is None:
+                return
+            if registered and adapter_path is not None:
+                # BlueZ must drop the AVRCP forwarding registration before the
+                # path goes away, or the next forwarded command races an
+                # object that is already gone.
+                await self._unregister(bus, adapter_path)
+            try:
+                bus.unexport(self.path)
+            except Exception as exc:
+                logger.debug("MPRIS unexport for %s failed: %s", self.mac, exc)
+            await self._close_bus(bus)
+
+    # -- internals -----------------------------------------------------
+
+    def _build_iface(self) -> Any:
+        if self._iface_builder is not None:
+            return self._iface_builder(self._player)
+        from sendspin_bridge.services.audio.mpris_player import _build_player_iface
+
+        return _build_player_iface(self._player)
+
+    def _resolve_adapter_path(self) -> str | None:
+        try:
+            return self._adapter_path_provider()
+        except Exception as exc:
+            logger.debug("MPRIS adapter path lookup failed for %s: %s", self.mac, exc)
+            return None
+
+    async def _media_interface(self, bus, adapter_path: str):
+        introspection = await bus.introspect("org.bluez", adapter_path)
+        proxy = bus.get_proxy_object("org.bluez", adapter_path, introspection)
+        return proxy.get_interface("org.bluez.Media1")
+
+    async def _register(self, bus, adapter_path: str) -> bool:
+        try:
+            media = await self._media_interface(bus, adapter_path)
+        except Exception as exc:
+            logger.warning("MPRIS register: org.bluez.Media1 not on %s for %s: %s", adapter_path, self.mac, exc)
+            return False
+        try:
+            await media.call_register_player(self.path, self._props_factory())
+        except Exception as exc:
+            logger.warning(
+                "MPRIS register: Media1.RegisterPlayer(%s) on %s failed for %s: %s",
+                self.path,
+                adapter_path,
+                self.mac,
+                exc,
+            )
+            return False
+        logger.info(
+            "MPRIS player registered with BlueZ Media1 for %s at %s on %s",
+            self.mac,
+            self.path,
+            adapter_path,
+        )
+        return True
+
+    async def _unregister(self, bus, adapter_path: str) -> None:
+        try:
+            media = await self._media_interface(bus, adapter_path)
+            await media.call_unregister_player(self.path)
+        except Exception as exc:
+            logger.debug("MPRIS Media1.UnregisterPlayer(%s) failed: %s", self.path, exc)
+
+    async def _close_bus(self, bus) -> None:
+        """Drop a connection. The path is unexported by the caller that owns it."""
+        try:
+            result = bus.disconnect()
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as exc:
+            logger.debug("MPRIS bus disconnect for %s failed: %s", self.mac, exc)

--- a/tests/unit/bluetooth/test_auto_reclaim.py
+++ b/tests/unit/bluetooth/test_auto_reclaim.py
@@ -84,28 +84,27 @@ def test_explicit_connected_argument_overrides_cached_state(released_manager):
 
 def test_quiet_period_damps_churn_flapping(released_manager):
     mgr = released_manager
-    mgr._auto_released_at = 990.0  # released 10 s ago
-    with patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1000.0):
-        assert mgr.maybe_auto_reclaim() is False
+    now = [1000.0]
+    mgr.policy._clock = lambda: now[0]
+    mgr.policy.mark_released()  # released just now
+
+    now[0] = 1010.0  # 10 s later
+    assert mgr.maybe_auto_reclaim() is False
     assert mgr.management_enabled is False
 
     # …but reclaim works once the quiet period has elapsed.
-    with (
-        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1100.0),
-        patch("sendspin_bridge.services.bluetooth.persist_device_released"),
-    ):
+    now[0] = 1100.0
+    with patch("sendspin_bridge.services.bluetooth.persist_device_released"):
         assert mgr.maybe_auto_reclaim() is True
 
 
 def test_reclaim_resets_churn_window(released_manager):
     mgr = released_manager
-    mgr._reconnect_timestamps = [1.0, 2.0, 3.0]
-    with (
-        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=1000.0),
-        patch("sendspin_bridge.services.bluetooth.persist_device_released"),
-    ):
+    for _ in range(3):
+        mgr._record_reconnect()
+    with patch("sendspin_bridge.services.bluetooth.persist_device_released"):
         assert mgr.maybe_auto_reclaim() is True
-    assert mgr._reconnect_timestamps == []
+    assert mgr.policy.reconnect_count() == 0
 
 
 def test_no_reclaim_when_management_already_enabled(released_manager):
@@ -114,36 +113,43 @@ def test_no_reclaim_when_management_already_enabled(released_manager):
     assert mgr.maybe_auto_reclaim() is False
 
 
-def test_auto_release_stamps_quiet_period_origin(released_manager):
-    """Both auto-release paths must stamp _auto_released_at and persist
+def test_auto_release_starts_the_quiet_period(released_manager):
+    """Both auto-release paths must start the quiet period and persist
     released_by="auto" so the reclaim gate can distinguish them from a
     manual release across the round-trip."""
     mgr = released_manager
     mgr.management_enabled = True
-    mgr._auto_released_at = None
+    now = [555.0]
+    mgr.policy._clock = lambda: now[0]
     mgr.max_reconnect_fails = 2
     mgr.paired = True
     mgr._has_ever_paired_since_start = True
-    with (
-        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=555.0),
-        patch("sendspin_bridge.services.bluetooth.persist_device_released") as persist_released,
-    ):
+    with patch("sendspin_bridge.services.bluetooth.persist_device_released") as persist_released:
         assert mgr._handle_reconnect_failure(3) is True
-    assert mgr._auto_released_at == 555.0
     persist_released.assert_called_once_with("TestSpeaker", True, released_by="auto")
 
+    mgr.host.status["bt_released_by"] = "auto"
+    assert mgr.maybe_auto_reclaim(connected=True) is False  # quiet period running
+    now[0] = 555.0 + 61
+    with patch("sendspin_bridge.services.bluetooth.persist_device_released"):
+        assert mgr.maybe_auto_reclaim(connected=True) is True
 
-def test_churn_release_stamps_quiet_period_origin(released_manager):
+
+def test_churn_release_starts_the_quiet_period(released_manager):
     mgr = released_manager
     mgr.management_enabled = True
-    mgr._auto_released_at = None
-    mgr._CHURN_THRESHOLD = 2
-    mgr._CHURN_WINDOW = 30
-    mgr._reconnect_timestamps = [90.0, 99.0]
-    with (
-        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=100.0),
-        patch("sendspin_bridge.services.bluetooth.persist_device_released") as persist_released,
-    ):
-        assert mgr._check_reconnect_churn() is True
-    assert mgr._auto_released_at == 100.0
+    now = [100.0]
+    mgr.policy._clock = lambda: now[0]
+    mgr.policy.churn_threshold = 2
+    mgr.policy.churn_window = 30
+    mgr._record_reconnect()
+    mgr._record_reconnect()
+    with patch("sendspin_bridge.services.bluetooth.persist_device_released") as persist_released:
+        assert mgr._handle_reconnect_failure(1) is True
     persist_released.assert_called_once_with("TestSpeaker", True, released_by="auto")
+
+    mgr.host.status["bt_released_by"] = "auto"
+    assert mgr.maybe_auto_reclaim(connected=True) is False
+    now[0] = 100.0 + 61
+    with patch("sendspin_bridge.services.bluetooth.persist_device_released"):
+        assert mgr.maybe_auto_reclaim(connected=True) is True

--- a/tests/unit/bluetooth/test_auto_reclaim_monitor.py
+++ b/tests/unit/bluetooth/test_auto_reclaim_monitor.py
@@ -32,7 +32,7 @@ async def test_finish_auto_reclaim_configures_audio_and_starts_player():
     assert await _finish_auto_reclaim(mgr, loop) is True
 
     mgr.configure_bluetooth_audio.assert_called_once()
-    mgr._record_reconnect.assert_called_once()
+    mgr.policy.record_reconnect.assert_called_once()
     mgr.host.start_subprocess.assert_awaited_once()
     status_update = mgr.host.update_status.call_args[0][0]
     assert status_update["bluetooth_connected"] is True

--- a/tests/unit/bluetooth/test_bt_manager.py
+++ b/tests/unit/bluetooth/test_bt_manager.py
@@ -701,37 +701,6 @@ async def test_monitor_dbus_raises_when_device_path_unavailable(bt_manager):
         await _monitor_dbus(bt_manager, None, None)
 
 
-def test_record_reconnect_prunes_old_entries(bt_manager):
-    """Only reconnects inside the churn window should be retained."""
-    bt_manager._CHURN_WINDOW = 10
-    with patch("sendspin_bridge.bluetooth.manager.time.monotonic", side_effect=[100.0, 111.0]):
-        bt_manager._record_reconnect()
-        bt_manager._record_reconnect()
-
-    assert bt_manager._reconnect_timestamps == [111.0]
-
-
-def test_check_reconnect_churn_disables_management(bt_manager):
-    """Churn threshold should auto-disable management and update host status."""
-    bt_manager._CHURN_THRESHOLD = 2
-    bt_manager._CHURN_WINDOW = 30
-    bt_manager._reconnect_timestamps = [90.0, 99.0]
-    bt_manager.host = MagicMock()
-    bt_manager.host.bt_management_enabled = True
-
-    with (
-        patch("sendspin_bridge.bluetooth.manager.time.monotonic", return_value=100.0),
-        patch("sendspin_bridge.services.bluetooth.persist_device_released") as persist_released,
-    ):
-        assert bt_manager._check_reconnect_churn() is True
-
-    assert bt_manager.management_enabled is False
-    assert bt_manager.host.bt_management_enabled is False
-    bt_manager.host.update_status.assert_called_once()
-    # released_by="auto" marks the release as auto-reclaim-eligible (#349/#350)
-    persist_released.assert_called_once_with("TestSpeaker", True, released_by="auto")
-
-
 def test_cancel_reconnect_clears_runtime_reconnect_status(bt_manager):
     mock_host = MagicMock()
     mock_host.get_status_value = MagicMock(return_value=True)

--- a/tests/unit/bluetooth/test_bt_monitor.py
+++ b/tests/unit/bluetooth/test_bt_monitor.py
@@ -9,7 +9,6 @@ so patches must target the *source module*, not ``bt_monitor.<name>``.
 """
 
 import asyncio
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -845,61 +844,6 @@ def test_reconnect_delay_caps_at_300(bt_manager):
 # ---------------------------------------------------------------------------
 # _record_reconnect and _check_reconnect_churn
 # ---------------------------------------------------------------------------
-
-
-def test_record_reconnect_adds_timestamp(bt_manager):
-    """_record_reconnect appends a monotonic timestamp."""
-    assert len(bt_manager._reconnect_timestamps) == 0
-
-    bt_manager._record_reconnect()
-
-    assert len(bt_manager._reconnect_timestamps) == 1
-
-
-def test_record_reconnect_prunes_outside_window(bt_manager):
-    """Timestamps outside the churn window are pruned on record."""
-    bt_manager._CHURN_WINDOW = 10
-    bt_manager._reconnect_timestamps = [time.monotonic() - 20]
-
-    bt_manager._record_reconnect()
-
-    assert len(bt_manager._reconnect_timestamps) == 1
-
-
-def test_check_reconnect_churn_returns_false_below_threshold(bt_manager):
-    """No churn release when reconnect count is below threshold."""
-    bt_manager._CHURN_THRESHOLD = 5
-    bt_manager._CHURN_WINDOW = 60
-    now = time.monotonic()
-    bt_manager._reconnect_timestamps = [now - 1, now - 2]
-
-    assert bt_manager._check_reconnect_churn() is False
-    assert bt_manager.management_enabled is True
-
-
-def test_check_reconnect_churn_disables_management_at_threshold(bt_manager):
-    """Churn detection disables management when threshold is reached."""
-    bt_manager._CHURN_THRESHOLD = 3
-    bt_manager._CHURN_WINDOW = 60
-    bt_manager.host = MagicMock()
-    bt_manager.host.bt_management_enabled = True
-
-    now = time.monotonic()
-    bt_manager._reconnect_timestamps = [now - 2, now - 1, now]
-
-    with patch("sendspin_bridge.services.bluetooth.persist_device_released"):
-        result = bt_manager._check_reconnect_churn()
-
-    assert result is True
-    assert bt_manager.management_enabled is False
-
-
-def test_check_reconnect_churn_disabled_threshold_zero(bt_manager):
-    """Churn detection is disabled when threshold is 0."""
-    bt_manager._CHURN_THRESHOLD = 0
-    bt_manager._reconnect_timestamps = [time.monotonic()] * 10
-
-    assert bt_manager._check_reconnect_churn() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/bluetooth/test_bt_monitor.py
+++ b/tests/unit/bluetooth/test_bt_monitor.py
@@ -560,7 +560,7 @@ async def test_inner_dbus_monitor_heartbeat_detects_missed_disconnect(bt_manager
         patch.object(loop, "run_in_executor", side_effect=_mock_run_in_executor),
         patch.object(bt_manager, "is_device_paired", return_value=True),
         # After heartbeat detects disconnect, _handle_reconnect_failure → True exits immediately
-        patch.object(bt_manager, "_handle_reconnect_failure", return_value=True),
+        patch.object(bt_manager, "handle_reconnect_failure", return_value=True),
     ):
         bt_manager.host = MagicMock()
         bt_manager.host.get_status_value = MagicMock(return_value=False)
@@ -638,7 +638,7 @@ async def test_inner_dbus_monitor_handle_reconnect_failure_returns(bt_manager):
     with (
         patch("sendspin_bridge.bluetooth.manager._bt_executor", new=None),
         patch.object(loop, "run_in_executor", side_effect=_mock_run_in_executor),
-        patch.object(bt_manager, "_handle_reconnect_failure", return_value=True),
+        patch.object(bt_manager, "handle_reconnect_failure", return_value=True),
         patch("sendspin_bridge.bluetooth.monitor.asyncio.sleep", new_callable=AsyncMock),
     ):
         # Should return without attempting connect
@@ -671,12 +671,12 @@ async def test_handle_reconnect_failure_runs_off_the_loop(bt_manager):
         patch("sendspin_bridge.bluetooth.manager._bt_executor", new=None),
         patch.object(loop, "run_in_executor", side_effect=_recording_executor),
         patch.object(bt_manager, "is_device_paired", return_value=True),
-        patch.object(bt_manager, "_handle_reconnect_failure", return_value=True),
+        patch.object(bt_manager, "handle_reconnect_failure", return_value=True),
         patch("sendspin_bridge.bluetooth.monitor.asyncio.sleep", new_callable=AsyncMock),
     ):
         await _inner_dbus_monitor(bt_manager, AsyncMock(), disconnect_event, asyncio.Event(), loop)
 
-    assert "_handle_reconnect_failure" in dispatched, "reconnect-failure handling was not offloaded"
+    assert "handle_reconnect_failure" in dispatched, "reconnect-failure handling was not offloaded"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/bluetooth/test_connection_transitions.py
+++ b/tests/unit/bluetooth/test_connection_transitions.py
@@ -1,0 +1,106 @@
+"""Connection callbacks must arrive in the order the state changed.
+
+The state write was serialised, but the callbacks fired outside the lock — so
+two threads flipping the link could run them in the opposite order and leave
+an MPRIS player registered for a speaker that had already disconnected, which
+is the inverse of the duplicate-registration bug the lock was added to fix.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from sendspin_bridge.bluetooth.manager import BluetoothManager
+
+MAC = "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(tmp_path, monkeypatch):
+    import sendspin_bridge.config as config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+
+
+def _manager(installed_bluez, events, *, on_connect_delay: float = 0.0):
+    installed_bluez.on("show", stdout="")
+
+    def _connected():
+        if on_connect_delay:
+            threading.Event().wait(on_connect_delay)
+        events.append("connected")
+
+    return BluetoothManager(
+        mac_address=MAC,
+        device_name="TestSpeaker",
+        on_connected=_connected,
+        on_disconnected=lambda: events.append("disconnected"),
+    )
+
+
+def test_transitions_fire_once_per_change(installed_bluez):
+    events: list[str] = []
+    mgr = _manager(installed_bluez, events)
+
+    mgr.apply_connected_state(True)
+    mgr.apply_connected_state(True)
+    mgr.apply_connected_state(False)
+
+    assert events == ["connected", "disconnected"]
+
+
+def test_a_slow_connect_callback_cannot_land_after_a_later_disconnect(installed_bluez):
+    """The bounce: a slow on_connected must not outlive the disconnect."""
+    events: list[str] = []
+    mgr = _manager(installed_bluez, events, on_connect_delay=0.15)
+
+    connect_thread = threading.Thread(target=mgr.apply_connected_state, args=(True,))
+    connect_thread.start()
+    threading.Event().wait(0.03)  # let the connect callback start
+    mgr.apply_connected_state(False)
+    connect_thread.join(timeout=5)
+
+    assert mgr.connected is False
+    assert events[-1] != "connected", f"a connect callback landed after the disconnect: {events}"
+
+
+def test_the_final_state_always_matches_the_last_callback(installed_bluez):
+    events: list[str] = []
+    mgr = _manager(installed_bluez, events, on_connect_delay=0.05)
+
+    threads = [
+        threading.Thread(target=mgr.apply_connected_state, args=(True,)),
+        threading.Thread(target=mgr.apply_connected_state, args=(False,)),
+        threading.Thread(target=mgr.apply_connected_state, args=(True,)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    if events:
+        expected = "connected" if mgr.connected else "disconnected"
+        assert events[-1] == expected, f"final state {mgr.connected} disagrees with callbacks {events}"
+
+
+def test_a_raising_callback_does_not_wedge_later_transitions(installed_bluez):
+    installed_bluez.on("show", stdout="")
+    events: list[str] = []
+
+    def _boom():
+        raise RuntimeError("callback exploded")
+
+    mgr = BluetoothManager(
+        mac_address=MAC,
+        device_name="TestSpeaker",
+        on_connected=_boom,
+        on_disconnected=lambda: events.append("disconnected"),
+    )
+
+    mgr.apply_connected_state(True)
+    mgr.apply_connected_state(False)
+
+    assert events == ["disconnected"]

--- a/tests/unit/bluetooth/test_manager_policy_delegation.py
+++ b/tests/unit/bluetooth/test_manager_policy_delegation.py
@@ -1,0 +1,155 @@
+"""The manager executes reconnect decisions; it no longer makes them.
+
+Backoff, churn and the release ladder are the policy's arithmetic.  The
+manager's job is the part the policy deliberately does not do: status
+updates, event publication and persistence.  These tests drive the manager
+with a policy on a fake clock — impossible while the counters and the
+timestamps lived on the manager itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sendspin_bridge.bluetooth.manager import BluetoothManager
+from sendspin_bridge.bluetooth.reconnect_policy import ReconnectPolicy
+
+MAC = "AA:BB:CC:DD:EE:FF"
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _Host:
+    def __init__(self):
+        self.status: dict = {}
+        self.bt_management_enabled = True
+
+    def get_status_value(self, key, default=None):
+        return self.status.get(key, default)
+
+    def update_status(self, updates):
+        self.status.update(updates)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(tmp_path, monkeypatch):
+    import sendspin_bridge.config as config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+
+
+@pytest.fixture()
+def clock():
+    return _Clock()
+
+
+@pytest.fixture()
+def bt_manager(installed_bluez, clock):
+    installed_bluez.on("show", stdout="")
+    mgr = BluetoothManager(
+        mac_address=MAC,
+        device_name="TestSpeaker",
+        check_interval=10,
+        max_reconnect_fails=3,
+        churn_threshold=3,
+        churn_window=300.0,
+    )
+    mgr.host = _Host()
+    mgr.policy = ReconnectPolicy(
+        check_interval=10,
+        max_fails=3,
+        churn_threshold=3,
+        churn_window=300.0,
+        clock=clock,
+    )
+    return mgr
+
+
+def test_the_manager_exposes_its_policy(installed_bluez):
+    installed_bluez.on("show", stdout="")
+    mgr = BluetoothManager(mac_address=MAC, device_name="TestSpeaker", check_interval=7)
+
+    assert isinstance(mgr.policy, ReconnectPolicy)
+    assert mgr.policy.check_interval == 7
+
+
+def test_backoff_comes_from_the_policy(bt_manager):
+    assert bt_manager._reconnect_delay(4) == bt_manager.policy.delay_for(4)
+
+
+def test_recorded_reconnects_land_in_the_policy(bt_manager, clock):
+    bt_manager._record_reconnect()
+    bt_manager._record_reconnect()
+
+    assert bt_manager.policy.reconnect_count() == 2
+
+    clock.advance(301)
+    assert bt_manager.policy.reconnect_count() == 0
+
+
+def test_churn_release_updates_status_and_stops_the_ladder(bt_manager):
+    for _ in range(3):
+        bt_manager._record_reconnect()
+
+    released = bt_manager._handle_reconnect_failure(1)
+
+    assert released is True
+    assert bt_manager.management_enabled is False
+    assert bt_manager.host.status["bt_released_by"] == "auto"
+    assert bt_manager.host.bt_management_enabled is False
+
+
+def test_failures_below_the_threshold_do_not_release(bt_manager):
+    assert bt_manager._handle_reconnect_failure(2) is False
+    assert bt_manager.management_enabled is True
+
+
+def test_reclaim_waits_out_the_policy_quiet_period(bt_manager, clock):
+    bt_manager.paired = True
+    bt_manager._has_ever_paired_since_start = True
+
+    assert bt_manager._handle_reconnect_failure(3) is True
+    assert bt_manager.management_enabled is False
+    bt_manager.host.status["bt_released_by"] = "auto"
+
+    assert bt_manager.maybe_auto_reclaim(connected=True) is False
+
+    clock.advance(61)
+    assert bt_manager.maybe_auto_reclaim(connected=True) is True
+    assert bt_manager.management_enabled is True
+    assert bt_manager.host.status["bt_released_by"] is None
+
+
+def test_reclaim_starts_the_churn_window_fresh(bt_manager, clock):
+    bt_manager.paired = True
+    bt_manager._has_ever_paired_since_start = True
+    for _ in range(2):
+        bt_manager._record_reconnect()
+    bt_manager._handle_reconnect_failure(3)
+    bt_manager.host.status["bt_released_by"] = "auto"
+    clock.advance(61)
+
+    assert bt_manager.maybe_auto_reclaim(connected=True) is True
+    assert bt_manager.policy.reconnect_count() == 0
+
+
+def test_an_unknown_link_state_never_reclaims(bt_manager, clock):
+    bt_manager.paired = True
+    bt_manager._has_ever_paired_since_start = True
+    bt_manager._handle_reconnect_failure(3)
+    bt_manager.host.status["bt_released_by"] = "auto"
+    clock.advance(61)
+
+    assert bt_manager.maybe_auto_reclaim(connected=None) is False
+    assert bt_manager.management_enabled is False

--- a/tests/unit/bluetooth/test_monitor_manager_interface.py
+++ b/tests/unit/bluetooth/test_monitor_manager_interface.py
@@ -1,0 +1,42 @@
+"""The monitor talks to the manager through a stated interface.
+
+Splitting the monitor loops into their own module did not create a seam: the
+module reached into nine private members of ``BluetoothManager`` across thirty
+call sites, including writing one of them.  Everything the monitor legitimately
+needs is now public on the manager (or on the reconnect policy), so this rule
+keeps the seam from silently eroding again — the same shape as the
+stdlib-only rule that guards the transport package.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_MONITOR = pathlib.Path("src/sendspin_bridge/bluetooth/monitor.py")
+
+#: Dunder attributes are Python's own, not the manager's private state.
+_ALLOWED = frozenset()
+
+
+def _private_manager_attributes() -> list[str]:
+    tree = ast.parse(_MONITOR.read_text())
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Name) or value.id != "mgr":
+            continue
+        name = node.attr
+        if name.startswith("__") or name in _ALLOWED:
+            continue
+        if name.startswith("_"):
+            found.append(f"{name} (line {node.lineno})")
+    return found
+
+
+def test_the_monitor_uses_no_private_manager_state():
+    offenders = _private_manager_attributes()
+
+    assert not offenders, "monitor.py reaches into BluetoothManager's private state: " + ", ".join(sorted(offenders))

--- a/tests/unit/bluetooth/test_reconnect_policy.py
+++ b/tests/unit/bluetooth/test_reconnect_policy.py
@@ -193,7 +193,9 @@ def test_reclaim_clears_the_churn_history(clock):
     assert isinstance(policy.on_failure(1, paired=True, ever_paired=True), KeepTrying)
 
 
-def test_a_policy_that_never_released_does_not_reclaim(clock):
+def test_a_release_carried_over_from_an_earlier_run_reclaims_at_once(clock):
+    """No quiet period to observe: the churn ended with the previous process."""
     policy = _policy(clock)
 
-    assert policy.may_reclaim(connected=True) is False
+    assert policy.may_reclaim(connected=True) is True
+    assert policy.may_reclaim(connected=False) is False

--- a/tests/unit/services/bluetooth/test_mpris_export.py
+++ b/tests/unit/services/bluetooth/test_mpris_export.py
@@ -1,0 +1,212 @@
+"""The MPRIS export is a resource with a lifecycle, not two loose hooks.
+
+Connect and disconnect used to schedule an export and an unexport
+fire-and-forget, with nothing ordering them.  On a reconnect bounce the
+unexport read a bus attribute the in-flight export had not set yet and
+returned; the export then finished, opening a system-bus connection and
+registering a player with BlueZ that nobody would ever unregister.  Each
+bounce leaked one socket and left one orphan registration, and a speaker
+that reconnect-loops does that until the process restarts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sendspin_bridge.services.bluetooth.mpris_export import MprisExport
+
+MAC = "AA:BB:CC:DD:EE:FF"
+ADAPTER_PATH = "/org/bluez/hci0"
+PATH = "/org/sendspin/players/AA_BB_CC_DD_EE_FF"
+
+
+class _FakeMedia:
+    def __init__(self, log: list[str]):
+        self._log = log
+
+    async def call_register_player(self, path, props):
+        self._log.append(f"register {path}")
+
+    async def call_unregister_player(self, path):
+        self._log.append(f"unregister {path}")
+
+
+class _FakeProxy:
+    def __init__(self, log: list[str]):
+        self._log = log
+
+    def get_interface(self, _name):
+        return _FakeMedia(self._log)
+
+
+class _FakeBus:
+    def __init__(self, log: list[str], connect_delay: float = 0.0):
+        self._log = log
+        self._connect_delay = connect_delay
+        self.connected = False
+        self.disconnected = False
+        self.exported: list[str] = []
+
+    async def connect(self):
+        if self._connect_delay:
+            await asyncio.sleep(self._connect_delay)
+        self.connected = True
+        self._log.append("bus connect")
+        return self
+
+    def export(self, path, _iface):
+        self.exported.append(path)
+        self._log.append(f"export {path}")
+
+    def unexport(self, path):
+        if path in self.exported:
+            self.exported.remove(path)
+        self._log.append(f"unexport {path}")
+
+    async def introspect(self, _service, _path):
+        return object()
+
+    def get_proxy_object(self, _service, _path, _introspection):
+        return _FakeProxy(self._log)
+
+    def disconnect(self):
+        self.disconnected = True
+        self._log.append("bus disconnect")
+
+
+@pytest.fixture()
+def log():
+    return []
+
+
+def _export(log, *, connect_delay: float = 0.0, buses: list | None = None):
+    def _bus_factory():
+        bus = _FakeBus(log, connect_delay=connect_delay)
+        if buses is not None:
+            buses.append(bus)
+        return bus
+
+    return MprisExport(
+        mac=MAC,
+        player=object(),
+        adapter_path_provider=lambda: ADAPTER_PATH,
+        bus_factory=_bus_factory,
+        iface_builder=lambda _player: object(),
+    )
+
+
+def test_export_registers_the_player_with_bluez(log):
+    export = _export(log)
+
+    assert asyncio.run(export.ensure_exported()) is True
+    assert log == ["bus connect", f"export {PATH}", f"register {PATH}"]
+
+
+def test_export_is_idempotent(log):
+    export = _export(log)
+
+    async def _run():
+        await export.ensure_exported()
+        await export.ensure_exported()
+
+    asyncio.run(_run())
+
+    assert log.count("bus connect") == 1
+    assert log.count(f"register {PATH}") == 1
+
+
+def test_unexport_unregisters_then_drops_the_connection(log):
+    export = _export(log)
+
+    async def _run():
+        await export.ensure_exported()
+        log.clear()
+        await export.ensure_unexported()
+
+    asyncio.run(_run())
+
+    assert log == [f"unregister {PATH}", f"unexport {PATH}", "bus disconnect"]
+
+
+def test_unexport_without_an_export_is_a_no_op(log):
+    export = _export(log)
+
+    asyncio.run(export.ensure_unexported())
+
+    assert log == []
+
+
+def test_a_bounce_leaves_nothing_registered_and_no_open_connection(log):
+    """The reconnect-bounce race: unexport starts while export is connecting."""
+    buses: list[_FakeBus] = []
+    export = _export(log, connect_delay=0.05, buses=buses)
+
+    async def _run():
+        exporting = asyncio.ensure_future(export.ensure_exported())
+        await asyncio.sleep(0)  # let the export reach its first await
+        await export.ensure_unexported()
+        await exporting
+
+    asyncio.run(_run())
+
+    assert log.count("bus connect") <= 1
+    registered = log.count(f"register {PATH}") - log.count(f"unregister {PATH}")
+    assert registered == 0, "BlueZ kept a registration for a player nobody will unregister"
+    assert all(bus.disconnected for bus in buses if bus.connected), "a system-bus connection leaked"
+    assert all(not bus.exported for bus in buses), "an object path stayed exported"
+
+
+def test_repeated_bounces_do_not_accumulate_connections(log):
+    buses: list[_FakeBus] = []
+    export = _export(log, connect_delay=0.01, buses=buses)
+
+    async def _run():
+        for _ in range(5):
+            exporting = asyncio.ensure_future(export.ensure_exported())
+            await asyncio.sleep(0)
+            await export.ensure_unexported()
+            await exporting
+
+    asyncio.run(_run())
+
+    open_connections = [bus for bus in buses if bus.connected and not bus.disconnected]
+    assert open_connections == []
+
+
+def test_a_repeated_connect_retires_the_previous_export(monkeypatch):
+    """BlueZ can repeat a connect transition on a flapping link."""
+    import sendspin_bridge.services.bluetooth.device_activation as activation
+
+    unexported: list[str] = []
+
+    class _Stale:
+        async def ensure_unexported(self):
+            unexported.append(MAC)
+
+    class _Loop:
+        def call_soon_threadsafe(self, *a, **kw):
+            return None
+
+    def _run_coroutine_threadsafe(coro, _loop):
+        asyncio.run(coro)
+
+        class _Future:
+            pass
+
+        return _Future()
+
+    monkeypatch.setitem(activation._EXPORTS, MAC, _Stale())
+    monkeypatch.setattr(activation.asyncio, "run_coroutine_threadsafe", _run_coroutine_threadsafe)
+    monkeypatch.setattr(activation, "MprisExport", lambda **kw: _Stale())
+    monkeypatch.setattr(
+        "sendspin_bridge.services.lifecycle.bridge_runtime_state.get_main_loop",
+        lambda: _Loop(),
+    )
+
+    client = type("_C", (), {"player_id": "p", "bt_manager": None})()
+    hook = activation._make_mpris_connected_hook(client, MAC)
+    hook()
+
+    assert unexported == [MAC], "the previous export was orphaned"


### PR DESCRIPTION
Stacked on #433, which is stacked on #432 — review those first. This PR's own commits are the five `C2 batch N` ones.

## Why

Two things in the Bluetooth layer had no owner:

**Reconnect decisions.** Backoff, churn detection, the never-paired auto-disable and the auto-reclaim quiet period are arithmetic over counters and a clock, but they lived inside `BluetoothManager`, tangled with the status writes and config persistence that carry them out. Reaching a decision meant standing up a manager and mocking its world — most of why the monitor's tests carried 182 mocks. And splitting the monitor loops into their own module never created a seam: `monitor.py` read and wrote nine private members of the manager across thirty call sites, so every decision the manager thought it owned could be made, or skipped, from outside.

**The MPRIS export.** Exporting a device's media player means three things that must be undone in order — a system-bus connection, an exported object path, and a `Media1.RegisterPlayer` pointer BlueZ keeps until told otherwise. Connect and disconnect scheduled those as two independent fire-and-forget coroutines, with the state kept as attributes hung off the player object and nothing ordering them.

## What changed

| Batch | Change |
|---|---|
| 1 | `ReconnectPolicy`: decisions as data (`KeepTrying`, `Churned`, `TryAdapterRecovery`, `DisableNeverPaired`, `ReleaseManagement`) over an injected clock. Sixteen table tests. |
| 2 | The manager executes verdicts instead of making them; the counters, the churn window and the released-at timestamp are gone from it. `check_interval` and `max_reconnect_fails` became properties over the policy. |
| 3 | A stated monitor-facing interface on the manager, with an AST rule keeping it from eroding — the same shape as the stdlib-only rule guarding the transport package. |
| 4 | `MprisExport` owns connection, path and registration behind one lock, with a generation counter so a late export abandons a superseded run. |
| 5 | Connection transitions dispatch in the order the state changed. |

## Bugs fixed on the way

- **Leak on every reconnect bounce.** The unexport read a bus attribute the in-flight export had not written yet, decided there was nothing to undo, and returned; the export then completed, leaving one leaked socket and one BlueZ registration for a player already dropped from the registry. A speaker that reconnect-loops repeated that until the process restarted, with BlueZ still routing AVRCP key-presses at objects that were gone. The interleaved bounce is now a test.
- **Callbacks arriving out of order.** A slow `on_connected` could land after a later disconnect and leave an MPRIS player registered for a speaker that was already gone — the inverse of the duplicate-registration bug the state lock was added to prevent.
- **A repeated connect** without an intervening disconnect now retires the previous export instead of orphaning it.

## One behaviour clarified rather than preserved

`may_reclaim` treats "no release recorded this run" as reclaimable, which is what the old code did by falling through the quiet-period check: a release carried over from a previous run has no quiet period to observe, since the churn that caused it ended with the process. My own policy test had asserted the opposite; it now states the real rule. Called out here because it is the one place where the refactor's first draft would have changed behaviour.

## Tests that moved with the seam

Seven manager tests that reached into `_reconnect_timestamps`, `_CHURN_*` and `_check_reconnect_churn` are covered by the policy's table tests. The auto-reclaim tests drive the policy's clock instead of patching `time.monotonic` inside the manager.

## Verification

```
uv run pytest -q            # 3200 passed, 1 skipped
uv run ruff check src tests
uv run mypy --config-file pyproject.toml src/sendspin_bridge
uv run python scripts/lint_changelog.py CHANGELOG.md
```

Not yet verified on hardware — the live stand needs an SSH key this machine does not have. The bounce path in particular is worth a run on a real flapping speaker before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)