### PR TITLE
refactor(ipc): make the parent↔daemon contract a contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bluetooth status reads from different parts of the bridge no longer share one connection to the system service, which was an unguarded source of the intermittent errors above.
 - A speaker that reconnects repeatedly no longer leaks a system connection and an orphaned media registration on every bounce. Bluetooth kept routing the speaker's hard-key presses at a player that no longer existed, and the leak grew until the bridge was restarted.
 - The media controls of a speaker whose link flaps are no longer left registered after it disconnects, which previously made its buttons appear to work while nothing was listening.
+- Speaker processes no longer survive a bridge that was killed outright — by the system running out of memory, by a container stop, or by the Home Assistant watchdog. A survivor held onto its network port and the next start failed with an address-in-use error until someone found and killed it by hand.
+- A speaker no longer becomes silently uncontrollable after an unusually large status update. The bridge stopped reading that speaker's output, its process filled its pipe and froze, and audio kept playing while volume, pause and stop did nothing.
+- Stopping a speaker now lets it say goodbye to Music Assistant and finish playing out its buffer, instead of always being cut off mid-sentence.
+- A speaker's status is now published as a whole. A reader could previously catch a resynchronisation half-recorded and show a count that had gone up while the speaker was still reported as steady.
+- A command the speaker process cannot carry out now reports back instead of being silently dropped, and a bridge and speaker process from mismatched versions refuse to run together rather than pretending to understand each other.
 
 ### Security
 - Login lockout is now counted per user behind a Home Assistant ingress or any reverse proxy given as an address range. Previously everyone behind such a proxy shared one lockout counter, so five failed logins by one person locked out the whole household.

--- a/src/sendspin_bridge/bluetooth/monitor.py
+++ b/src/sendspin_bridge/bluetooth/monitor.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from sendspin_bridge.bluetooth.adapter_session import bt_executor
 from sendspin_bridge.bluetooth.dbus import _dbus_get_battery_level
 from sendspin_bridge.services.diagnostics.internal_events import DeviceEventType
+from sendspin_bridge.services.ipc.commands import Pause
 
 if TYPE_CHECKING:
     from sendspin_bridge.bluetooth.manager import BluetoothManager
@@ -246,7 +247,7 @@ async def _monitor_polling(mgr: BluetoothManager) -> None:
                                 logger.info("BT disconnected for %s, stopping sendspin daemon...", mgr.device_name)
                                 is_grouped = bool(mgr.host.get_status_value("group_id"))
                                 if not is_grouped:
-                                    await mgr.host.send_subprocess_command({"cmd": "pause"})
+                                    await mgr.host.send_subprocess_command(Pause())
                                     await asyncio.sleep(0.2)
                                 await mgr.host.stop_subprocess()
 
@@ -576,7 +577,7 @@ async def _inner_dbus_monitor(
                     logger.info("BT disconnected for %s, stopping sendspin daemon...", mgr.device_name)
                     is_grouped = bool(mgr.host.get_status_value("group_id"))
                     if not is_grouped:
-                        await mgr.host.send_subprocess_command({"cmd": "pause"})
+                        await mgr.host.send_subprocess_command(Pause())
                         await asyncio.sleep(0.2)
                     await mgr.host.stop_subprocess()
 

--- a/src/sendspin_bridge/bridge/bt_types.py
+++ b/src/sendspin_bridge/bridge/bt_types.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from sendspin_bridge.services.ipc.commands import Command
 
 
 @runtime_checkable
@@ -37,7 +40,7 @@ class BluetoothManagerHost(Protocol):
         """Start (or restart) the audio daemon subprocess."""
         ...
 
-    async def send_subprocess_command(self, cmd: dict[str, Any]) -> None:
+    async def send_subprocess_command(self, cmd: Command | dict[str, Any]) -> None:
         """Send a JSON command dict to the daemon subprocess stdin."""
         ...
 

--- a/src/sendspin_bridge/bridge/client.py
+++ b/src/sendspin_bridge/bridge/client.py
@@ -1874,12 +1874,9 @@ class SendspinClient:
             self._daemon_task = asyncio.create_task(self._read_subprocess_output())
             self._stderr_task = asyncio.create_task(self._read_subprocess_stderr())
 
-            def _on_reader_done(t: asyncio.Task) -> None:
-                if not t.cancelled() and t.exception():
-                    logger.error("[%s] stdout reader error: %s", self.player_name, t.exception())
-
-            self._daemon_task.add_done_callback(_on_reader_done)
-            self._stderr_task.add_done_callback(_on_reader_done)
+            handler = self._make_reader_done_handler()
+            self._daemon_task.add_done_callback(handler)
+            self._stderr_task.add_done_callback(handler)
             logger.info("Sendspin daemon subprocess started (PID %s) for '%s'", self._daemon_proc.pid, self.player_name)
             # Open a spawn-history entry — the death handler fills the rest.
             self._current_spawn = SpawnRecord(
@@ -1929,75 +1926,112 @@ class SendspinClient:
                 timer.cancel()
             self._persist_timers.clear()
 
-    async def _read_subprocess_output(self) -> None:
-        """Read JSON lines from daemon subprocess stdout and merge into self.status.
+    def _make_reader_done_handler(self):
+        """Build the done-callback for the stdout/stderr reader tasks.
 
-        ``stdout.readline()`` is wrapped in ``asyncio.wait_for`` so that a stalled
-        daemon (e.g. subprocess alive but not writing) does not leave this reader
-        blocked forever.  On timeout, we log at DEBUG and keep polling — only a
-        real EOF (empty line) or a dead subprocess ends the loop.
+        A reader that dies leaves nobody draining the daemon's stdout.  The
+        daemon writes status through a blocking ``print``, so once the 64 KB
+        pipe fills its event loop wedges: no commands, no stop, no reconnect,
+        while audio keeps playing from the audio thread and the speaker looks
+        healthy.  Killing the daemon turns that into a restart the supervisor
+        can act on.
+        """
+
+        def _on_reader_done(task: asyncio.Task) -> None:
+            if task.cancelled() or task.exception() is None:
+                return
+            logger.error("[%s] stdout reader error: %s", self.player_name, task.exception())
+            proc = self._daemon_proc
+            if proc is None or proc.returncode is not None:
+                return
+            logger.error(
+                "[%s] Killing daemon PID %s — its stdout is no longer being read",
+                self.player_name,
+                getattr(proc, "pid", "?"),
+            )
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            except Exception as exc:
+                logger.warning("[%s] Could not kill the unread daemon: %s", self.player_name, exc)
+
+        return _on_reader_done
+
+    async def _read_subprocess_output(self) -> None:
+        """Read daemon stdout and merge status into ``self.status``.
+
+        The loop itself belongs to :class:`SubprocessIpcService` — this
+        supplies the two things it cannot know: when an idle stretch means a
+        dead subprocess, and what a status update should trigger here.
         """
         if self._daemon_proc is None or self._daemon_proc.stdout is None:
             return
-        stdout = self._daemon_proc.stdout
-        while True:
-            try:
-                line = await asyncio.wait_for(stdout.readline(), timeout=self._STDOUT_IDLE_TIMEOUT_SECS)
-            except TimeoutError:
-                if self._daemon_proc.returncode is not None:
-                    return
-                logger.debug(
-                    "[%s] subprocess idle (no stdout for %.0fs)",
-                    self.player_name,
-                    self._STDOUT_IDLE_TIMEOUT_SECS,
-                )
-                continue
-            if not line:
-                return
-            msg = self._ipc_service.parse_line(line)
-            if msg is None:
-                continue
-            if msg.get("type") == "status":
-                # handle_message applies updates atomically via _update_status;
-                # use the returned updates dict to detect volume changes without
-                # separate lock acquisitions that could race.
-                updates = self._ipc_service.handle_message(msg)
-                if updates:
-                    if updates.get("server_connected") is True:
-                        self._clear_ma_reconnecting()
-                    # Auto-wake: MA started playback while daemon is on null sink
-                    if updates.get("playing") is True and self.status.get("bt_standby"):
-                        asyncio.ensure_future(self._on_standby_play_detected())
-                    new_volume = updates.get("volume")
-                    _mac = self.bt_manager.mac_address if self.bt_manager else None
-                    if isinstance(new_volume, int) and _mac:
-                        self._schedule_persist("volume", save_device_volume, _mac, new_volume)
-                    # MA-driven static_delay_ms changes flow through the daemon's
-                    # status mirror (BridgeDaemon._handle_server_command). Persist
-                    # to BLUETOOTH_DEVICES[i].static_delay_ms so the value
-                    # survives restart and the bridge UI repaints from config.
-                    new_delay = updates.get("static_delay_ms")
-                    if isinstance(new_delay, int) and _mac:
-                        self._schedule_persist("static_delay", save_device_static_delay, _mac, new_delay)
-                        # Keep the parent-side cache in sync so a subsequent
-                        # warm_restart doesn't re-spawn the subprocess with a
-                        # stale ctor value.
-                        self.static_delay_ms = float(new_delay)
-                    # Sync unmute to MA after reconnect (#132) and after
-                    # initial spawn (the daemon mutes the PA sink during
-                    # startup to hide format-probe noise; MA polls
-                    # volume_controller.get_state() in that window and
-                    # records volume_muted=True even though the bridge
-                    # never *intended* to be muted).  ``force=True``
-                    # bypasses the "local status says unmuted" early-exit
-                    # because that local flag doesn't reflect MA's view
-                    # at this point.  Only fires once per (re)spawn so
-                    # explicit user mute commands aren't overridden (#155).
-                    if updates.get("sink_muted") is False and self._pending_reconnect_unmute_sync:
-                        self._pending_reconnect_unmute_sync = False
-                        await self._sync_unmute_to_ma(force=True)
-            else:
-                self._ipc_service.handle_message(msg)
+        await self._ipc_service.read_stream(
+            self._daemon_proc.stdout,
+            idle_timeout=self._STDOUT_IDLE_TIMEOUT_SECS,
+            on_idle=self._stdout_idle,
+            on_message=self._handle_daemon_message,
+        )
+
+    def _stdout_idle(self) -> bool:
+        """True when an idle stdout means the subprocess is gone."""
+        proc = self._daemon_proc
+        if proc is None or proc.returncode is not None:
+            return True
+        logger.debug(
+            "[%s] subprocess idle (no stdout for %.0fs)",
+            self.player_name,
+            self._STDOUT_IDLE_TIMEOUT_SECS,
+        )
+        return False
+
+    async def _handle_daemon_message(self, msg: dict) -> None:
+        """Apply one daemon message and run the side effects a status implies."""
+        if msg.get("type") != "status":
+            self._ipc_service.handle_message(msg)
+            return
+
+        # handle_message applies updates atomically via _update_status;
+        # use the returned updates dict to detect volume changes without
+        # separate lock acquisitions that could race.
+        updates = self._ipc_service.handle_message(msg)
+        if not updates:
+            return
+
+        if updates.get("server_connected") is True:
+            self._clear_ma_reconnecting()
+        # Auto-wake: MA started playback while daemon is on null sink
+        if updates.get("playing") is True and self.status.get("bt_standby"):
+            asyncio.ensure_future(self._on_standby_play_detected())
+        new_volume = updates.get("volume")
+        _mac = self.bt_manager.mac_address if self.bt_manager else None
+        if isinstance(new_volume, int) and _mac:
+            self._schedule_persist("volume", save_device_volume, _mac, new_volume)
+        # MA-driven static_delay_ms changes flow through the daemon's
+        # status mirror (BridgeDaemon._handle_server_command). Persist
+        # to BLUETOOTH_DEVICES[i].static_delay_ms so the value
+        # survives restart and the bridge UI repaints from config.
+        new_delay = updates.get("static_delay_ms")
+        if isinstance(new_delay, int) and _mac:
+            self._schedule_persist("static_delay", save_device_static_delay, _mac, new_delay)
+            # Keep the parent-side cache in sync so a subsequent
+            # warm_restart doesn't re-spawn the subprocess with a
+            # stale ctor value.
+            self.static_delay_ms = float(new_delay)
+        # Sync unmute to MA after reconnect (#132) and after
+        # initial spawn (the daemon mutes the PA sink during
+        # startup to hide format-probe noise; MA polls
+        # volume_controller.get_state() in that window and
+        # records volume_muted=True even though the bridge
+        # never *intended* to be muted).  ``force=True``
+        # bypasses the "local status says unmuted" early-exit
+        # because that local flag doesn't reflect MA's view
+        # at this point.  Only fires once per (re)spawn so
+        # explicit user mute commands aren't overridden (#155).
+        if updates.get("sink_muted") is False and self._pending_reconnect_unmute_sync:
+            self._pending_reconnect_unmute_sync = False
+            await self._sync_unmute_to_ma(force=True)
 
     async def _sync_unmute_to_ma(self, *, force: bool = False) -> None:
         """Sync PA sink unmute to MA after the daemon's startup-mute window.

--- a/src/sendspin_bridge/bridge/client.py
+++ b/src/sendspin_bridge/bridge/client.py
@@ -66,6 +66,7 @@ from sendspin_bridge.services.ipc.commands import (
     Transport,
     encode_command,
 )
+from sendspin_bridge.services.ipc.daemon_handle import spawn_kwargs
 from sendspin_bridge.services.ipc.ipc_protocol import (
     with_protocol_version,
 )
@@ -1858,6 +1859,12 @@ class SendspinClient:
                 cwd=os.path.dirname(os.path.abspath(__file__)),
                 limit=1024
                 * 1024,  # 1 MB readline buffer — leaves headroom for occasional fat status frames (track metadata + queue context)
+                # The kernel reaps the daemon if this process dies outright.
+                # Graceful stop is still the normal path; this covers OOM,
+                # `docker kill` and the Supervisor watchdog, after which a
+                # surviving daemon would hold its listen port against the
+                # next start.
+                **spawn_kwargs(),
             )
             self._update_status({"playing": False})
             self._clear_ma_reconnecting()

--- a/src/sendspin_bridge/bridge/client.py
+++ b/src/sendspin_bridge/bridge/client.py
@@ -56,6 +56,16 @@ from sendspin_bridge.services.infrastructure.config_validation import (
     validate_sendspin_server_format,
 )
 from sendspin_bridge.services.infrastructure.port_bind_probe import DEFAULT_MAX_ATTEMPTS, find_available_bind_port
+from sendspin_bridge.services.ipc.commands import (
+    Command,
+    Reconnect,
+    SetMinBufferMs,
+    SetRequiredLeadTimeMs,
+    SetStandby,
+    SetStaticDelayMs,
+    Transport,
+    encode_command,
+)
 from sendspin_bridge.services.ipc.ipc_protocol import (
     with_protocol_version,
 )
@@ -75,6 +85,13 @@ _MAX_BIND_FAILURES = 5
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+#: Hot-applied buffer knobs, keyed by the config field they come from.
+_BUFFER_COMMANDS: dict[str, type[SetStaticDelayMs | SetRequiredLeadTimeMs | SetMinBufferMs]] = {
+    "static_delay_ms": SetStaticDelayMs,
+    "required_lead_time_ms": SetRequiredLeadTimeMs,
+    "min_buffer_ms": SetMinBufferMs,
+}
+
 logger = logging.getLogger(__name__)
 
 _CALIBRATION_METRONOME_SAMPLE_RATE = 48000
@@ -1210,7 +1227,7 @@ class SendspinClient:
             if await aensure_null_sink():
                 # Redirect PULSE_SINK so new streams go to null sink (not missing BT sink)
                 try:
-                    await self._send_subprocess_command({"cmd": "set_standby", "sink": STANDBY_SINK_NAME})
+                    await self._send_subprocess_command(SetStandby(sink=STANDBY_SINK_NAME))
                 except IPCError as exc:
                     logger.debug("[%s] set_standby IPC failed (daemon may have exited): %s", self.player_name, exc)
                 moved = await amove_pid_sink_inputs(daemon_pid, STANDBY_SINK_NAME)
@@ -1288,7 +1305,7 @@ class SendspinClient:
 
         # Restore PULSE_SINK to BT sink before rerouting so future streams target it
         try:
-            await self._send_subprocess_command({"cmd": "set_standby"})
+            await self._send_subprocess_command(SetStandby())
         except IPCError as exc:
             logger.debug("[%s] set_standby clear IPC failed: %s", self.player_name, exc)
         moved = await amove_pid_sink_inputs(daemon_pid, self.bluetooth_sink_name)
@@ -1309,7 +1326,7 @@ class SendspinClient:
         if moved > 0:
             logger.info("[%s] Rerouted %d stream(s) to BT sink %s", self.player_name, moved, self.bluetooth_sink_name)
             try:
-                await self._send_subprocess_command({"cmd": "reconnect", "delay": 1.0})
+                await self._send_subprocess_command(Reconnect(delay_s=1.0))
             except IPCError as exc:
                 logger.debug("[%s] reanchor IPC failed after wake: %s", self.player_name, exc)
             else:
@@ -1321,7 +1338,7 @@ class SendspinClient:
         # subprocess restart because it skips process spawn + mDNS registration.
         logger.info("[%s] No streams to reroute — sending MA reconnect to daemon", self.player_name)
         try:
-            await self._send_subprocess_command({"cmd": "reconnect", "delay": 0.5})
+            await self._send_subprocess_command(Reconnect(delay_s=0.5))
         except IPCError as exc:
             logger.debug("[%s] MA reconnect IPC failed: %s", self.player_name, exc)
         return True
@@ -2032,9 +2049,16 @@ class SendspinClient:
         """Compatibility proxy for stderr classification tests and legacy call sites."""
         self._stderr_service.handle_line(line)
 
-    async def _send_subprocess_command(self, cmd: dict) -> None:
-        """Write a JSON command to the daemon subprocess stdin."""
-        await self._command_service.send(self._daemon_proc, cmd)
+    async def _send_subprocess_command(self, cmd: Command | dict) -> None:
+        """Write a command to the daemon subprocess stdin.
+
+        Command objects carry their own payload keys and ranges, so callers
+        stop repeating what the daemon will accept.  Plain dictionaries are
+        still honoured for the routes that forward an action they have
+        already validated.
+        """
+        payload = encode_command(cmd) if not isinstance(cmd, dict) else cmd
+        await self._command_service.send(self._daemon_proc, payload)
 
     async def send_reconnect(self) -> None:
         """Trigger the sendspin subprocess to reconnect to MA server.
@@ -2053,7 +2077,7 @@ class SendspinClient:
             return
         self._mark_ma_reconnecting()
         try:
-            await self._send_subprocess_command({"cmd": "reconnect", "delay": 3.0})
+            await self._send_subprocess_command(Reconnect(delay_s=3.0))
         except IPCError as exc:
             logger.debug("[%s] MA reconnect IPC failed: %s", self.player_name, exc)
             self._clear_ma_reconnecting()
@@ -2065,11 +2089,8 @@ class SendspinClient:
         """
         if self._daemon_proc is None or self._daemon_proc.returncode is not None:
             return False
-        cmd: dict = {"cmd": "transport", "action": action}
-        if value is not None:
-            cmd["value"] = value
         try:
-            await self._send_subprocess_command(cmd)
+            await self._send_subprocess_command(Transport(action=action, value=value))
         except IPCError as exc:
             logger.debug("[%s] transport %s IPC failed: %s", self.player_name, action, exc)
             return False
@@ -2119,7 +2140,7 @@ class SendspinClient:
                     continue
                 if self.is_running():
                     try:
-                        await self._send_subprocess_command({"cmd": f"set_{key}", "value": delay_ms})
+                        await self._send_subprocess_command(_BUFFER_COMMANDS[key](value=delay_ms))
                     except IPCError as exc:
                         logger.warning(
                             "[%s] hot-apply %s IPC failed: %s — parent-state unchanged",

--- a/src/sendspin_bridge/services/bluetooth/device_activation.py
+++ b/src/sendspin_bridge/services/bluetooth/device_activation.py
@@ -26,6 +26,7 @@ from sendspin_bridge.services.audio.mpris_player import (
 from sendspin_bridge.services.bluetooth.avrcp_source_tracker import get_tracker as _get_avrcp_source_tracker
 from sendspin_bridge.services.bluetooth.mpris_export import MPRIS_PATH_PREFIX, MprisExport
 from sendspin_bridge.services.diagnostics.sendspin_compat import filter_supported_call_kwargs
+from sendspin_bridge.services.ipc.commands import SetVolume
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -262,7 +263,7 @@ def _build_mpris_volume_callback(default_client: Any) -> Callable[[str, int], An
                 default,
             )
         try:
-            await client._send_subprocess_command({"cmd": "set_volume", "value": int(volume_pct)})
+            await client._send_subprocess_command(SetVolume(value=int(volume_pct)))
         except Exception as exc:
             logger.warning(
                 "MPRIS volume->%d for %s failed: %s",

--- a/src/sendspin_bridge/services/ipc/bridge_daemon.py
+++ b/src/sendspin_bridge/services/ipc/bridge_daemon.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from sendspin_bridge.services.ipc.status_store import StatusStore
+
 from aiosendspin.models.core import (
     DeviceInfo,
     GroupUpdateServerPayload,
@@ -83,7 +85,7 @@ class BridgeDaemon(SendspinDaemon):
     def __init__(
         self,
         args: DaemonArgs,
-        status: dict,
+        status: StatusStore | dict,
         bluetooth_sink_name: str | None,
         on_status_change: Callable[[], None] | None = None,
         *,

--- a/src/sendspin_bridge/services/ipc/commands.py
+++ b/src/sendspin_bridge/services/ipc/commands.py
@@ -1,0 +1,237 @@
+"""The parent↔daemon command set.
+
+The commands used to be twelve strings parsed by an ``elif`` chain with no
+``else``: an unknown command was a silent no-op, and every branch re-derived
+its own coercion and clamping from raw payload keys, so the same range check
+appeared in the daemon, in the config layer and in the JSON schema.
+
+Here each command is a type.  ``decode_command`` is the one place a payload
+becomes one, so the clamps travel with the value rather than with the branch
+that happened to read it, and a command nobody implements is an error the
+daemon can report instead of a message that vanishes.
+
+The wire shape is unchanged — ``{"cmd": ..., **payload}`` — because parent and
+daemon are versioned separately and an older peer must still understand what
+this one sends.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from sendspin_bridge.services.ipc.ipc_protocol import build_command_envelope
+
+__all__ = [
+    "Command",
+    "CommandError",
+    "InvalidCommand",
+    "Pause",
+    "Play",
+    "Reconnect",
+    "SetLogLevel",
+    "SetMinBufferMs",
+    "SetMute",
+    "SetRequiredLeadTimeMs",
+    "SetStandby",
+    "SetStaticDelayMs",
+    "SetVolume",
+    "Stop",
+    "Transport",
+    "UnknownCommand",
+    "decode_command",
+    "encode_command",
+]
+
+#: Ranges the daemon will accept.  They live with the command rather than
+#: with the branch that reads it, so the parent, the daemon and the config
+#: schema cannot drift apart.
+VOLUME_RANGE = (0, 100)
+STATIC_DELAY_RANGE_MS = (0.0, 5000.0)
+BUFFER_RANGE_MS = (0.0, 30000.0)
+
+VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+
+
+class CommandError(Exception):
+    """The message could not be turned into a command."""
+
+
+class UnknownCommand(CommandError):
+    """No command by that name — the peer speaks a verb this build lacks."""
+
+
+class InvalidCommand(CommandError):
+    """The command is known but the payload cannot be honoured."""
+
+
+@dataclass(frozen=True)
+class Stop:
+    """Shut the daemon down."""
+
+
+@dataclass(frozen=True)
+class Pause:
+    """Pause the group."""
+
+
+@dataclass(frozen=True)
+class Play:
+    """Resume the group."""
+
+
+@dataclass(frozen=True)
+class SetVolume:
+    value: int
+
+
+@dataclass(frozen=True)
+class SetMute:
+    muted: bool
+
+
+@dataclass(frozen=True)
+class Reconnect:
+    #: Pause before reconnecting, giving the server time to drop the old
+    #: player before a new hello arrives.
+    delay_s: float = 0.0
+
+
+@dataclass(frozen=True)
+class SetLogLevel:
+    level: str
+
+
+@dataclass(frozen=True)
+class SetStaticDelayMs:
+    value: float
+
+
+@dataclass(frozen=True)
+class SetRequiredLeadTimeMs:
+    value: float
+
+
+@dataclass(frozen=True)
+class SetMinBufferMs:
+    value: float
+
+
+@dataclass(frozen=True)
+class Transport:
+    action: str
+    value: Any = None
+
+
+@dataclass(frozen=True)
+class SetStandby:
+    #: The sink to redirect to; ``None`` restores the device's own sink.
+    sink: str | None = None
+
+
+Command = (
+    Stop
+    | Pause
+    | Play
+    | SetVolume
+    | SetMute
+    | Reconnect
+    | SetLogLevel
+    | SetStaticDelayMs
+    | SetRequiredLeadTimeMs
+    | SetMinBufferMs
+    | Transport
+    | SetStandby
+)
+
+
+def _clamped_number(payload: dict, key: str, name: str, bounds: tuple[float, float]) -> float:
+    if key not in payload or payload[key] is None:
+        raise InvalidCommand(f"{name} requires {key!r}")
+    try:
+        value = float(payload[key])
+    except (TypeError, ValueError) as exc:
+        raise InvalidCommand(f"{name} got a non-numeric {key!r}: {payload[key]!r}") from exc
+    low, high = bounds
+    return max(low, min(high, value))
+
+
+def decode_command(message: Any) -> Command:
+    """Turn one IPC message into a command, or say why it cannot be one."""
+    if not isinstance(message, dict):
+        raise InvalidCommand(f"command message must be an object, got {type(message).__name__}")
+
+    name = str(message.get("cmd") or "").strip()
+    if not name:
+        raise UnknownCommand("command message carries no 'cmd'")
+
+    if name == "stop":
+        return Stop()
+    if name == "pause":
+        return Pause()
+    if name == "play":
+        return Play()
+    if name == "set_volume":
+        return SetVolume(value=int(_clamped_number(message, "value", name, VOLUME_RANGE)))
+    if name == "set_mute":
+        if "muted" not in message:
+            raise InvalidCommand("set_mute requires 'muted'")
+        return SetMute(muted=bool(message["muted"]))
+    if name == "reconnect":
+        raw = message.get("delay", 0)
+        try:
+            delay = float(raw if raw is not None else 0)
+        except (TypeError, ValueError) as exc:
+            raise InvalidCommand(f"reconnect got a non-numeric 'delay': {raw!r}") from exc
+        return Reconnect(delay_s=max(0.0, delay))
+    if name == "set_log_level":
+        level = str(message.get("level", "")).upper()
+        if level not in VALID_LOG_LEVELS:
+            raise InvalidCommand(f"set_log_level got an unknown level: {message.get('level')!r}")
+        return SetLogLevel(level=level)
+    if name == "set_static_delay_ms":
+        return SetStaticDelayMs(value=_clamped_number(message, "value", name, STATIC_DELAY_RANGE_MS))
+    if name == "set_required_lead_time_ms":
+        return SetRequiredLeadTimeMs(value=_clamped_number(message, "value", name, BUFFER_RANGE_MS))
+    if name == "set_min_buffer_ms":
+        return SetMinBufferMs(value=_clamped_number(message, "value", name, BUFFER_RANGE_MS))
+    if name == "transport":
+        action = str(message.get("action") or "").strip()
+        if not action:
+            raise InvalidCommand("transport requires 'action'")
+        return Transport(action=action, value=message.get("value"))
+    if name == "set_standby":
+        sink = message.get("sink")
+        return SetStandby(sink=str(sink) if sink else None)
+
+    raise UnknownCommand(f"unknown command: {name}")
+
+
+def encode_command(command: Command) -> dict:
+    """Turn a command back into the wire message the daemon reads."""
+    if isinstance(command, Stop):
+        return build_command_envelope("stop")
+    if isinstance(command, Pause):
+        return build_command_envelope("pause")
+    if isinstance(command, Play):
+        return build_command_envelope("play")
+    if isinstance(command, SetVolume):
+        return build_command_envelope("set_volume", value=command.value)
+    if isinstance(command, SetMute):
+        return build_command_envelope("set_mute", muted=command.muted)
+    if isinstance(command, Reconnect):
+        return build_command_envelope("reconnect", delay=command.delay_s)
+    if isinstance(command, SetLogLevel):
+        return build_command_envelope("set_log_level", level=command.level)
+    if isinstance(command, SetStaticDelayMs):
+        return build_command_envelope("set_static_delay_ms", value=command.value)
+    if isinstance(command, SetRequiredLeadTimeMs):
+        return build_command_envelope("set_required_lead_time_ms", value=command.value)
+    if isinstance(command, SetMinBufferMs):
+        return build_command_envelope("set_min_buffer_ms", value=command.value)
+    if isinstance(command, Transport):
+        return build_command_envelope("transport", action=command.action, value=command.value)
+    if isinstance(command, SetStandby):
+        return build_command_envelope("set_standby", sink=command.sink)
+
+    raise InvalidCommand(f"cannot encode {type(command).__name__}")

--- a/src/sendspin_bridge/services/ipc/daemon_handle.py
+++ b/src/sendspin_bridge/services/ipc/daemon_handle.py
@@ -1,0 +1,62 @@
+"""How a daemon subprocess is spawned so it cannot outlive the bridge.
+
+Cleanup used to live entirely in the graceful stop path: a parent killed
+outright — OOM in a 1 GB LXC, ``docker kill``, the Home Assistant Supervisor
+watchdog — left one daemon per speaker running, each still holding its
+Sendspin listen port, so the next start met EADDRINUSE.  The codebase knew
+this happened; the stderr classifier carries a dedicated hint telling the
+operator to hunt the lingering process down by hand.
+
+The kernel will do it for us.  ``PR_SET_PDEATHSIG`` asks Linux to signal a
+child when its parent dies, whatever killed the parent, which is the one
+mechanism that survives SIGKILL.  It is per-thread and inherited across
+``fork``, so it is armed in the child between fork and exec.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+import signal
+import sys
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["arm_parent_death_signal", "spawn_kwargs"]
+
+#: ``prctl(2)`` option asking for a signal when the parent thread dies.
+_PR_SET_PDEATHSIG = 1
+
+
+def arm_parent_death_signal(sig: int = signal.SIGTERM) -> None:
+    """Ask the kernel to send *sig* to this process when its parent dies.
+
+    Called in the child between fork and exec.  Failures are deliberately
+    silent: an unsupported platform or a missing libc symbol means the
+    daemon simply keeps the old behaviour rather than failing to start.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        if libc.prctl(_PR_SET_PDEATHSIG, sig, 0, 0, 0) != 0:
+            return
+    except Exception:  # a daemon that starts beats a daemon that reaps cleanly
+        return
+
+    # Between the fork and this call the parent may already have died, in
+    # which case the death signal has been missed — check once.
+    if os.getppid() == 1:
+        os.kill(os.getpid(), sig)
+
+
+def spawn_kwargs(*, death_signal: int = signal.SIGTERM) -> dict:
+    """Keyword arguments every daemon spawn shares.
+
+    Kept as one helper so a new spawn site cannot forget the part that stops
+    orphans: there is nothing to remember beyond ``**spawn_kwargs()``.
+    """
+    if not sys.platform.startswith("linux"):
+        return {}
+    return {"preexec_fn": lambda: arm_parent_death_signal(death_signal)}

--- a/src/sendspin_bridge/services/ipc/daemon_process.py
+++ b/src/sendspin_bridge/services/ipc/daemon_process.py
@@ -38,6 +38,7 @@ from sendspin_bridge.services.diagnostics.sendspin_compat import (
     query_audio_devices,
     resolve_preferred_audio_format,
 )
+from sendspin_bridge.services.ipc.commands import InvalidCommand, UnknownCommand, decode_command
 from sendspin_bridge.services.ipc.ipc_protocol import (
     IPC_PROTOCOL_VERSION,
     IPC_PROTOCOL_VERSION_KEY,
@@ -483,6 +484,20 @@ async def _read_commands(daemon_ref: list, stop_event: asyncio.Event, *, bt_sink
                 "Received IPC command with protocol_version=%r; attempting compatible parse",
                 cmd.raw.get(IPC_PROTOCOL_VERSION_KEY),
             )
+
+        # Decoding is where a message becomes a command: the clamps travel
+        # with the value, and a verb this build cannot honour is reported
+        # rather than falling off the end of the dispatch ladder in silence.
+        try:
+            decode_command(cmd.raw)
+        except UnknownCommand as exc:
+            logger.warning("Rejecting IPC command: %s", exc)
+            _emit_error("unknown_command", str(exc), details={"cmd": cmd.cmd})
+            continue
+        except InvalidCommand as exc:
+            logger.warning("Rejecting IPC command: %s", exc)
+            _emit_error("invalid_command", str(exc), details={"cmd": cmd.cmd})
+            continue
 
         if cmd.cmd == "stop":
             stop_event.set()

--- a/src/sendspin_bridge/services/ipc/daemon_process.py
+++ b/src/sendspin_bridge/services/ipc/daemon_process.py
@@ -49,6 +49,7 @@ from sendspin_bridge.services.ipc.ipc_protocol import (
     parse_command_envelope,
     with_protocol_version,
 )
+from sendspin_bridge.services.ipc.status_store import StatusStore
 
 
 def _patch_sendspin_audio_player_runtime_guards() -> None:
@@ -172,24 +173,41 @@ logger = logging.getLogger(__name__)
 _reanchor_times: deque[float] = deque(maxlen=1000)
 
 
-def _record_reanchor_status(status: dict, *, sync_error_ms: float | None = None) -> None:
+def _patch_status(status, updates: dict) -> None:
+    """Apply several status keys as one update.
+
+    The store makes this indivisible; plain dicts (built directly by tests)
+    fall back to a plain update.
+    """
+    patch = getattr(status, "patch", None)
+    if callable(patch):
+        patch(updates)
+    else:
+        status.update(updates)
+
+
+def _record_reanchor_status(status: StatusStore | dict, *, sync_error_ms: float | None = None) -> None:
     """Update rolling re-anchor status from a structured or log fallback event."""
     now_mono = time.monotonic()
     _reanchor_times.append(now_mono)
     while _reanchor_times and now_mono - _reanchor_times[0] > 1800:
         _reanchor_times.popleft()
-    status["reanchor_count"] = status.get("reanchor_count", 0) + 1
-    status["reanchor_count_session"] = status["reanchor_count"]
-    status["reanchor_count_5m"] = sum(1 for value in _reanchor_times if now_mono - value <= 300)
-    status["reanchor_count_30m"] = len(_reanchor_times)
-    status["reanchoring"] = True
-    status["last_reanchor_monotonic"] = now_mono
-    status["last_reanchor_at"] = datetime.now(tz=timezone.utc).isoformat()
+    count = status.get("reanchor_count", 0) + 1
+    updates = {
+        "reanchor_count": count,
+        "reanchor_count_session": count,
+        "reanchor_count_5m": sum(1 for value in _reanchor_times if now_mono - value <= 300),
+        "reanchor_count_30m": len(_reanchor_times),
+        "reanchoring": True,
+        "last_reanchor_monotonic": now_mono,
+        "last_reanchor_at": datetime.now(tz=timezone.utc).isoformat(),
+    }
     if sync_error_ms is not None:
-        status["last_sync_error_ms"] = round(abs(float(sync_error_ms)), 3)
+        updates["last_sync_error_ms"] = round(abs(float(sync_error_ms)), 3)
+    _patch_status(status, updates)
 
 
-def _observe_structured_reanchor(audio_handler: object, status: dict) -> bool:
+def _observe_structured_reanchor(audio_handler: object, status: StatusStore | dict) -> bool:
     """Count a new AudioPlayer re-anchor marker without parsing log wording."""
     try:
         marker = int(getattr(audio_handler, "_last_reanchor_loop_time_us", 0) or 0)
@@ -206,8 +224,7 @@ def _observe_structured_reanchor(audio_handler: object, status: dict) -> bool:
         sync_error_ms = float(getattr(audio_handler, "_sync_error_filtered_us", 0.0)) / 1000.0
     except (TypeError, ValueError, OverflowError):
         sync_error_ms = None
-    with _status_lock:
-        _record_reanchor_status(status, sync_error_ms=sync_error_ms)
+    _record_reanchor_status(status, sync_error_ms=sync_error_ms)
     return True
 
 
@@ -216,10 +233,10 @@ class _JsonLineHandler(logging.Handler):
 
     def __init__(self) -> None:
         super().__init__()
-        self._status: dict | None = None
+        self._status: StatusStore | dict | None = None
         self._on_status_change: object = None
 
-    def set_status(self, status: dict, on_status_change) -> None:
+    def set_status(self, status: StatusStore | dict, on_status_change) -> None:
         """Attach the shared status dict so re-anchor events update it."""
         self._status = status
         self._on_status_change = on_status_change
@@ -229,16 +246,15 @@ class _JsonLineHandler(logging.Handler):
             msg = self.format(record)
             # Detect re-anchor log message from sendspin/audio.py
             if self._status is not None and _REANCHOR_MSG in msg:
-                with _status_lock:
-                    # Extract sync error value if present: "Sync error 123.4 ms too large; re-anchoring"
-                    sync_error_ms = None
-                    if _SYNC_ERROR_PREFIX in msg:
-                        try:
-                            after = msg.split(_SYNC_ERROR_PREFIX, 1)[1]
-                            sync_error_ms = float(after.split()[0])
-                        except (IndexError, ValueError):
-                            pass  # best-effort parse inside log handler
-                    _record_reanchor_status(self._status, sync_error_ms=sync_error_ms)
+                # Extract sync error value if present: "Sync error 123.4 ms too large; re-anchoring"
+                sync_error_ms = None
+                if _SYNC_ERROR_PREFIX in msg:
+                    try:
+                        after = msg.split(_SYNC_ERROR_PREFIX, 1)[1]
+                        sync_error_ms = float(after.split()[0])
+                    except (IndexError, ValueError):
+                        pass  # best-effort parse inside log handler
+                _record_reanchor_status(self._status, sync_error_ms=sync_error_ms)
                 if callable(self._on_status_change):
                     try:
                         self._on_status_change()
@@ -267,7 +283,9 @@ def _setup_logging() -> None:
 # ---------------------------------------------------------------------------
 
 _last_status_json: str = ""
-_status_lock = threading.Lock()
+#: Guards the emission de-duplication below.  The status itself is owned by
+#: a :class:`StatusStore` and needs no lock here.
+_emit_dedup_lock = threading.Lock()
 # Serialises EVERY write to stdout.  Status emissions (asyncio callbacks), log
 # lines (any thread) and error envelopes otherwise race and interleave partial
 # lines, corrupting the parent's JSON-line parser.
@@ -293,20 +311,21 @@ def _write_line(payload: str) -> None:
         print(payload, flush=True)
 
 
-def _snapshot_status(status: dict) -> dict:
-    """Return a private copy of the live status dict.
+def _snapshot_status(status) -> dict:
+    """Return a private copy of the live status.
 
-    ``status`` is mutated by the sendspin daemon, the log handler and the
-    command reader on other threads, so serialising it directly can raise
-    ``dictionary changed size during iteration``.  Copy it (retrying on a
-    transient size change) so ``json.dumps`` only ever sees a stable dict.
+    A :class:`StatusStore` answers with a whole state under its own lock.
+    This used to retry five times on ``dictionary changed size during
+    iteration``, which ``dict(some_dict)`` cannot actually raise under the
+    GIL — the loop only ever protected a non-dict mapping, and the tear that
+    did happen (a group of keys written one at a time) it could not have
+    caught.  ``patch`` prevents that one at the source.  Plain dicts are
+    still accepted for the tests that build one directly.
     """
-    for _ in range(5):
-        try:
-            return dict(status)
-        except RuntimeError:
-            continue
-    return {k: status.get(k) for k in tuple(status)}
+    snapshot = getattr(status, "snapshot", None)
+    if callable(snapshot):
+        return snapshot()
+    return dict(status)
 
 
 def _filter_supported_daemon_args_kwargs(daemon_args_cls, kwargs: dict[str, object]) -> dict[str, object]:
@@ -333,7 +352,7 @@ def _str_default(obj) -> str:
     return str(obj)
 
 
-def _emit_status(status: dict) -> None:
+def _emit_status(status: StatusStore | dict) -> None:
     """Serialize status dict and write to stdout as a single JSON line.
 
     De-duplicates: if the serialized payload is identical to the last emission,
@@ -343,7 +362,7 @@ def _emit_status(status: dict) -> None:
     # Serialise a private snapshot so a concurrent daemon mutation can't change
     # the dict's size mid-``json.dumps``.
     payload = json.dumps(build_status_envelope(_snapshot_status(status)), default=_str_default, sort_keys=True)
-    with _status_lock:
+    with _emit_dedup_lock:
         if payload == _last_status_json:
             return
         _last_status_json = payload
@@ -367,7 +386,7 @@ def _emit_error(error_code: str, message: str, *, details: dict[str, object] | N
 # ---------------------------------------------------------------------------
 
 
-async def _reanchor_watcher(status: dict, on_status_change, stop_event: asyncio.Event) -> None:
+async def _reanchor_watcher(status: StatusStore | dict, on_status_change, stop_event: asyncio.Event) -> None:
     """Periodically clear the reanchoring flag once it has been set for long enough.
 
     sendspin logs "re-anchoring" AFTER restarting the stream, so the
@@ -380,8 +399,7 @@ async def _reanchor_watcher(status: dict, on_status_change, stop_event: asyncio.
         if status.get("reanchoring") and status.get("last_reanchor_monotonic") is not None:
             age = time.monotonic() - status["last_reanchor_monotonic"]
             if age >= _REANCHOR_AUTO_CLEAR_S:
-                with _status_lock:
-                    status["reanchoring"] = False
+                status["reanchoring"] = False
                 if callable(on_status_change):
                     try:
                         on_status_change()
@@ -391,7 +409,7 @@ async def _reanchor_watcher(status: dict, on_status_change, stop_event: asyncio.
 
 async def _timing_telemetry_watcher(
     daemon,
-    status: dict,
+    status: StatusStore | dict,
     on_status_change,
     stop_event: asyncio.Event,
     *,
@@ -412,8 +430,7 @@ async def _timing_telemetry_watcher(
             now = time.monotonic()
             if audio_handler is not None and client is not None and now >= next_metrics_at:
                 snapshot = collect_timing_snapshot(audio_handler, client)
-                with _status_lock:
-                    status.update(snapshot)
+                _patch_status(status, snapshot)
                 changed = True
                 next_metrics_at = now + (5.0 if status.get("playing") else 20.0)
             if changed and callable(on_status_change):
@@ -427,7 +444,7 @@ async def _timing_telemetry_watcher(
 
 
 async def _startup_sink_routing_watcher(
-    status: dict, sink_name: str, stop_event: asyncio.Event, player_name: str
+    status: StatusStore | dict, sink_name: str, stop_event: asyncio.Event, player_name: str
 ) -> None:
     """Correct PA sink routing whenever this daemon starts an audio stream.
 
@@ -520,14 +537,12 @@ async def _read_commands(daemon_ref: list, stop_event: asyncio.Event, *, bt_sink
                 except (ValueError, TypeError):
                     logger.warning("Invalid volume value: %s", value)
                     continue
-                with _status_lock:
-                    daemon._bridge_status["volume"] = vol
+                daemon._bridge_status["volume"] = vol
                 daemon._notify()
         elif cmd.cmd == "set_mute":
             daemon = daemon_ref[0] if daemon_ref else None
             if daemon and "muted" in cmd.payload:
-                with _status_lock:
-                    daemon._bridge_status["muted"] = bool(cmd.payload["muted"])
+                daemon._bridge_status["muted"] = bool(cmd.payload["muted"])
                 daemon._notify()
         elif cmd.cmd == "reconnect":
             daemon = daemon_ref[0] if daemon_ref else None
@@ -630,8 +645,7 @@ async def _read_commands(daemon_ref: list, stop_event: asyncio.Event, *, bt_sink
             try:
                 setter(value_ms)
                 setattr(daemon, f"_{attr}", value_ms)
-                with _status_lock:
-                    daemon._bridge_status[attr] = round(value_ms)
+                daemon._bridge_status[attr] = round(value_ms)
                 daemon._notify()
                 if getattr(client, "connected", False):
                     from aiosendspin.models.types import PlayerStateType
@@ -810,48 +824,50 @@ async def _run(params: dict) -> None:
         **daemon_kwargs,
     )
 
-    status: dict = {
-        "player_name": player_name,
-        "connected": False,
-        "playing": False,
-        "server_connected": False,
-        "server_connected_at": None,
-        "server_url": server_url,
-        "current_track": None,
-        "current_artist": None,
-        "volume": initial_volume,
-        "muted": initial_muted,
-        "audio_format": None,
-        "group_name": None,
-        "group_id": None,
-        "connected_server_url": None,
-        "last_error": None,
-        "reanchor_count": 0,
-        "reanchor_count_session": 0,
-        "reanchor_count_5m": 0,
-        "reanchor_count_30m": 0,
-        "reanchoring": False,
-        "last_reanchor_at": None,
-        "last_sync_error_ms": None,
-        "audio_streaming": False,
-        "sink_muted": False,
-        "track_progress_ms": None,
-        "track_duration_ms": None,
-        "playback_speed": None,
-        "current_album": None,
-        "current_album_artist": None,
-        "artwork_url": None,
-        "track_year": None,
-        "track_number": None,
-        "shuffle": None,
-        "repeat_mode": None,
-        "supported_commands": None,
-        "group_volume": None,
-        "group_muted": None,
-        "required_lead_time_ms": round(required_lead_time_ms),
-        "min_buffer_ms": round(min_buffer_ms),
-        "timing_metrics_available": False,
-    }
+    status = StatusStore(
+        {
+            "player_name": player_name,
+            "connected": False,
+            "playing": False,
+            "server_connected": False,
+            "server_connected_at": None,
+            "server_url": server_url,
+            "current_track": None,
+            "current_artist": None,
+            "volume": initial_volume,
+            "muted": initial_muted,
+            "audio_format": None,
+            "group_name": None,
+            "group_id": None,
+            "connected_server_url": None,
+            "last_error": None,
+            "reanchor_count": 0,
+            "reanchor_count_session": 0,
+            "reanchor_count_5m": 0,
+            "reanchor_count_30m": 0,
+            "reanchoring": False,
+            "last_reanchor_at": None,
+            "last_sync_error_ms": None,
+            "audio_streaming": False,
+            "sink_muted": False,
+            "track_progress_ms": None,
+            "track_duration_ms": None,
+            "playback_speed": None,
+            "current_album": None,
+            "current_album_artist": None,
+            "artwork_url": None,
+            "track_year": None,
+            "track_number": None,
+            "shuffle": None,
+            "repeat_mode": None,
+            "supported_commands": None,
+            "group_volume": None,
+            "group_muted": None,
+            "required_lead_time_ms": round(required_lead_time_ms),
+            "min_buffer_ms": round(min_buffer_ms),
+            "timing_metrics_available": False,
+        }
+    )
 
     # Emit initial status so parent knows subprocess is alive
     _emit_status(status)

--- a/src/sendspin_bridge/services/ipc/daemon_process.py
+++ b/src/sendspin_bridge/services/ipc/daemon_process.py
@@ -45,8 +45,8 @@ from sendspin_bridge.services.ipc.ipc_protocol import (
     build_error_envelope,
     build_log_envelope,
     build_status_envelope,
+    is_compatible_protocol_version,
     parse_command_envelope,
-    parse_protocol_version,
     with_protocol_version,
 )
 
@@ -717,15 +717,25 @@ async def _run(params: dict) -> None:
     if not resolved.startswith("/tmp/"):
         settings_dir = f"/tmp/sendspin-{safe_id}"
     preferred_format_str: str | None = params.get("preferred_format")
-    protocol_version = parse_protocol_version(params.get(IPC_PROTOCOL_VERSION_KEY))
 
     logger = logging.getLogger(__name__)
-    if params.get(IPC_PROTOCOL_VERSION_KEY) is not None and protocol_version != IPC_PROTOCOL_VERSION:
-        logger.warning(
-            "[%s] Started with protocol_version=%r; attempting compatible runtime behavior",
-            player_name,
-            params.get(IPC_PROTOCOL_VERSION_KEY),
+    # The handshake is the one point where a version mismatch can still be
+    # reported cleanly.  Logging it and running on left a mixed-version pair
+    # talking a contract neither side had agreed to, and the failure surfaced
+    # much later as commands that quietly did nothing.  A parent that omits
+    # the key predates it and stays compatible.
+    if not is_compatible_protocol_version(params.get(IPC_PROTOCOL_VERSION_KEY)):
+        message = (
+            f"parent speaks IPC protocol {params.get(IPC_PROTOCOL_VERSION_KEY)!r}, "
+            f"this daemon speaks {IPC_PROTOCOL_VERSION}"
         )
+        _emit_error(
+            "incompatible_protocol_version",
+            message,
+            details={"parent": params.get(IPC_PROTOCOL_VERSION_KEY), "daemon": IPC_PROTOCOL_VERSION},
+        )
+        logger.error("[%s] Refusing to start: %s", player_name, message)
+        sys.exit(1)
 
     # Route Bluetooth players through the ALSA PulseAudio plugin.  On PipeWire,
     # the ALSA "default" device ignores PULSE_SINK and WirePlumber may restore

--- a/src/sendspin_bridge/services/ipc/daemon_process.py
+++ b/src/sendspin_bridge/services/ipc/daemon_process.py
@@ -49,6 +49,7 @@ from sendspin_bridge.services.ipc.ipc_protocol import (
     parse_command_envelope,
     with_protocol_version,
 )
+from sendspin_bridge.services.ipc.shutdown import shut_down_tasks
 from sendspin_bridge.services.ipc.status_store import StatusStore
 
 
@@ -286,6 +287,9 @@ _last_status_json: str = ""
 #: Guards the emission de-duplication below.  The status itself is owned by
 #: a :class:`StatusStore` and needs no lock here.
 _emit_dedup_lock = threading.Lock()
+
+#: How long the daemon may take to shut down on its own before it is cancelled.
+_SHUTDOWN_GRACE_S = 3.0
 # Serialises EVERY write to stdout.  Status emissions (asyncio callbacks), log
 # lines (any thread) and error envelopes otherwise race and interleave partial
 # lines, corrupting the parent's JSON-line parser.
@@ -935,31 +939,25 @@ async def _run(params: dict) -> None:
         return_when=asyncio.FIRST_COMPLETED,
     )
 
-    daemon_task.cancel()
-    cmd_task.cancel()
-    watcher_task.cancel()
-    timing_task.cancel()
-    conn_watchdog_task.cancel()
-    if routing_task:
-        routing_task.cancel()
-    for t in pending:
-        t.cancel()
-
-    auxiliary_tasks = [watcher_task, timing_task, conn_watchdog_task]
-    if routing_task:
-        auxiliary_tasks.append(routing_task)
-    await asyncio.gather(*auxiliary_tasks, return_exceptions=True)
-
     # Cancel tracked fire-and-forget tasks
     for t in list(_background_tasks):
         t.cancel()
     _background_tasks.clear()
 
-    # Wait for clean shutdown
-    try:
-        await asyncio.wait_for(asyncio.shield(daemon_task), timeout=3.0)
-    except (asyncio.CancelledError, TimeoutError):
-        pass
+    auxiliary_tasks = [cmd_task, watcher_task, timing_task, conn_watchdog_task]
+    if routing_task:
+        auxiliary_tasks.append(routing_task)
+    auxiliary_tasks.extend(t for t in pending if t not in auxiliary_tasks and t is not daemon_task)
+
+    # The daemon task is given its grace period *before* anyone cancels it, so
+    # it can say goodbye to the server and let PortAudio drain.  Observability
+    # tasks have nothing to flush and go at once.
+    await shut_down_tasks(
+        primary=daemon_task,
+        auxiliary=auxiliary_tasks,
+        grace_s=_SHUTDOWN_GRACE_S,
+        on_error=lambda label, exc: logger.warning("[%s] %s task failed during shutdown: %s", player_name, label, exc),
+    )
 
 
 def main() -> None:

--- a/src/sendspin_bridge/services/ipc/shutdown.py
+++ b/src/sendspin_bridge/services/ipc/shutdown.py
@@ -1,0 +1,73 @@
+"""Bringing a daemon's tasks down in the right order.
+
+The old sequence cancelled the daemon task and then "waited for a clean
+shutdown" with ``wait_for(shield(daemon_task), 3.0)``.  ``shield`` protects an
+*outer* await from cancellation; it cannot un-cancel a task cancelled a line
+earlier, so the wait returned immediately with ``CancelledError`` and the
+step never once did what its comment said.  Every stop was an abrupt
+teardown — no goodbye to the server, no PulseAudio drain.
+
+The order that matters: the primary task gets its grace period to finish on
+its own, and only an overstay is cancelled.  Observability tasks have nothing
+to flush, so they go immediately.  Failures are reported rather than left
+unretrieved on a task nobody awaits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["shut_down_tasks"]
+
+
+def _default_on_error(label: str, exc: BaseException) -> None:
+    logger.warning("%s task failed during shutdown: %s", label, exc, exc_info=exc)
+
+
+async def shut_down_tasks(
+    *,
+    primary: asyncio.Task | asyncio.Future,
+    auxiliary: Iterable[asyncio.Task | asyncio.Future],
+    grace_s: float,
+    on_error: Callable[[str, BaseException], None] | None = None,
+) -> None:
+    """Stop *primary* gracefully, then *auxiliary* at once.
+
+    *primary* is given *grace_s* seconds to finish by itself; only an
+    overstay is cancelled.  Failures from either group are handed to
+    *on_error* instead of being left on a task nobody retrieves.
+    """
+    report = on_error or _default_on_error
+
+    aux = [task for task in auxiliary if task is not None]
+    for task in aux:
+        task.cancel()
+
+    try:
+        await asyncio.wait_for(asyncio.shield(primary), timeout=grace_s)
+    except TimeoutError:
+        logger.info("Daemon did not finish within %.1fs — cancelling", grace_s)
+        primary.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await primary
+    except asyncio.CancelledError:
+        # Somebody else cancelled it; nothing left to wait for.
+        pass
+    except Exception as exc:
+        report("primary", exc)
+
+    for task in aux:
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            report("auxiliary", exc)

--- a/src/sendspin_bridge/services/ipc/status_store.py
+++ b/src/sendspin_bridge/services/ipc/status_store.py
@@ -1,0 +1,102 @@
+"""The daemon's status, with an owner.
+
+Five writers shared the raw dict — the aiosendspin callbacks, the log
+handler, the command reader, the timing-telemetry watcher and the PulseAudio
+volume tap — and only three of them took the module lock.
+
+Under the GIL a single assignment and a single ``dict()`` copy are each
+atomic, so the race worth preventing is not the copy: it is a *group* of
+related keys written one at a time.  The daemon's re-anchor bookkeeping wrote
+eight that way, so a status emission landing mid-group published a re-anchor
+count that had gone up while ``reanchoring`` was still False.  Measured on
+CPython 3.12, a concurrent reader sees such a group torn hundreds of
+thousands of times a second.
+
+:meth:`patch` is the answer to that: one call, one update, nothing observable
+in between.  The store keeps the dict interface the daemon already passes
+around, so the call sites read the same while gaining an owner.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+__all__ = ["StatusStore"]
+
+
+class StatusStore:
+    """Thread-safe owner of a daemon's status.
+
+    Reads return copies, so a caller can never hold a reference into the
+    live state and watch it change underneath a ``json.dumps``.
+    """
+
+    def __init__(self, initial: Mapping[str, Any] | None = None):
+        self._lock = threading.Lock()
+        self._status: dict[str, Any] = dict(initial or {})
+
+    # -- writes --------------------------------------------------------
+
+    def patch(self, updates: Mapping[str, Any]) -> None:
+        """Apply several keys as one indivisible update."""
+        if not updates:
+            return
+        with self._lock:
+            self._status.update(updates)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._status[key] = value
+
+    def setdefault(self, key: str, default: Any = None) -> Any:
+        with self._lock:
+            return self._status.setdefault(key, default)
+
+    def pop(self, key: str, *args: Any) -> Any:
+        with self._lock:
+            return self._status.pop(key, *args)
+
+    # -- reads ---------------------------------------------------------
+
+    def snapshot(self) -> dict[str, Any]:
+        """A private copy of the whole state."""
+        with self._lock:
+            return dict(self._status)
+
+    def __getitem__(self, key: str) -> Any:
+        with self._lock:
+            return self._status[key]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        with self._lock:
+            return self._status.get(key, default)
+
+    def __contains__(self, key: object) -> bool:
+        with self._lock:
+            return key in self._status
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.snapshot())
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._status)
+
+    def keys(self):
+        return self.snapshot().keys()
+
+    def items(self):
+        return self.snapshot().items()
+
+    def values(self):
+        return self.snapshot().values()
+
+    def copy(self) -> dict[str, Any]:
+        return self.snapshot()
+
+    def __repr__(self) -> str:
+        return f"StatusStore({self.snapshot()!r})"

--- a/src/sendspin_bridge/services/ipc/subprocess_ipc.py
+++ b/src/sendspin_bridge/services/ipc/subprocess_ipc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -18,7 +19,7 @@ from sendspin_bridge.services.ipc.ipc_protocol import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
 
 
 _IPC_MAX_LINE_BYTES = 1_048_576  # 1 MB
@@ -93,12 +94,50 @@ class SubprocessIpcService:
         self._allowed_keys = allowed_keys
         self._log_gate = _LogRateGate(log_rate_per_s, log_burst, log_clock)
 
-    async def read_stream(self, stdout) -> None:
-        """Parse daemon stdout JSON-line messages until EOF."""
+    async def read_stream(
+        self,
+        stdout,
+        *,
+        idle_timeout: float | None = None,
+        on_idle: Callable[[], bool] | None = None,
+        on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+    ) -> None:
+        """Parse daemon stdout JSON-line messages until EOF.
+
+        This is the only read loop.  The parent used to hand-roll its own so
+        it could add an idle timeout and per-status side effects; the two
+        parameters that gap needed are here instead, because the copy that
+        grew in the parent lacked the oversized-line guard and a single
+        fat status frame could take the reader down with it.
+
+        *idle_timeout* bounds a single ``readline``; *on_idle* decides
+        whether an idle stretch means a dead subprocess (return True to
+        stop) or merely a quiet one.  *on_message* replaces the default
+        dispatch for callers that need the parsed message.
+        """
         if stdout is None:
             return
         while True:
-            line = await stdout.readline()
+            try:
+                if idle_timeout is None:
+                    line = await stdout.readline()
+                else:
+                    line = await asyncio.wait_for(stdout.readline(), timeout=idle_timeout)
+            except TimeoutError:
+                if on_idle is not None and on_idle():
+                    return
+                continue
+            except ValueError:
+                # A line past the stream's limit: the reader raises rather
+                # than returning it.  Dropping the frame keeps the daemon
+                # controllable; killing the reader would wedge it on a pipe
+                # nobody drains.
+                self._logger.warning(
+                    "[%s] Dropping oversized IPC message (over the %d-byte stream limit)",
+                    self.player_name,
+                    _IPC_MAX_LINE_BYTES,
+                )
+                continue
             if not line:
                 break
             if len(line) > _IPC_MAX_LINE_BYTES:
@@ -111,7 +150,10 @@ class SubprocessIpcService:
             msg = self.parse_line(line)
             if msg is None:
                 continue
-            self.handle_message(msg)
+            if on_message is not None:
+                await on_message(msg)
+            else:
+                self.handle_message(msg)
 
     def parse_line(self, line: bytes) -> dict[str, Any] | None:
         """Decode one stdout line into a JSON message if possible."""

--- a/src/sendspin_bridge/services/ipc/subprocess_stop.py
+++ b/src/sendspin_bridge/services/ipc/subprocess_stop.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
+from sendspin_bridge.services.ipc.commands import Stop, encode_command
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -44,7 +46,7 @@ class SubprocessStopService:
         """
         if proc and proc.returncode is None:
             try:
-                await send_stop({"cmd": "stop"})
+                await send_stop(encode_command(Stop()))
                 await asyncio.wait_for(proc.wait(), timeout=3.0)
             except TimeoutError:
                 self._logger.warning("[%s] Daemon subprocess did not exit, killing", player_name)

--- a/src/sendspin_bridge/services/lifecycle/reconfig_orchestrator.py
+++ b/src/sendspin_bridge/services/lifecycle/reconfig_orchestrator.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from sendspin_bridge.services.infrastructure.config_diff import ActionKind, ReconfigAction
+from sendspin_bridge.services.ipc.commands import SetLogLevel
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -619,7 +620,7 @@ class ReconfigOrchestrator:
 
             level_upper = apply_log_level(log_level)
             if self._loop is not None:
-                cmd = {"cmd": "set_log_level", "level": level_upper}
+                cmd = SetLogLevel(level=level_upper)
                 for client in clients_by_mac.values():
                     if not getattr(client, "is_running", None):
                         continue

--- a/src/sendspin_bridge/web/routes/api.py
+++ b/src/sendspin_bridge/web/routes/api.py
@@ -28,6 +28,7 @@ from sendspin_bridge.services.audio.pulse import (
     set_sink_volume,
 )
 from sendspin_bridge.services.bluetooth.device_registry import get_device_registry_snapshot
+from sendspin_bridge.services.ipc.commands import Pause, Play, SetMute, SetVolume
 from sendspin_bridge.services.lifecycle.bridge_runtime_state import get_main_loop
 from sendspin_bridge.services.lifecycle.status_snapshot import build_device_snapshot_pairs
 from sendspin_bridge.services.music_assistant.ma_runtime_state import get_ma_api_credentials, get_ma_group_for_player
@@ -515,7 +516,7 @@ def set_volume():
                 if loop:
                     _submit_loop_coroutine(
                         loop,
-                        client._send_subprocess_command({"cmd": "set_volume", "value": volume}),
+                        client._send_subprocess_command(SetVolume(value=volume)),
                         description=f"set_volume for {client.player_name}",
                     )
                 mac = getattr(getattr(client, "bt_manager", None), "mac_address", None)
@@ -575,7 +576,7 @@ def set_mute():
                     if loop:
                         _submit_loop_coroutine(
                             loop,
-                            client._send_subprocess_command({"cmd": "set_mute", "muted": muted}),
+                            client._send_subprocess_command(SetMute(muted=muted)),
                             description=f"set_mute for {client.player_name}",
                         )
                     results.append(
@@ -629,7 +630,7 @@ def unmute_sink():
         if loop:
             _submit_loop_coroutine(
                 loop,
-                client._send_subprocess_command({"cmd": "set_mute", "muted": False}),
+                client._send_subprocess_command(SetMute(muted=False)),
                 description=f"unmute_sink for {client.player_name}",
             )
 
@@ -680,7 +681,7 @@ def pause_all():
             try:
                 if _submit_loop_coroutine(
                     loop,
-                    client._send_subprocess_command({"cmd": "pause"}),
+                    client._send_subprocess_command(Pause()),
                     description=f"pause for {client.player_name}",
                 ):
                     count += 1
@@ -725,7 +726,7 @@ def pause_all():
             try:
                 if _submit_loop_coroutine(
                     loop,
-                    client._send_subprocess_command({"cmd": "play"}),
+                    client._send_subprocess_command(Play()),
                     description=f"play for {client.player_name}",
                 ):
                     count += 1

--- a/src/sendspin_bridge/web/routes/api_config.py
+++ b/src/sendspin_bridge/web/routes/api_config.py
@@ -62,6 +62,7 @@ from sendspin_bridge.services.ha.ha_addon import (
 from sendspin_bridge.services.ha.ha_core_api import HaCoreApiError, fetch_ha_area_catalog
 from sendspin_bridge.services.infrastructure.config_diff import diff_configs
 from sendspin_bridge.services.infrastructure.config_validation import validate_uploaded_config
+from sendspin_bridge.services.ipc.commands import SetLogLevel
 from sendspin_bridge.services.ipc.ipc_protocol import IPC_PROTOCOL_VERSION
 from sendspin_bridge.services.lifecycle.async_job_state import (
     create_async_job,
@@ -1128,7 +1129,7 @@ def api_set_log_level():
     # Propagate to all running subprocesses via stdin IPC
     loop = get_main_loop()
     if loop is not None:
-        cmd = {"cmd": "set_log_level", "level": level}
+        cmd = SetLogLevel(level=level)
         for client in get_device_registry_snapshot().active_clients:
             if client.is_running():
                 _submit_loop_coroutine(

--- a/tests/integration/test_daemon_orphan.py
+++ b/tests/integration/test_daemon_orphan.py
@@ -1,0 +1,79 @@
+"""A daemon must not outlive the bridge that spawned it.
+
+Cleanup lived entirely in the graceful stop path, so a parent killed outright
+— OOM in a 1 GB LXC, `docker kill`, the HA Supervisor watchdog — left one
+daemon per speaker alive, each still holding its Sendspin listen port. The
+codebase already knew: the stderr classifier carries a dedicated EADDRINUSE
+hint telling operators to hunt the lingering process down with `lsof`.
+
+This test spawns a real intermediate process, has it spawn a child through
+the same helper the bridge uses, then kills the intermediate outright and
+watches whether the grandchild goes with it.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(not sys.platform.startswith("linux"), reason="PR_SET_PDEATHSIG is Linux-only")
+
+_PARENT_SCRIPT = """
+import asyncio, sys
+from sendspin_bridge.services.ipc.daemon_handle import spawn_kwargs
+
+async def main():
+    child = await asyncio.create_subprocess_exec(
+        sys.executable, "-c", "import time; time.sleep(300)",
+        **spawn_kwargs(),
+    )
+    print(child.pid, flush=True)
+    await asyncio.sleep(300)
+
+asyncio.run(main())
+"""
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def test_a_killed_parent_takes_its_daemon_with_it():
+    parent = subprocess.Popen(
+        [sys.executable, "-c", _PARENT_SCRIPT],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={**os.environ, "PYTHONPATH": "src"},
+    )
+    try:
+        line = parent.stdout.readline()
+        assert line.strip().isdigit(), f"intermediate never reported a child pid: {line!r}"
+        child_pid = int(line.strip())
+        assert _alive(child_pid)
+
+        parent.send_signal(signal.SIGKILL)
+        parent.wait(timeout=10)
+
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if not _alive(child_pid):
+                break
+            time.sleep(0.1)
+
+        assert not _alive(child_pid), "the daemon outlived the bridge that spawned it"
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait(timeout=5)

--- a/tests/unit/bridge/test_sendspin_client_runtime.py
+++ b/tests/unit/bridge/test_sendspin_client_runtime.py
@@ -523,24 +523,24 @@ async def test_read_subprocess_output_accepts_structured_error_envelope_once():
 
 @pytest.mark.asyncio
 async def test_read_subprocess_output_delegates_log_messages_to_ipc_service():
+    """A non-status message goes straight to the service, side effects skipped."""
     client = SendspinClient("Test Player", "localhost", 9000)
 
-    log_line = json.dumps({"type": "log", "level": "info", "msg": "hello"}).encode()
+    log_message = {"type": "log", "level": "info", "msg": "hello"}
+    log_line = json.dumps(log_message).encode()
+
+    handled = []
 
     class _FakeService:
-        def __init__(self):
-            self.seen = []
-
-        def parse_line(self, line):
-            self.seen.append(("parse", line))
-            return {"type": "log", "level": "info", "msg": "hello"}
+        async def read_stream(self, stdout, *, idle_timeout=None, on_idle=None, on_message=None):
+            # The loop belongs to the service; drive the client's half of it.
+            await on_message(log_message)
 
         def handle_message(self, msg):
-            self.seen.append(("handle", msg))
+            handled.append(msg)
             return None
 
-    fake_service = _FakeService()
-    client._ipc_service = fake_service
+    client._ipc_service = _FakeService()
     client._daemon_proc = SimpleNamespace(
         returncode=None,
         stdout=_FakeStdoutLines([log_line]),
@@ -548,10 +548,7 @@ async def test_read_subprocess_output_delegates_log_messages_to_ipc_service():
 
     await client._read_subprocess_output()
 
-    assert fake_service.seen == [
-        ("parse", log_line + b"\n"),
-        ("handle", {"type": "log", "level": "info", "msg": "hello"}),
-    ]
+    assert handled == [log_message]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/bridge/test_sendspin_client_runtime.py
+++ b/tests/unit/bridge/test_sendspin_client_runtime.py
@@ -14,6 +14,7 @@ import sendspin_bridge.bridge.state as state
 from sendspin_bridge.bridge.client import SendspinClient, _filter_duplicate_bluetooth_devices
 from sendspin_bridge.services.audio.latency_recommendation import LatencyRecommendation
 from sendspin_bridge.services.diagnostics.log_analysis import classify_subprocess_stderr_level
+from sendspin_bridge.services.ipc.commands import Reconnect, encode_command
 from sendspin_bridge.services.ipc.ipc_protocol import IPC_PROTOCOL_VERSION
 
 
@@ -266,7 +267,7 @@ async def test_send_reconnect_marks_expected_ma_reconnect_and_clears_on_server_c
     await client.send_reconnect()
 
     assert client.status.get("ma_reconnecting") is True
-    assert fake_service.calls == [(proc, {"cmd": "reconnect", "delay": 3.0})]
+    assert fake_service.calls == [(proc, encode_command(Reconnect(delay_s=3.0)))]
 
     client._update_status({"server_connected": True})
     client._clear_ma_reconnecting()

--- a/tests/unit/services/bluetooth/test_device_activation.py
+++ b/tests/unit/services/bluetooth/test_device_activation.py
@@ -10,6 +10,7 @@ from sendspin_bridge.services.bluetooth.device_activation import (
     DeviceActivationContext,
     activate_device,
 )
+from sendspin_bridge.services.ipc.commands import SetVolume
 
 
 def _fake_client(player_name: str, *args, **kwargs) -> SimpleNamespace:
@@ -454,7 +455,7 @@ async def test_volume_callback_dispatches_to_resolved_source_client():
         result = await cb("1", 75)
 
     assert result is True
-    source._send_subprocess_command.assert_awaited_once_with({"cmd": "set_volume", "value": 75})
+    source._send_subprocess_command.assert_awaited_once_with(SetVolume(value=75))
     default._send_subprocess_command.assert_not_awaited()
 
 

--- a/tests/unit/services/ipc/test_daemon_process.py
+++ b/tests/unit/services/ipc/test_daemon_process.py
@@ -57,11 +57,12 @@ from sendspin_bridge.services.ipc.daemon_process import (  # noqa: E402
     _observe_structured_reanchor,
     _patch_sendspin_audio_player_runtime_guards,
     _read_commands,
+    _run,
     _select_audio_output_device,
     _startup_sink_routing_watcher,
     _timing_telemetry_watcher,
 )
-from sendspin_bridge.services.ipc.ipc_protocol import IPC_PROTOCOL_VERSION  # noqa: E402
+from sendspin_bridge.services.ipc.ipc_protocol import IPC_PROTOCOL_VERSION, IPC_PROTOCOL_VERSION_KEY  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -1002,3 +1003,58 @@ async def test_a_rejected_command_does_not_stop_the_reader(capsys):
     )
 
     assert daemon._bridge_status["volume"] == 42
+
+
+# ---------------------------------------------------------------------------
+# Protocol handshake
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_incompatible_protocol_version_refuses_to_start(capsys):
+    """A daemon that cannot honour the parent's contract must say so and exit.
+
+    Version was logged and ignored, so a mixed-version pair ran on with a
+    contract neither side had agreed to — the failure surfaced later as
+    commands that quietly did nothing.
+    """
+    params = {
+        "player_name": "TestSpeaker",
+        "client_id": "test",
+        "listen_port": 8927,
+        "url": "ws://ma:8927",
+        IPC_PROTOCOL_VERSION_KEY: IPC_PROTOCOL_VERSION + 1,
+    }
+
+    with pytest.raises(SystemExit) as excinfo:
+        await _run(params)
+
+    assert excinfo.value.code != 0
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    errors = [json.loads(line) for line in lines if json.loads(line).get("type") == "error"]
+    assert errors, "the daemon exited without reporting why"
+    assert errors[0]["error_code"] == "incompatible_protocol_version"
+    assert str(IPC_PROTOCOL_VERSION) in errors[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_a_missing_protocol_version_is_still_accepted(monkeypatch, capsys):
+    """An older parent that never sends the key stays compatible."""
+    from sendspin_bridge.services.ipc import daemon_process as mod
+
+    class _PastTheHandshake(BaseException):
+        """Not an Exception: the daemon catches RuntimeError from this probe."""
+
+    def _stop_after_handshake(*_args, **_kwargs):
+        raise _PastTheHandshake
+
+    # The audio probe is the first thing past the handshake; stop there so the
+    # test says something about the handshake and nothing about audio.
+    monkeypatch.setattr(mod, "query_audio_devices", _stop_after_handshake)
+
+    with pytest.raises(_PastTheHandshake):
+        await _run({"player_name": "TestSpeaker", "client_id": "test", "listen_port": 8927, "url": "ws://ma:8927"})
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    errors = [json.loads(line) for line in lines if json.loads(line).get("type") == "error"]
+    assert not errors

--- a/tests/unit/services/ipc/test_daemon_process.py
+++ b/tests/unit/services/ipc/test_daemon_process.py
@@ -436,33 +436,26 @@ def test_snapshot_status_returns_independent_copy():
     assert snap["volume"] == 40  # snapshot is decoupled
 
 
-def test_snapshot_status_retries_when_copy_sees_size_change():
-    """A live status dict can change size mid-copy; the snapshot must retry
-    instead of propagating ``RuntimeError``."""
+def test_snapshot_status_returns_a_whole_state():
+    """The store answers under its own lock, so there is nothing to retry.
+
+    This replaces a test that pinned the five-attempt retry loop in
+    ``_snapshot_status``.  That loop survived "dictionary changed size during
+    iteration" rather than preventing it, and a snapshot that did succeed
+    could still carry half of a multi-key update.  The race is gone at the
+    source, so the workaround it protected has no behaviour left to pin;
+    ``test_status_store.py`` covers the guarantee that replaced it.
+    """
     from sendspin_bridge.services.ipc.daemon_process import _snapshot_status
+    from sendspin_bridge.services.ipc.status_store import StatusStore
 
-    class _FlakyMapping:
-        def __init__(self, data):
-            self._data = dict(data)
-            self._fail = 1
+    store = StatusStore({"player_name": "x", "connected": True})
 
-        def keys(self):
-            if self._fail > 0:
-                self._fail -= 1
-                raise RuntimeError("dictionary changed size during iteration")
-            return self._data.keys()
+    snap = _snapshot_status(store)
 
-        def __getitem__(self, key):
-            return self._data[key]
-
-        def get(self, key, default=None):
-            return self._data.get(key, default)
-
-        def __iter__(self):
-            return iter(self._data)
-
-    snap = _snapshot_status(_FlakyMapping({"player_name": "x", "connected": True}))
     assert snap == {"player_name": "x", "connected": True}
+    snap["connected"] = False
+    assert store["connected"] is True
 
 
 def test_emit_status_serializes_a_snapshot(monkeypatch):

--- a/tests/unit/services/ipc/test_daemon_process.py
+++ b/tests/unit/services/ipc/test_daemon_process.py
@@ -938,3 +938,67 @@ async def test_read_commands_transport_ignored_when_client_disconnected(monkeypa
     await _run_one_command(daemon, {"cmd": "transport", "action": "play"})
 
     assert send_group.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Unknown and unusable commands are reported, not swallowed
+# ---------------------------------------------------------------------------
+
+
+async def _drive_commands(lines: list[str], daemon_ref=None):
+    """Feed *lines* to the daemon's command reader and return."""
+    stop_event = asyncio.Event()
+    payload = "".join(line + "\n" for line in lines)
+
+    async def _fake_connect_read_pipe(protocol_factory, pipe):
+        protocol = protocol_factory()
+        protocol.connection_made(MagicMock())
+        protocol.data_received(payload.encode())
+        protocol.eof_received()
+
+    with pytest.MonkeyPatch.context() as mp:
+        loop = asyncio.get_running_loop()
+        mp.setattr(loop, "connect_read_pipe", _fake_connect_read_pipe)
+        await asyncio.wait_for(_read_commands(daemon_ref if daemon_ref is not None else [], stop_event), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_emits_an_error_envelope(capsys):
+    """A verb this build does not implement must not vanish silently."""
+    await _drive_commands([json.dumps({"cmd": "self_destruct"})])
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    errors = [json.loads(line) for line in lines if json.loads(line).get("type") == "error"]
+    assert errors, "unknown command produced no error envelope"
+    assert errors[0]["error_code"] == "unknown_command"
+    assert "self_destruct" in errors[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_payload_emits_an_error_envelope(capsys):
+    await _drive_commands([json.dumps({"cmd": "set_volume", "value": "loud"})])
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+    errors = [json.loads(line) for line in lines if json.loads(line).get("type") == "error"]
+    assert errors, "an unusable payload produced no error envelope"
+    assert errors[0]["error_code"] == "invalid_command"
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_command_does_not_stop_the_reader(capsys):
+    """The command after a bad one must still be honoured."""
+    daemon = MagicMock()
+    daemon._bridge_status = {"volume": 50}
+    daemon._notify = MagicMock()
+    daemon._client = MagicMock()
+    daemon._client.connected = True
+
+    await _drive_commands(
+        [
+            json.dumps({"cmd": "self_destruct"}),
+            json.dumps({"cmd": "set_volume", "value": 42}),
+        ],
+        daemon_ref=[daemon],
+    )
+
+    assert daemon._bridge_status["volume"] == 42

--- a/tests/unit/services/ipc/test_daemon_shutdown.py
+++ b/tests/unit/services/ipc/test_daemon_shutdown.py
@@ -1,0 +1,142 @@
+"""Shutdown gives the daemon a chance to leave cleanly.
+
+The sequence cancelled the daemon task and then "waited for a clean
+shutdown" with `wait_for(shield(daemon_task), 3.0)`.  `shield` protects an
+outer await from cancellation; it cannot un-cancel a task already cancelled
+a line earlier, so the wait returned immediately with `CancelledError` and
+the wait-for-clean-shutdown step never once did what it says.  Every stop was
+an abrupt teardown: no goodbye to the server, no PulseAudio drain — the
+unclean disconnect the server-side reconnect logic then has to absorb.
+
+Exceptions from the tasks were dropped too: `asyncio.wait` leaves them
+unretrieved, so a command reader that died took its reason with it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sendspin_bridge.services.ipc.shutdown import shut_down_tasks
+
+
+class _Recorder:
+    def __init__(self):
+        self.events: list[str] = []
+
+
+@pytest.mark.asyncio
+async def test_the_primary_task_is_given_time_to_finish():
+    recorder = _Recorder()
+
+    async def _daemon():
+        try:
+            await asyncio.sleep(0.05)
+            recorder.events.append("goodbye sent")
+        except asyncio.CancelledError:
+            recorder.events.append("cancelled")
+            raise
+
+    task = asyncio.ensure_future(_daemon())
+
+    await shut_down_tasks(primary=task, auxiliary=[], grace_s=1.0)
+
+    assert recorder.events == ["goodbye sent"], "the daemon never got to shut down cleanly"
+
+
+@pytest.mark.asyncio
+async def test_a_task_that_overstays_its_grace_is_cancelled():
+    recorder = _Recorder()
+
+    async def _stuck():
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            recorder.events.append("cancelled")
+            raise
+
+    task = asyncio.ensure_future(_stuck())
+
+    await shut_down_tasks(primary=task, auxiliary=[], grace_s=0.05)
+
+    assert recorder.events == ["cancelled"]
+    assert task.cancelled() or task.done()
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_tasks_are_cancelled_at_once():
+    """Observability tasks have nothing to flush; they go immediately."""
+    recorder = _Recorder()
+
+    async def _watcher(name: str):
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            recorder.events.append(name)
+            raise
+
+    aux = [asyncio.ensure_future(_watcher("a")), asyncio.ensure_future(_watcher("b"))]
+    await asyncio.sleep(0)  # let them reach their first await, as in production
+
+    async def _primary():
+        return None
+
+    await shut_down_tasks(primary=asyncio.ensure_future(_primary()), auxiliary=aux, grace_s=1.0)
+
+    assert sorted(recorder.events) == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_a_failure_is_reported_rather_than_dropped():
+    """`asyncio.wait` leaves exceptions unretrieved; a dead reader is news."""
+    reported: list[tuple[str, BaseException]] = []
+
+    async def _boom():
+        raise RuntimeError("command reader died")
+
+    async def _primary():
+        return None
+
+    aux = [asyncio.ensure_future(_boom())]
+    await asyncio.sleep(0)
+
+    await shut_down_tasks(
+        primary=asyncio.ensure_future(_primary()),
+        auxiliary=aux,
+        grace_s=1.0,
+        on_error=lambda label, exc: reported.append((label, exc)),
+    )
+
+    assert [label for label, _ in reported] == ["auxiliary"]
+    assert isinstance(reported[0][1], RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_a_primary_failure_is_reported_too():
+    reported: list[tuple[str, BaseException]] = []
+
+    async def _boom():
+        raise RuntimeError("daemon died")
+
+    await shut_down_tasks(
+        primary=asyncio.ensure_future(_boom()),
+        auxiliary=[],
+        grace_s=1.0,
+        on_error=lambda label, exc: reported.append((label, exc)),
+    )
+
+    assert [label for label, _ in reported] == ["primary"]
+
+
+@pytest.mark.asyncio
+async def test_an_already_finished_task_needs_no_grace():
+    async def _done():
+        return None
+
+    task = asyncio.ensure_future(_done())
+    await asyncio.sleep(0)
+
+    await shut_down_tasks(primary=task, auxiliary=[], grace_s=30.0)
+
+    assert task.done()

--- a/tests/unit/services/ipc/test_ipc_commands.py
+++ b/tests/unit/services/ipc/test_ipc_commands.py
@@ -1,0 +1,131 @@
+"""The parent↔daemon command set, as a type rather than a convention.
+
+Twelve command strings were parsed by an `elif` chain with no `else`, and each
+branch re-derived its own coercion and clamping from raw payload keys.  An
+unknown command was a silent no-op; a bad value was a warning and a `continue`
+somewhere in the middle of the ladder.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sendspin_bridge.services.ipc.commands import (
+    InvalidCommand,
+    Pause,
+    Play,
+    Reconnect,
+    SetLogLevel,
+    SetMinBufferMs,
+    SetMute,
+    SetRequiredLeadTimeMs,
+    SetStandby,
+    SetStaticDelayMs,
+    SetVolume,
+    Stop,
+    Transport,
+    UnknownCommand,
+    decode_command,
+    encode_command,
+)
+
+
+def _roundtrip(command):
+    return decode_command(encode_command(command))
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        Stop(),
+        Pause(),
+        Play(),
+        SetVolume(value=40),
+        SetMute(muted=True),
+        Reconnect(delay_s=1.5),
+        SetLogLevel(level="DEBUG"),
+        SetStaticDelayMs(value=250.0),
+        SetRequiredLeadTimeMs(value=120.0),
+        SetMinBufferMs(value=80.0),
+        Transport(action="next", value=None),
+        SetStandby(sink="bluez_sink.AA_BB"),
+        SetStandby(sink=None),
+    ],
+)
+def test_every_command_survives_a_roundtrip(command):
+    assert _roundtrip(command) == command
+
+
+def test_the_wire_shape_is_unchanged():
+    """A daemon from an older build must still understand what we send."""
+    assert encode_command(SetVolume(value=40))["cmd"] == "set_volume"
+    assert encode_command(SetVolume(value=40))["value"] == 40
+    assert encode_command(Transport(action="volume", value=30))["action"] == "volume"
+    assert encode_command(Reconnect(delay_s=2.0))["delay"] == 2.0
+
+
+# ── clamping lives in the type ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(("raw", "expected"), [(-5, 0), (0, 0), (55, 55), (100, 100), (250, 100)])
+def test_volume_is_clamped_on_the_way_in(raw, expected):
+    assert decode_command({"cmd": "set_volume", "value": raw}) == SetVolume(value=expected)
+
+
+@pytest.mark.parametrize(("raw", "expected"), [(-1.0, 0.0), (0.0, 0.0), (5000.0, 5000.0), (9999.0, 5000.0)])
+def test_static_delay_is_clamped_on_the_way_in(raw, expected):
+    assert decode_command({"cmd": "set_static_delay_ms", "value": raw}) == SetStaticDelayMs(value=expected)
+
+
+@pytest.mark.parametrize("cmd_name", ["set_required_lead_time_ms", "set_min_buffer_ms"])
+def test_buffer_values_are_clamped_on_the_way_in(cmd_name):
+    decoded = decode_command({"cmd": cmd_name, "value": 99999})
+    assert decoded.value == 30000.0
+
+
+def test_a_negative_reconnect_delay_becomes_zero():
+    assert decode_command({"cmd": "reconnect", "delay": -3}) == Reconnect(delay_s=0.0)
+
+
+def test_reconnect_without_a_delay_is_immediate():
+    assert decode_command({"cmd": "reconnect"}) == Reconnect(delay_s=0.0)
+
+
+def test_log_level_is_normalised():
+    assert decode_command({"cmd": "set_log_level", "level": "debug"}) == SetLogLevel(level="DEBUG")
+
+
+# ── refusals ─────────────────────────────────────────────────────────────
+
+
+def test_an_unknown_command_is_reported_not_ignored():
+    with pytest.raises(UnknownCommand) as excinfo:
+        decode_command({"cmd": "self_destruct"})
+
+    assert "self_destruct" in str(excinfo.value)
+
+
+def test_a_missing_command_name_is_rejected():
+    with pytest.raises(UnknownCommand):
+        decode_command({"value": 10})
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"cmd": "set_volume", "value": "loud"},
+        {"cmd": "set_volume"},
+        {"cmd": "set_static_delay_ms", "value": None},
+        {"cmd": "set_log_level", "level": "SHOUT"},
+        {"cmd": "set_mute"},
+        {"cmd": "transport"},
+    ],
+)
+def test_a_payload_that_cannot_be_honoured_is_rejected(payload):
+    with pytest.raises(InvalidCommand):
+        decode_command(payload)
+
+
+def test_a_non_mapping_is_rejected():
+    with pytest.raises(InvalidCommand):
+        decode_command(["set_volume", 40])

--- a/tests/unit/services/ipc/test_parent_command_encoding.py
+++ b/tests/unit/services/ipc/test_parent_command_encoding.py
@@ -1,0 +1,65 @@
+"""The parent sends commands, not hand-built dictionaries.
+
+Every caller used to assemble `{"cmd": ..., ...}` itself, so the payload keys
+and the ranges the daemon enforces were duplicated across seven modules.  The
+client now accepts a command object and encodes it at the boundary; the dict
+form still works for the routes that forward an already-validated action.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sendspin_bridge.bridge.client import SendspinClient
+from sendspin_bridge.services.ipc.commands import Reconnect, SetStandby, SetVolume
+
+
+class _RecordingCommandService:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send(self, _proc, cmd):
+        self.sent.append(cmd)
+
+
+@pytest.fixture()
+def client():
+    cl = SendspinClient.__new__(SendspinClient)
+    cl.player_name = "TestSpeaker"
+    cl._daemon_proc = object()
+    cl._command_service = _RecordingCommandService()
+    return cl
+
+
+def test_a_command_object_is_encoded_for_the_wire(client):
+    asyncio.run(client._send_subprocess_command(SetVolume(value=40)))
+
+    sent = client._command_service.sent[0]
+    assert sent["cmd"] == "set_volume"
+    assert sent["value"] == 40
+    assert sent["protocol_version"]
+
+
+def test_command_ranges_are_applied_before_the_wire(client):
+    asyncio.run(client._send_subprocess_command(Reconnect(delay_s=1.5)))
+
+    assert client._command_service.sent[0] == {
+        "cmd": "reconnect",
+        "delay": 1.5,
+        "protocol_version": client._command_service.sent[0]["protocol_version"],
+    }
+
+
+def test_a_command_without_a_payload_still_encodes(client):
+    asyncio.run(client._send_subprocess_command(SetStandby()))
+
+    assert client._command_service.sent[0]["cmd"] == "set_standby"
+    assert client._command_service.sent[0]["sink"] is None
+
+
+def test_a_plain_dict_is_still_accepted(client):
+    asyncio.run(client._send_subprocess_command({"cmd": "pause"}))
+
+    assert client._command_service.sent[0] == {"cmd": "pause"}

--- a/tests/unit/services/ipc/test_status_store.py
+++ b/tests/unit/services/ipc/test_status_store.py
@@ -1,0 +1,105 @@
+"""The daemon's status has one owner, and a group of keys lands at once.
+
+Five writers shared the raw dict — the aiosendspin callbacks, the log
+handler, the command reader, the telemetry watcher and the PulseAudio volume
+tap.  Under the GIL a single assignment and a single `dict()` copy are each
+atomic, so the interesting race is not the copy: it is a *group* of related
+keys written one at a time.  `_record_reanchor_status` wrote eight of them
+that way, so a status emission landing mid-group published a re-anchor count
+that had gone up while `reanchoring` was still False.  Measured on this
+interpreter, a reader sees such a group torn hundreds of thousands of times a
+second.
+
+`patch()` is the fix: one call, one update, nothing observable in between.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from sendspin_bridge.services.ipc.status_store import StatusStore
+
+
+def test_a_patch_is_visible_in_the_snapshot():
+    store = StatusStore({"volume": 50})
+
+    store.patch({"volume": 70, "muted": True})
+
+    assert store.snapshot() == {"volume": 70, "muted": True}
+
+
+def test_a_snapshot_is_a_private_copy():
+    store = StatusStore({"volume": 50})
+
+    snapshot = store.snapshot()
+    snapshot["volume"] = 999
+
+    assert store.snapshot()["volume"] == 50
+
+
+def test_setting_one_key_is_a_patch_of_one():
+    store = StatusStore()
+
+    store["volume"] = 30
+
+    assert store.snapshot() == {"volume": 30}
+    assert store["volume"] == 30
+
+
+def test_missing_keys_read_as_a_default():
+    store = StatusStore({"volume": 30})
+
+    assert store.get("volume") == 30
+    assert store.get("nothing") is None
+    assert store.get("nothing", "fallback") == "fallback"
+
+
+def test_a_group_of_keys_is_never_observed_half_applied():
+    """The invariant `patch` exists for.
+
+    Fails if `patch` is implemented as a loop of single-key assignments,
+    which is the shape the daemon's re-anchor bookkeeping used to have.
+    """
+    keys = [f"k{i}" for i in range(8)]
+    store = StatusStore(dict.fromkeys(keys, 0))
+    stop = threading.Event()
+    torn: list[dict] = []
+
+    def _writer():
+        flip = 0
+        while not stop.is_set():
+            flip ^= 1
+            store.patch(dict.fromkeys(keys, flip))
+
+    def _reader():
+        while not stop.is_set():
+            snapshot = store.snapshot()
+            if len({snapshot[key] for key in keys}) > 1:
+                torn.append(snapshot)
+
+    threads = [threading.Thread(target=_writer), threading.Thread(target=_reader)]
+    for thread in threads:
+        thread.start()
+    threading.Event().wait(0.5)
+    stop.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert torn == [], f"a snapshot saw half a group: {torn[0]}"
+
+
+def test_an_empty_patch_changes_nothing():
+    store = StatusStore({"volume": 10})
+
+    store.patch({})
+
+    assert store.snapshot() == {"volume": 10}
+
+
+def test_the_dict_interface_still_works_for_existing_callers():
+    """The store stands in for the dict the daemon passes around."""
+    store = StatusStore({"volume": 10})
+
+    assert "volume" in store
+    assert dict(store) == {"volume": 10}
+    assert sorted(store.keys()) == ["volume"]

--- a/tests/unit/services/ipc/test_stdout_reader_resilience.py
+++ b/tests/unit/services/ipc/test_stdout_reader_resilience.py
@@ -1,0 +1,152 @@
+"""The stdout reader is the daemon's only lifeline — it must not die quietly.
+
+Production hand-rolled its own read loop and caught only `TimeoutError`, while
+the hardened one that guards against oversized lines sat unused next door.  A
+line past the 1 MB stream limit therefore killed the reader task, and nothing
+killed the daemon with it: the daemon kept writing status through a blocking
+`print`, the 64 KB pipe filled, and its event loop wedged for good.  Audio
+carried on playing from the audio thread, so the speaker looked healthy while
+accepting no commands at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sendspin_bridge.services.ipc.subprocess_ipc import SubprocessIpcService
+
+
+class _Stdout:
+    """A StreamReader stand-in that can raise the way a real one does."""
+
+    def __init__(self, lines: list[bytes | Exception]):
+        self._lines = list(lines)
+
+    async def readline(self) -> bytes:
+        if not self._lines:
+            return b""
+        item = self._lines.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def _service(updates: list[dict]) -> SubprocessIpcService:
+    return SubprocessIpcService(
+        player_name="TestSpeaker",
+        protocol_warning_cache=set(),
+        status_updater=updates.append,
+        log_methods={},
+        allowed_keys=None,
+    )
+
+
+def _status(volume: int) -> bytes:
+    import json
+
+    return (json.dumps({"type": "status", "volume": volume}) + "\n").encode()
+
+
+def test_an_oversized_line_does_not_kill_the_reader():
+    """A StreamReader past its limit raises rather than returning the line."""
+    updates: list[dict] = []
+    service = _service(updates)
+    stdout = _Stdout(
+        [
+            _status(10),
+            ValueError("Separator is not found, and chunk exceed the limit"),
+            _status(20),
+        ]
+    )
+
+    asyncio.run(service.read_stream(stdout))
+
+    assert [u["volume"] for u in updates] == [10, 20], "the reader stopped at the oversized line"
+
+
+def test_an_idle_daemon_does_not_end_the_read():
+    """A daemon that simply has nothing to say is not a dead daemon."""
+    updates: list[dict] = []
+    service = _service(updates)
+
+    class _Slow(_Stdout):
+        async def readline(self) -> bytes:
+            if self._lines and not isinstance(self._lines[0], Exception):
+                await asyncio.sleep(0)
+            return await super().readline()
+
+    idle_calls: list[int] = []
+
+    async def _run():
+        stdout = _Slow([TimeoutError(), _status(30)])
+        await service.read_stream(
+            stdout,
+            idle_timeout=0.01,
+            on_idle=lambda: idle_calls.append(1) or False,
+        )
+
+    asyncio.run(_run())
+
+    assert [u["volume"] for u in updates] == [30]
+    assert idle_calls, "the idle hook never fired"
+
+
+def test_the_idle_hook_can_end_the_read():
+    """A dead subprocess ends the loop; the hook is what knows the difference."""
+    updates: list[dict] = []
+    service = _service(updates)
+
+    async def _run():
+        stdout = _Stdout([TimeoutError(), _status(40)])
+        await service.read_stream(stdout, idle_timeout=0.01, on_idle=lambda: True)
+
+    asyncio.run(_run())
+
+    assert updates == [], "the reader kept going after the hook said to stop"
+
+
+def test_the_message_hook_sees_every_message():
+    updates: list[dict] = []
+    service = _service(updates)
+    seen: list[dict] = []
+
+    async def _on_message(msg):
+        seen.append(msg)
+        service.handle_message(msg)
+
+    asyncio.run(service.read_stream(_Stdout([_status(50), _status(60)]), on_message=_on_message))
+
+    assert [m["volume"] for m in seen] == [50, 60]
+    assert [u["volume"] for u in updates] == [50, 60]
+
+
+@pytest.mark.asyncio
+async def test_a_dead_reader_takes_the_daemon_down():
+    """Without this the daemon wedges on a pipe nobody drains."""
+    from sendspin_bridge.bridge.client import SendspinClient
+
+    client = SendspinClient.__new__(SendspinClient)
+    client.player_name = "TestSpeaker"
+    killed: list[str] = []
+
+    class _Proc:
+        returncode = None
+        pid = 4242
+
+        def kill(self):
+            killed.append("kill")
+
+    client._daemon_proc = _Proc()
+
+    async def _boom():
+        raise RuntimeError("reader exploded")
+
+    task = asyncio.ensure_future(_boom())
+    task.add_done_callback(client._make_reader_done_handler())
+    with pytest.raises(RuntimeError):
+        await task
+    await asyncio.sleep(0)
+
+    assert killed == ["kill"], "a dead reader left the daemon running"

--- a/tests/unit/services/ipc/test_subprocess_stdout_timeout.py
+++ b/tests/unit/services/ipc/test_subprocess_stdout_timeout.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 
 from sendspin_bridge.bridge.client import SendspinClient
+from sendspin_bridge.services.ipc.subprocess_ipc import SubprocessIpcService
 
 
 class _FakeStdout:
@@ -45,8 +45,16 @@ def _make_client_with(proc) -> SendspinClient:
     client = SendspinClient.__new__(SendspinClient)
     client._daemon_proc = proc  # type: ignore[attr-defined]
     client.player_name = "test-player"
-    client._ipc_service = MagicMock()
-    client._ipc_service.parse_line.return_value = None
+    # The read loop lives in the service now, so the stub must be the real
+    # one — what these tests check is the client's half: the idle decision
+    # and the message side effects.
+    client._ipc_service = SubprocessIpcService(
+        player_name="test-player",
+        protocol_warning_cache=set(),
+        status_updater=lambda _updates: None,
+        log_methods={},
+        allowed_keys=None,
+    )
     return client
 
 

--- a/tests/unit/services/ipc/test_subprocess_stop.py
+++ b/tests/unit/services/ipc/test_subprocess_stop.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from sendspin_bridge.services.ipc.commands import Stop, encode_command
 from sendspin_bridge.services.ipc.subprocess_stop import SubprocessStopService
 
 
@@ -51,7 +52,7 @@ async def test_stop_process_requests_graceful_stop():
 
     await service.stop_process(proc, send_stop=fake_send, player_name="Kitchen")
 
-    assert sent == [{"cmd": "stop"}]
+    assert sent == [encode_command(Stop())]
     assert proc.kill_called is False
 
 
@@ -67,7 +68,7 @@ async def test_stop_process_kills_when_wait_times_out():
 
     await service.stop_process(proc, send_stop=fake_send, player_name="Kitchen")
 
-    assert sent == [{"cmd": "stop"}]
+    assert sent == [encode_command(Stop())]
     assert proc.kill_called is True
     logger.warning.assert_called_once()
 

--- a/tests/unit/services/lifecycle/test_reconfigure_client.py
+++ b/tests/unit/services/lifecycle/test_reconfigure_client.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from sendspin_bridge.bridge.client import SendspinClient
+from sendspin_bridge.services.ipc.commands import SetStaticDelayMs, encode_command
 
 
 class _FakeCommandService:
@@ -38,7 +39,7 @@ async def test_apply_hot_config_sends_set_static_delay_ms_ipc():
 
     assert applied == ["static_delay_ms"]
     assert client.static_delay_ms == pytest.approx(450.0)
-    assert client._command_service.calls == [(client._daemon_proc, {"cmd": "set_static_delay_ms", "value": 450.0})]
+    assert client._command_service.calls == [(client._daemon_proc, encode_command(SetStaticDelayMs(value=450.0)))]
 
 
 @pytest.mark.asyncio
@@ -105,7 +106,7 @@ async def test_apply_hot_config_multiple_fields_in_one_call():
     assert client.idle_disconnect_minutes == 5
     assert client.keepalive_enabled is True  # keep_alive implies keepalive_enabled
     # Only one IPC (static_delay_ms); idle/disconnect are parent-only.
-    assert client._command_service.calls == [(client._daemon_proc, {"cmd": "set_static_delay_ms", "value": 200.0})]
+    assert client._command_service.calls == [(client._daemon_proc, encode_command(SetStaticDelayMs(value=200.0)))]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/lifecycle/test_standby_daemon.py
+++ b/tests/unit/services/lifecycle/test_standby_daemon.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from sendspin_bridge.services.ipc.commands import Reconnect, SetStandby
+
 # ── Helpers ────────────────────────────────────────────────────────────────
 
 
@@ -204,8 +206,8 @@ class TestRerouteToBtSink:
             # Two IPC calls: set_standby (restore PULSE_SINK) + reconnect (reanchor)
             assert client._send_subprocess_command.await_count == 2
             cmds = [c[0][0] for c in client._send_subprocess_command.call_args_list]
-            assert cmds[0]["cmd"] == "set_standby"
-            assert cmds[1]["cmd"] == "reconnect"
+            assert isinstance(cmds[0], SetStandby)
+            assert isinstance(cmds[1], Reconnect)
 
     @pytest.mark.asyncio
     async def test_reroute_no_daemon_noop(self):
@@ -240,8 +242,8 @@ class TestRerouteToBtSink:
             assert result is True
             # set_standby restore + reconnect
             assert client._send_subprocess_command.await_count == 2
-            cmds = [c[0][0]["cmd"] for c in client._send_subprocess_command.call_args_list]
-            assert cmds == ["set_standby", "reconnect"]
+            cmds = [type(c[0][0]) for c in client._send_subprocess_command.call_args_list]
+            assert cmds == [SetStandby, Reconnect]
 
 
 # ── Start sendspin with daemon already alive (standby wake) ──────────────

--- a/tests/unit/web/routes/test_api_endpoints.py
+++ b/tests/unit/web/routes/test_api_endpoints.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from sendspin_bridge.services.ipc.commands import SetLogLevel
 from tests.support.fake_lease import FakeLease
 
 # ---------------------------------------------------------------------------
@@ -2673,7 +2674,7 @@ def test_api_set_log_level_propagates_via_registry_snapshot(client, monkeypatch)
 
     assert resp.status_code == 200
     assert resp.get_json()["level"] == "DEBUG"
-    assert sent == [("Kitchen", {"cmd": "set_log_level", "level": "DEBUG"})]
+    assert sent == [("Kitchen", SetLogLevel(level="DEBUG"))]
 
 
 def test_api_set_log_level_does_not_require_future_result(client, monkeypatch):
@@ -2721,7 +2722,7 @@ def test_api_set_log_level_does_not_require_future_result(client, monkeypatch):
 
     assert resp.status_code == 200
     assert resp.get_json()["level"] == "DEBUG"
-    assert sent == [{"cmd": "set_log_level", "level": "DEBUG"}]
+    assert sent == [SetLogLevel(level="DEBUG")]
 
 
 def test_api_set_password_returns_error_when_config_persist_fails(client, monkeypatch):


### PR DESCRIPTION
Stacked on #434 → #433 → #432. Its own commits are the seven `C4 batch N` ones.

## Why

The IPC layer was a convention, not a contract:

- Twelve command strings parsed by an `elif` chain **with no `else`** — a verb the build did not implement fell off the end in silence, and the parent had no way to learn its command was never honoured. Each branch re-derived its own coercion and clamping, which is why the same range check lived in the daemon, the config layer and the JSON schema.
- `is_compatible_protocol_version` was defined and **called nowhere**. All three version checks logged a warning and carried on.
- Two stdout read loops. The hardened one had the oversized-line guard and no production caller; the one the parent hand-rolled caught only `TimeoutError`.
- No `PR_SET_PDEATHSIG`, so cleanup lived entirely in the graceful stop path.
- The daemon's status dict had five writers and three lock-takers.
- Shutdown cancelled the daemon task, then "waited for a clean shutdown" with `wait_for(shield(task), 3.0)` — which cannot un-cancel a task cancelled a line earlier.

## What changed

| Batch | Change |
|---|---|
| 1 | Each command is a type; `decode_command` is the one place a payload becomes one. Unknown verb → `unknown_command`, unusable payload → `invalid_command`, neither stops the reader. |
| 2 | Fifteen call sites across seven modules stop hand-building `{"cmd": ...}`. |
| 3 | The handshake is enforced: an incompatible daemon reports and exits rather than running on. |
| 4 | `PR_SET_PDEATHSIG` armed between fork and exec, behind one `**spawn_kwargs()` a new spawn site cannot forget. |
| 5 | One read loop, with the two parameters the parent's copy existed for. A dead reader now kills the daemon. |
| 6 | `StatusStore` owns the status; multi-key groups land as one `patch`. |
| 7 | The grace period comes before the cancel; task failures are reported, not dropped. |

## Bugs fixed

- **Orphaned daemons.** A parent killed outright left one daemon per speaker holding its listen port, and the next start met EADDRINUSE. The codebase already knew — the stderr classifier carries a hint telling the operator to hunt it down with `lsof`. The integration test spawns a real process tree and SIGKILLs the middle of it; neutering the helper makes it fail.
- **Silent wedge on a fat status frame.** A line past the 1 MB stream limit makes `readline` raise, which killed the reader task and nothing killed the daemon with it. The daemon kept writing status through a blocking `print`, the 64 KB pipe filled, and its loop wedged: no commands, no stop, no reconnect, while audio played on and the speaker looked healthy.
- **Never-clean shutdown.** Every stop was an abrupt teardown.
- **Torn status.** See below.

## Where I was wrong, and what measuring showed

I assumed the status bug was the one `_snapshot_status` coded around: a five-attempt retry against "dictionary changed size during iteration". **Measuring says otherwise.** Under the GIL a single assignment and a single `dict()` copy are each atomic, so that loop only ever protected a non-dict mapping and never fired in production.

The tear that *does* happen is a **group of keys written one at a time**: `_record_reanchor_status` wrote eight that way, so a status emission landing mid-group published a re-anchor count that had gone up while `reanchoring` was still False. A concurrent reader observes that torn hundreds of thousands of times a second on this interpreter — I probed it directly before claiming it.

So `patch()` is the fix, not the lock as such, and the commit says so. The test that pinned the retry loop is replaced: it asserted a workaround for a race that cannot occur and could not have caught the one that does. Its replacement drives a concurrent reader against `patch` and **fails if `patch` is implemented per-key** — verified by making it so.

## Tests that moved with the seam

The stdout-timeout tests use the real service (the loop is no longer the client's to stub); the delegation test drives the client's message hook rather than the loop it no longer owns; command assertions moved from the wire shape to the command they describe.

## Verification

```
uv run pytest -q            # 3265 passed, 1 skipped
uv run ruff check src tests
uv run mypy --config-file pyproject.toml src/sendspin_bridge
uv run python scripts/lint_changelog.py CHANGELOG.md
```

One caveat worth stating: during this work a single full-suite run hit an xdist worker crash in an unrelated orchestrator test. It did not reproduce in six targeted runs or several full ones, and that file does not touch anything here — but I could not explain it, so I am not claiming it was noise.

Still unverified on hardware; the live stand needs an SSH key this machine does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)