### PR TITLE
chore(deps): move the uv toolchain to 0.12.5, everywhere it is pinned

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.2"
+          version: "0.12.5"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
           # setup-uv v9 defaults this to false; preserve v7 cache pruning.

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.2"
+          version: "0.12.5"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
           # setup-uv v9 defaults this to false; preserve v7 cache pruning.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.12.2
+    rev: 0.12.5
     hooks:
       # `uv lock --check` — fail if uv.lock is out of sync with pyproject.toml.
       - id: uv-lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ ARG UV_STAGE=uv-default
 # Default — pull the static binary directly from the upstream image.
 # This is what amd64/arm64 builds use; the COPY --from below short-
 # circuits to a single layer copy (~50 MB pull amortised across builds).
-FROM ghcr.io/astral-sh/uv:0.12.2 AS uv-default
+FROM ghcr.io/astral-sh/uv:0.12.5 AS uv-default
 
 # armv7 fallback — the upstream image has no linux/arm/v7 manifest, so install
 # the same pinned uv version from its PyPI armv7 wheel instead.
 # Selected by passing --build-arg UV_STAGE=uv-armv7 in the release workflow.
 FROM python:3.13-slim AS uv-armv7
-RUN pip install --no-cache-dir --root-user-action=ignore "uv==0.12.2" && \
+RUN pip install --no-cache-dir --root-user-action=ignore "uv==0.12.5" && \
     cp "$(command -v uv)" /uv
 
 FROM ${UV_STAGE} AS uv-source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 # Pin the project resolver used by contributors and CI to the same version as
 # Docker and pre-commit. The armv7 Docker fallback installs this version from
 # PyPI because the GHCR image manifest lacks linux/arm/v7.
-required-version = "==0.12.2"
+required-version = "==0.12.5"
 
 # ``sendspin`` 7.5.0 caps its own ``aiosendspin`` dependency at ``~=6.0.1``
 # (``>=6.0.1,<6.1``), but ``seek_relative`` (advertised by current Music


### PR DESCRIPTION
Supersedes #428.

## Why the dependabot PR could not be merged

It bumps **one** of the six places the uv version is pinned — the Dockerfile's default stage. `required-version` in `pyproject.toml` is a hard error, not a hint; pointing it at a version that is not installed gives:

```
error: Required uv version `==0.12.5` does not match the running version `0.12.2`
```

So #428 would have built an image whose uv **refuses to run `uv sync` against this project**.

Its `docker-smoke` check passed regardless. That says the smoke build never reaches the point where uv resolves the project — a gap in that check worth looking at on its own, since it is exactly the failure it exists to catch.

## The six pins

| File | What it pins |
|---|---|
| `pyproject.toml` | `required-version` — the resolver contributors and CI must run |
| `Dockerfile` (default stage) | the GHCR uv image for amd64/arm64 |
| `Dockerfile` (armv7 stage) | the same version from PyPI — GHCR has no `linux/arm/v7` manifest |
| `.pre-commit-config.yaml` | `uv-pre-commit` rev, which regenerates `requirements.txt` |
| `.github/workflows/_lint.yml` | `setup-uv` version |
| `.github/workflows/_test.yml` | `setup-uv` version |

## No dependency drift

0.12.5 resolves to the same 96 packages — `uv.lock` and `requirements.txt` come out byte-identical, so this is purely a toolchain move.

## Verification, all run under 0.12.5

```
uvx uv@0.12.5 lock                                 # Resolved 96 packages, lockfile unchanged
uvx uv@0.12.5 run pytest -q                        # 3265 passed, 1 skipped
uvx uv@0.12.5 run ruff check src tests
uvx uv@0.12.5 run mypy --config-file pyproject.toml src/sendspin_bridge
uvx uv@0.12.5 run python scripts/generate_ha_addon_variants.py check-current-repo   # exit 0
uvx uv@0.12.5 run python scripts/lint_changelog.py CHANGELOG.md                     # clean
```

**What I could not verify here:** the actual multi-arch and armv7 image builds. Those only run in the release workflow, and the armv7 path in particular takes a different route (PyPI wheel instead of the GHCR image). The pins are consistent and the resolver is verified, but the first real proof is the next release build.

One consequence worth stating: after this lands, a contributor on uv 0.12.2 gets a hard error until they update. That is the point of `required-version`, but it does mean the bump is felt immediately rather than lazily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)