### PR TITLE
fix: four defects found by running the bridge on real hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The diagnostics bundle no longer reports that the bridge cannot reach
+  D-Bus on a host where Bluetooth is working; it now measures the runtime it
+  describes, so the bundle and the dashboard agree.
+- A speaker paired on a second Bluetooth controller is counted again: setup
+  guidance used to announce that no paired speakers were available while such
+  a speaker was connected and streaming.
+- Two restarts arriving together can no longer leave a second audio daemon
+  running unwatched, holding the speaker's audio sink and its port.
+
 ## [2.75.0-rc.3] - 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a speaker was connected and streaming.
 - Two restarts arriving together can no longer leave a second audio daemon
   running unwatched, holding the speaker's audio sink and its port.
+- Queue controls work for a speaker that is not in a Music Assistant sync
+  group. The bridge used to guess that speaker's queue address instead of
+  asking Music Assistant for it, so every queue command reached nothing and
+  the device card claimed Music Assistant was disconnected while it was
+  connected.
 
 ## [2.75.0-rc.3] - 2026-08-25
 

--- a/src/sendspin_bridge/bridge/client.py
+++ b/src/sendspin_bridge/bridge/client.py
@@ -1499,9 +1499,7 @@ class SendspinClient:
 
     async def _zombie_restart(self) -> None:
         """Restart subprocess to recover from zombie playback."""
-        await self.stop_sendspin()
-        await asyncio.sleep(1)
-        await self.start_sendspin()
+        await self._restart_daemon(settle_s=1.0)
 
     async def start_sendspin(self) -> None:
         """Start the sendspin daemon as an isolated subprocess with PULSE_SINK routing."""
@@ -2129,11 +2127,35 @@ class SendspinClient:
         self._update_status({"reloading": True})
         try:
             self._apply_warm_restart_fields(new_device)
-            await self.stop_sendspin()
-            if self.running:
-                await self._start_sendspin_inner()
+            await self._restart_daemon()
         finally:
             self._update_status({"reloading": False})
+
+    async def _restart_daemon(self, *, settle_s: float = 0.0) -> None:
+        """Stop the daemon and spawn its replacement as one operation.
+
+        The spawn path coalesces concurrent starts behind a lock; a restart
+        that stopped and spawned outside it could neither see a start in
+        flight nor be seen by one.  Two spawns then landed a millisecond
+        apart, the second overwrote the tracked handle, and the first daemon
+        kept the Bluetooth sink and the listen port with nothing watching it.
+        """
+        lock = self._start_sendspin_lock
+        if lock is None:
+            await self.stop_sendspin()
+            if settle_s:
+                await asyncio.sleep(settle_s)
+            if self.running:
+                await self._start_sendspin_inner()
+            return
+        async with lock:
+            # This restart satisfies whatever start requests queued behind it.
+            self._start_sendspin_processed = self._start_sendspin_requests
+            await self.stop_sendspin()
+            if settle_s:
+                await asyncio.sleep(settle_s)
+            if self.running:
+                await self._start_sendspin_inner()
 
     def _apply_warm_restart_fields(self, device: dict[str, object]) -> None:
         """Mutate self.<field> from the new device config before respawn."""

--- a/src/sendspin_bridge/bridge/client.py
+++ b/src/sendspin_bridge/bridge/client.py
@@ -2149,12 +2149,16 @@ class SendspinClient:
                 await self._start_sendspin_inner()
             return
         async with lock:
-            # This restart satisfies whatever start requests queued behind it.
-            self._start_sendspin_processed = self._start_sendspin_requests
             await self.stop_sendspin()
             if settle_s:
                 await asyncio.sleep(settle_s)
             if self.running:
+                # Every start request raised up to this point is served by the
+                # spawn below — including the ones that queued while we were
+                # stopping.  Stamped here rather than on entry so those are
+                # counted, and not at all when nothing is spawned: a stopped
+                # client has served nobody.
+                self._start_sendspin_processed = self._start_sendspin_requests
                 await self._start_sendspin_inner()
 
     def _apply_warm_restart_fields(self, device: dict[str, object]) -> None:

--- a/src/sendspin_bridge/bridge/state.py
+++ b/src/sendspin_bridge/bridge/state.py
@@ -68,6 +68,7 @@ __all__ = [
     "get_ma_groups",
     "get_ma_now_playing",
     "get_ma_now_playing_for_group",
+    "get_ma_player_id",
     "get_ma_server_version",
     "get_main_loop",
     "get_runtime_mode_info",
@@ -92,6 +93,7 @@ __all__ = [
     "set_ma_groups",
     "set_ma_now_playing",
     "set_ma_now_playing_for_group",
+    "set_ma_player_ids",
     "set_ma_server_version",
     "set_main_loop",
     "set_runtime_mode_info",
@@ -549,6 +551,16 @@ def get_duplicate_device_warnings() -> list:
 def is_ma_connected() -> bool:
     """Return True if MA API integration is active and discovery succeeded."""
     return _ma_runtime_state.is_ma_connected()
+
+
+def set_ma_player_ids(mapping: dict[str, str]) -> None:
+    """Store the learned bridge-client → MA-player mapping."""
+    _ma_runtime_state.set_ma_player_ids(mapping)
+
+
+def get_ma_player_id(client_id: str) -> str:
+    """The MA player id for *client_id*, or ``""`` when MA has not named one."""
+    return _ma_runtime_state.get_ma_player_id(client_id)
 
 
 def set_ma_connected(value: bool) -> None:

--- a/src/sendspin_bridge/services/diagnostics/preflight_status.py
+++ b/src/sendspin_bridge/services/diagnostics/preflight_status.py
@@ -9,7 +9,7 @@ import socket as _socket
 import subprocess
 from typing import Any
 
-from sendspin_bridge.bluetooth.bluez import Outcome, get_bluez
+from sendspin_bridge.bluetooth.bluez import Adapter, Outcome, get_bluez
 from sendspin_bridge.config import get_runtime_version
 from sendspin_bridge.services.audio.pulse import get_server_name, list_sinks
 
@@ -294,7 +294,19 @@ def collect_preflight_status(
             bt_info["daemon"] = daemon_state_fn()
         # Parsed whitelist rows only — async ``[CHG] Device`` noise on the
         # same stdout must not inflate the count (ghost-row fix).
-        bt_info["paired_devices"] = len(bluez.list_devices())
+        #
+        # Every controller is asked, not just the default one: on a host with
+        # two adapters the speaker is often bonded to the second, and counting
+        # only the first reported "no paired speakers" while that speaker was
+        # connected and streaming.  A MAC bonded to two controllers is one
+        # speaker, so the union is by address.
+        paired_macs: set[str] = set()
+        for adapter_ref in adapters or []:
+            scope = Adapter.select(adapter_ref.mac) if adapter_ref.mac else Adapter.DEFAULT
+            paired_macs.update(entry.mac for entry in bluez.list_devices(scope) if entry.mac)
+        if not adapters:
+            paired_macs.update(entry.mac for entry in bluez.list_devices() if entry.mac)
+        bt_info["paired_devices"] = len(paired_macs)
         collections_status["bluetooth"] = collection_status_payload("ok", count=bt_info["paired_devices"])
     except Exception as exc:
         failed_collections.append("bluetooth")

--- a/src/sendspin_bridge/services/music_assistant/ma_monitor.py
+++ b/src/sendspin_bridge/services/music_assistant/ma_monitor.py
@@ -24,6 +24,7 @@ import sendspin_bridge.bridge.state as _state
 from sendspin_bridge.services.bluetooth.device_registry import get_device_registry_snapshot
 from sendspin_bridge.services.diagnostics.internal_events import DeviceEventType
 from sendspin_bridge.services.music_assistant.ma_artwork import build_artwork_proxy_url
+from sendspin_bridge.services.music_assistant.ma_player_map import learn_ma_player_ids
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -144,7 +145,14 @@ async def push_now_playing_to_mpris(fresh: dict, clients: list, registry) -> Non
 
 
 def solo_queue_candidates(player_id: str | None) -> list[str]:
-    """Return ordered MA solo queue IDs compatible with current and legacy players."""
+    """Return ordered MA solo queue IDs, the learned one first.
+
+    Music Assistant numbers its own players, so the id a queue command has to
+    carry is the one MA published for us — looked up in the cache the monitor
+    fills from ``players/all``.  The derived forms below are what older
+    servers used and stay as a fallback for them; on a current server they
+    address a queue that does not exist.
+    """
     raw_player_id = str(player_id or "").strip()
     if not raw_player_id:
         return []
@@ -152,11 +160,19 @@ def solo_queue_candidates(player_id: str | None) -> list[str]:
     if raw_player_id.startswith(("media_player.", "ma_", "syncgroup_")):
         return [raw_player_id]
 
-    legacy_queue_id = "up" + raw_player_id.replace("-", "")
-    if raw_player_id.startswith("sendspin-"):
-        return [raw_player_id, legacy_queue_id]
+    candidates: list[str] = []
+    learned = _state.get_ma_player_id(raw_player_id)
+    if learned:
+        candidates.append(learned)
 
-    return [legacy_queue_id, raw_player_id]
+    legacy_queue_id = "up" + raw_player_id.replace("-", "")
+    derived = (
+        [raw_player_id, legacy_queue_id] if raw_player_id.startswith("sendspin-") else [legacy_queue_id, raw_player_id]
+    )
+    for candidate in derived:
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return candidates
 
 
 class _AuthFailed(Exception):
@@ -745,6 +761,11 @@ class MaMonitor:
                 for c in clients
                 if getattr(c, "player_id", "")
             ]
+
+            # The same answer says which MA player fronts each of our
+            # speakers.  Without it a queue command for an ungrouped speaker
+            # is aimed at an id MA does not have.
+            _state.set_ma_player_ids(learn_ma_player_ids(players, bridge_info))
 
             member_set_by_group: dict[str, set[str]] = {}
 

--- a/src/sendspin_bridge/services/music_assistant/ma_player_map.py
+++ b/src/sendspin_bridge/services/music_assistant/ma_player_map.py
@@ -1,0 +1,68 @@
+"""Which Music Assistant player fronts each of our speakers.
+
+Music Assistant wraps every output in a player of its own and gives it an id
+we do not choose.  The bridge used to derive that id from its own client id —
+`up` + the id with the dashes stripped — which was the numbering an older
+server used.  Against a current one, every queue command aimed at an
+ungrouped speaker addressed a queue that does not exist, and no queue state
+ever came back for it.
+
+The link is published rather than derivable: the player that fronts our
+speaker lists our client id among its output protocols.  This module reads it
+out of a ``players/all`` payload; nothing here guesses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["learn_ma_player_ids"]
+
+
+def _display_name(player: dict[str, Any]) -> str:
+    return str(player.get("display_name") or player.get("name") or "").strip()
+
+
+def _output_protocol_ids(player: dict[str, Any]) -> set[str]:
+    protocols = player.get("output_protocols") or []
+    if not isinstance(protocols, list):
+        return set()
+    return {
+        str(entry.get("output_protocol_id") or "").strip()
+        for entry in protocols
+        if isinstance(entry, dict) and entry.get("output_protocol_id")
+    }
+
+
+def learn_ma_player_ids(
+    players: list[dict[str, Any]],
+    bridge_players: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Map ``{bridge client id → MA player id}`` for the clients MA knows.
+
+    A client id carried as one of a player's output protocols is proof; an
+    exact display-name match stands in for servers that publish no protocols.
+    A name that merely resembles ours is not a match — two bridges serving the
+    same speaker differ only by the suffix on that name.
+    """
+    by_protocol: dict[str, str] = {}
+    by_exact_name: dict[str, str] = {}
+    for player in players or []:
+        player_id = str(player.get("player_id") or "").strip()
+        if not player_id:
+            continue
+        for protocol_id in _output_protocol_ids(player):
+            by_protocol.setdefault(protocol_id, player_id)
+        name = _display_name(player)
+        if name:
+            by_exact_name.setdefault(name, player_id)
+
+    mapping: dict[str, str] = {}
+    for bridge_player in bridge_players or []:
+        client_id = str(bridge_player.get("player_id") or "").strip()
+        if not client_id:
+            continue
+        resolved = by_protocol.get(client_id) or by_exact_name.get(str(bridge_player.get("player_name") or "").strip())
+        if resolved:
+            mapping[client_id] = resolved
+    return mapping

--- a/src/sendspin_bridge/services/music_assistant/ma_runtime_state.py
+++ b/src/sendspin_bridge/services/music_assistant/ma_runtime_state.py
@@ -28,6 +28,33 @@ _MA_SYNC_META_KEY = "_sync_meta"
 _duplicate_device_warnings: list[Any] = []
 _duplicate_device_warnings_lock = threading.Lock()
 
+#: ``{bridge client id → MA player id}``, learned from ``players/all``.  MA
+#: numbers its own players, so the id a queue command must carry is looked up
+#: here rather than derived from our client id.
+_ma_player_ids: dict[str, str] = {}
+_ma_player_ids_lock = threading.Lock()
+
+
+def set_ma_player_ids(mapping: dict[str, str]) -> None:
+    """Store the learned bridge-client → MA-player mapping."""
+    with _ma_player_ids_lock:
+        changed = _ma_player_ids != mapping
+        _ma_player_ids.clear()
+        _ma_player_ids.update(mapping)
+    if changed:
+        logger.info("MA player id cache updated: %d bridge player(s) resolved", len(mapping))
+
+
+def get_ma_player_id(client_id: str) -> str:
+    """The MA player id for *client_id*, or ``""`` when MA has not named one."""
+    with _ma_player_ids_lock:
+        return _ma_player_ids.get(str(client_id or "").strip(), "")
+
+
+def get_ma_player_ids() -> dict[str, str]:
+    with _ma_player_ids_lock:
+        return dict(_ma_player_ids)
+
 
 def set_duplicate_device_warnings(warnings: list[Any]) -> None:
     """Store the latest cross-bridge duplicate device warnings."""

--- a/src/sendspin_bridge/web/routes/api_status.py
+++ b/src/sendspin_bridge/web/routes/api_status.py
@@ -931,13 +931,19 @@ def api_diagnostics():
         # bundle attached to a bug report was the one built the other way.
         diagnostics_config = load_config()
         diagnostics_devices = [device for _client, device in snapshot_pairs]
+        # Measured, not guessed: the bundle has no "preflight" key, so this
+        # used to hand the state model an empty one.  An empty preflight reads
+        # as "D-Bus unavailable", and the recovery card in the bundle then
+        # reported a runtime that cannot reach D-Bus on a host that was
+        # paired, connected and playing.
+        diagnostics_preflight = _collect_preflight_status()
         try:
             diagnostics_state = build_bridge_state_model(
                 config=diagnostics_config,
                 devices=diagnostics_devices,
                 runtime_mode=diag["runtime_info"].get("mode", "unknown"),
                 ma_connected=is_ma_connected(),
-                preflight=diag.get("preflight") or {},
+                preflight=diagnostics_preflight,
             )
         except Exception:
             logger.warning("Could not build the state model for diagnostics", exc_info=True)
@@ -945,6 +951,7 @@ def api_diagnostics():
 
         try:
             onboarding_assistant = _build_onboarding_assistant_payload(
+                preflight=diagnostics_preflight,
                 config=diagnostics_config,
                 devices=diagnostics_devices,
                 runtime_mode=diag["runtime_info"].get("mode", "unknown"),
@@ -963,6 +970,7 @@ def api_diagnostics():
             )
         try:
             diag["recovery_assistant"] = _build_recovery_assistant_payload(
+                preflight=diagnostics_preflight,
                 config=diagnostics_config,
                 devices=diagnostics_devices,
                 onboarding_assistant=onboarding_assistant,

--- a/tests/unit/bridge/test_restart_request_accounting.py
+++ b/tests/unit/bridge/test_restart_request_accounting.py
@@ -1,0 +1,63 @@
+"""A start that queues behind a restart is served by that restart's spawn.
+
+`start_sendspin` counts requests so a start arriving while another is in
+flight is not lost: the holder re-runs the spawn if the count moved.  A
+restart holds the same lock, so a start arriving during one returns early —
+and its request has in fact been served, by the daemon the restart spawns.
+The counter has to say so, or the bookkeeping drifts from what happened.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sendspin_bridge.bridge.client import SendspinClient
+
+
+def _client() -> SendspinClient:
+    client = SendspinClient("Test Player", "localhost", 9000)
+    client.running = True
+    client._start_sendspin_lock = asyncio.Lock()
+    client._start_sendspin_requests = 0
+    client._start_sendspin_processed = 0
+    return client
+
+
+@pytest.mark.asyncio
+async def test_a_start_arriving_during_a_restart_is_accounted_for(monkeypatch):
+    client = _client()
+    spawns: list[str] = []
+
+    async def _spawn():
+        spawns.append("spawn")
+
+    async def _stop():
+        # A start arrives while the restart is still stopping the old daemon.
+        await client.start_sendspin()
+
+    monkeypatch.setattr(client, "_start_sendspin_inner", _spawn)
+    monkeypatch.setattr(client, "stop_sendspin", _stop)
+
+    await client.warm_restart({"static_delay_ms": 100})
+
+    assert spawns == ["spawn"], "the queued start spawned a second daemon"
+    assert client._start_sendspin_processed == client._start_sendspin_requests, (
+        "the restart served the queued start but the counter still calls it pending"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_restart_that_spawns_nothing_leaves_the_request_pending(monkeypatch):
+    """A stopped client cannot serve a start; the next one still must."""
+    client = _client()
+    client.running = False
+    monkeypatch.setattr(client, "stop_sendspin", lambda: asyncio.sleep(0))
+    monkeypatch.setattr(client, "_start_sendspin_inner", lambda: asyncio.sleep(0))
+
+    client._start_sendspin_requests = 1
+
+    await client.warm_restart({"static_delay_ms": 100})
+
+    assert client._start_sendspin_processed == 0

--- a/tests/unit/bridge/test_restart_serialization.py
+++ b/tests/unit/bridge/test_restart_serialization.py
@@ -1,0 +1,130 @@
+"""A restart must not race the spawn path into a second daemon.
+
+Found on hardware: two restarts arrived while a device was reconnecting, and
+the bridge logged two spawns 1 ms apart with different PIDs.  The second
+overwrote the tracked handle, so the first daemon kept the Bluetooth sink and
+the listen port with nothing watching it — no exit was ever logged for it, and
+it had to be killed by hand.
+
+`start_sendspin` coalesces concurrent starts behind a lock.  `warm_restart`
+stopped and spawned outside that lock, so it could not see a start in flight
+and a start could not see it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sendspin_bridge.bridge.client import SendspinClient
+
+
+def _client() -> SendspinClient:
+    client = SendspinClient("Test Player", "localhost", 9000)
+    client.running = True
+    client._start_sendspin_lock = asyncio.Lock()
+    client._start_sendspin_requests = 0
+    client._start_sendspin_processed = 0
+    return client
+
+
+class _SpawnRecorder:
+    """Counts spawns and reports whether two ever overlapped."""
+
+    def __init__(self):
+        self.spawns = 0
+        self.in_flight = 0
+        self.overlapped = False
+
+    async def spawn(self) -> None:
+        self.spawns += 1
+        self.in_flight += 1
+        self.overlapped = self.overlapped or self.in_flight > 1
+        await asyncio.sleep(0.02)  # the real spawn awaits the subprocess
+        self.in_flight -= 1
+
+    async def stop(self) -> None:
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_a_warm_restart_and_a_start_do_not_spawn_two_daemons(monkeypatch):
+    client = _client()
+    recorder = _SpawnRecorder()
+
+    monkeypatch.setattr(client, "_start_sendspin_inner", recorder.spawn)
+    monkeypatch.setattr(client, "stop_sendspin", recorder.stop)
+
+    await asyncio.gather(
+        client.warm_restart({"static_delay_ms": 100}),
+        client.start_sendspin(),
+    )
+
+    assert not recorder.overlapped, "a restart and a start spawned daemons at the same time"
+
+
+@pytest.mark.asyncio
+async def test_two_warm_restarts_are_serialised(monkeypatch):
+    client = _client()
+    recorder = _SpawnRecorder()
+
+    monkeypatch.setattr(client, "_start_sendspin_inner", recorder.spawn)
+    monkeypatch.setattr(client, "stop_sendspin", recorder.stop)
+
+    await asyncio.gather(
+        client.warm_restart({"static_delay_ms": 100}),
+        client.warm_restart({"static_delay_ms": 200}),
+    )
+
+    assert not recorder.overlapped, "two restarts spawned daemons at the same time"
+
+
+@pytest.mark.asyncio
+async def test_a_restart_still_respawns(monkeypatch):
+    """Serialising must not turn a restart into a no-op."""
+    client = _client()
+    recorder = _SpawnRecorder()
+
+    monkeypatch.setattr(client, "_start_sendspin_inner", recorder.spawn)
+    monkeypatch.setattr(client, "stop_sendspin", recorder.stop)
+
+    await client.warm_restart({"static_delay_ms": 100})
+
+    assert recorder.spawns == 1
+
+
+@pytest.mark.asyncio
+async def test_a_restart_of_a_stopped_client_does_not_spawn(monkeypatch):
+    client = _client()
+    client.running = False
+    recorder = _SpawnRecorder()
+
+    monkeypatch.setattr(client, "_start_sendspin_inner", recorder.spawn)
+    monkeypatch.setattr(client, "stop_sendspin", recorder.stop)
+
+    await client.warm_restart({"static_delay_ms": 100})
+
+    assert recorder.spawns == 0
+
+
+@pytest.mark.asyncio
+async def test_a_zombie_restart_does_not_race_a_warm_restart(monkeypatch):
+    """The watchdog restart took the same route around the lock."""
+    client = _client()
+    recorder = _SpawnRecorder()
+
+    monkeypatch.setattr(client, "_start_sendspin_inner", recorder.spawn)
+    monkeypatch.setattr(client, "stop_sendspin", recorder.stop)
+    # The watchdog settles for a second before respawning; the point here is
+    # the ordering, not the wait.
+    original_restart = client._restart_daemon
+    monkeypatch.setattr(client, "_restart_daemon", lambda **kw: original_restart(settle_s=0.0))
+
+    await asyncio.gather(
+        client._zombie_restart(),
+        client.warm_restart({"static_delay_ms": 100}),
+    )
+
+    assert not recorder.overlapped, "the watchdog restart raced the warm restart"
+    assert recorder.spawns == 2

--- a/tests/unit/services/diagnostics/test_diagnostics_preflight.py
+++ b/tests/unit/services/diagnostics/test_diagnostics_preflight.py
@@ -1,0 +1,59 @@
+"""The diagnostics bundle must not invent a broken runtime.
+
+`/api/diagnostics` built its state model with `diag.get("preflight")` — a key
+the bundle does not have.  The state model therefore always saw an empty
+preflight, decided D-Bus was unavailable, and the recovery card in the
+bundle claimed "the bridge runtime cannot reach the host D-Bus services
+required for Bluetooth control" on a host that was paired, connected and
+playing.  `/api/status`, which collects a real preflight, said nothing of the
+kind — so the bug report contradicted the screen it was taken from.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app(monkeypatch, tmp_path):
+    import sendspin_bridge.config as config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    (tmp_path / "config.json").write_text(json.dumps({}))
+
+    import sendspin_bridge.web.routes.api_status as api_status
+
+    monkeypatch.setattr(
+        api_status,
+        "_collect_preflight_status",
+        lambda: {"dbus": {"available": True}, "bluetooth": {"status": "ok"}, "audio": {"status": "ok"}},
+    )
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(api_status.status_bp)
+    return flask_app, api_status
+
+
+def test_the_bundle_state_model_keeps_the_runtime_it_measured(app, monkeypatch):
+    flask_app, api_status = app
+
+    seen: list[object] = []
+
+    def _spy(**kwargs):
+        seen.append(kwargs.get("bridge_state"))
+        return {}
+
+    monkeypatch.setattr(api_status, "_build_recovery_assistant_payload", _spy)
+    monkeypatch.setattr(api_status, "_build_onboarding_assistant_payload", lambda **kw: {})
+    monkeypatch.setattr(api_status, "_build_operator_guidance_payload", lambda **kw: {})
+
+    flask_app.test_client().get("/api/diagnostics")
+
+    assert seen and seen[0] is not None, "the bundle was built without a state model"
+    substrate = seen[0].to_dict()["runtime_substrate"]
+    assert substrate["dbus_available"] is True, "the bundle reported a D-Bus it never measured"
+    assert substrate["bluetooth"] == {"status": "ok"}

--- a/tests/unit/services/diagnostics/test_preflight_bluetooth_daemon.py
+++ b/tests/unit/services/diagnostics/test_preflight_bluetooth_daemon.py
@@ -140,3 +140,26 @@ def test_bluetooth_collection_errors_when_transport_unavailable(fake_bluez):
     assert "bluetooth" in result["failed_collections"]
     assert result["collections_status"]["bluetooth"]["status"] == "error"
     assert probe.calls == 0
+
+
+# ── more than one controller ─────────────────────────────────────────────
+
+
+def test_paired_devices_are_counted_across_every_controller(fake_bluez):
+    """Found on a two-adapter host: the speaker was paired on the second one.
+
+    The probe asked only the first controller, counted zero, and onboarding
+    announced "No paired Bluetooth speakers are currently available to the
+    bridge" while that speaker was connected and streaming.
+    """
+    first, second = "C0:FB:F9:62:D7:D6", "00:02:72:0A:E4:3B"
+    fake_bluez.on(
+        "list",
+        stdout=f"Controller {first} HP-ProDesk [default]\nController {second} HP-ProDesk #2\n",
+    )
+    fake_bluez.on("devices Paired", stdout="")
+    fake_bluez.on_adapter(second).on("devices Paired", stdout="Device 6C:5C:3D:35:17:99 ENEBY Portable\n")
+
+    bt = _collect(fake_bluez, _DaemonProbe("unused"))["bluetooth"]
+
+    assert bt["paired_devices"] == 1, "a speaker paired on the second controller was not counted"

--- a/tests/unit/services/music_assistant/test_ma_player_map.py
+++ b/tests/unit/services/music_assistant/test_ma_player_map.py
@@ -1,0 +1,179 @@
+"""Which Music Assistant player is this bridge client?
+
+The bridge derived a solo player's MA queue id from its own client id —
+`up` + the id with the dashes stripped.  Music Assistant used to number
+players that way; it no longer does.  Measured against a live server:
+
+    player_queues/get up8e34f1108d9b5eeeb08e7dad2a4ae478 -> null
+    player_queues/get 8e34f110-8d9b-5eee-b08e-7dad2a4ae478 -> null
+    player_queues/get up4098e820 -> ENEBY Portable @ local-test
+
+So every queue command aimed at an ungrouped speaker addressed a queue that
+does not exist, and the queue never appeared in the now-playing cache — which
+is what made the device card report Music Assistant as disconnected while it
+was connected.
+
+MA does publish the link: the universal player that fronts our speaker lists
+our client id as one of its output protocols.  It is looked up, not guessed.
+"""
+
+from __future__ import annotations
+
+from sendspin_bridge.services.music_assistant.ma_player_map import learn_ma_player_ids
+
+CLIENT_ID = "8e34f110-8d9b-5eee-b08e-7dad2a4ae478"
+
+# Shapes taken from a live MA 2026.x `players/all` response.
+PLAYERS = [
+    {
+        "player_id": "up4098e820",
+        "name": "ENEBY Portable @ local-test",
+        "display_name": "ENEBY Portable @ local-test",
+        "provider": "universal_player",
+        "output_protocols": [{"output_protocol_id": CLIENT_ID, "name": "Sendspin", "protocol_domain": "sendspin"}],
+    },
+    {
+        "player_id": "up366c5814",
+        "name": "ENEBY Portable @ 85b1ecde-sendspin-bt-bridge-rc",
+        "display_name": "ENEBY Portable @ 85b1ecde-sendspin-bt-bridge-rc",
+        "provider": "universal_player",
+        "output_protocols": [{"output_protocol_id": "8e718155-dd65-50df-ab9b-fd166b2a572d", "name": "Sendspin"}],
+    },
+    {
+        "player_id": "ys_MK0000000000000131310000f057007a",
+        "name": "yandexioreceiver",
+        "provider": "yandex_station",
+        "output_protocols": [{"output_protocol_id": "native", "name": "Yandex Station"}],
+    },
+]
+
+
+def test_the_player_that_carries_our_output_protocol_is_ours():
+    mapping = learn_ma_player_ids(PLAYERS, [{"player_id": CLIENT_ID, "player_name": "ENEBY Portable @ local-test"}])
+
+    assert mapping == {CLIENT_ID: "up4098e820"}
+
+
+def test_another_bridge_serving_the_same_speaker_is_not_ours():
+    """Two bridges expose the same speaker; only our client id decides."""
+    mapping = learn_ma_player_ids(PLAYERS, [{"player_id": CLIENT_ID, "player_name": "ENEBY Portable @ local-test"}])
+
+    assert "up366c5814" not in mapping.values()
+
+
+def test_a_client_music_assistant_does_not_know_is_absent():
+    mapping = learn_ma_player_ids(PLAYERS, [{"player_id": "no-such-client", "player_name": "Nowhere"}])
+
+    assert mapping == {}
+
+
+def test_an_exact_display_name_stands_in_when_no_protocol_matches():
+    """Older servers list no output protocols; the name is then all there is."""
+    players = [{"player_id": "up111", "display_name": "Study", "provider": "universal_player"}]
+
+    mapping = learn_ma_player_ids(players, [{"player_id": "client-1", "player_name": "Study"}])
+
+    assert mapping == {"client-1": "up111"}
+
+
+def test_a_near_miss_on_the_name_is_not_a_match():
+    """ "Study" and "Study @ other-bridge" are different speakers."""
+    players = [{"player_id": "up111", "display_name": "Study @ other-bridge", "provider": "universal_player"}]
+
+    mapping = learn_ma_player_ids(players, [{"player_id": "client-1", "player_name": "Study"}])
+
+    assert mapping == {}
+
+
+def test_the_protocol_match_wins_over_a_name_that_points_elsewhere():
+    players = [
+        {"player_id": "up111", "display_name": "Kitchen", "provider": "universal_player"},
+        {
+            "player_id": "up222",
+            "display_name": "Kitchen",
+            "provider": "universal_player",
+            "output_protocols": [{"output_protocol_id": "client-1"}],
+        },
+    ]
+
+    mapping = learn_ma_player_ids(players, [{"player_id": "client-1", "player_name": "Kitchen"}])
+
+    assert mapping == {"client-1": "up222"}
+
+
+# ── what a queue command is aimed at ─────────────────────────────────────
+
+
+def test_the_learned_id_is_the_first_queue_a_command_is_aimed_at(monkeypatch):
+    from sendspin_bridge.services.music_assistant import ma_runtime_state
+    from sendspin_bridge.services.music_assistant.ma_monitor import solo_queue_candidates
+
+    ma_runtime_state.set_ma_player_ids({CLIENT_ID: "up4098e820"})
+    try:
+        candidates = solo_queue_candidates(CLIENT_ID)
+    finally:
+        ma_runtime_state.set_ma_player_ids({})
+
+    assert candidates[0] == "up4098e820"
+
+
+def test_the_derived_ids_remain_as_a_fallback():
+    """Servers that do number players our way must keep working."""
+    from sendspin_bridge.services.music_assistant.ma_monitor import solo_queue_candidates
+
+    candidates = solo_queue_candidates(CLIENT_ID)
+
+    assert "up8e34f1108d9b5eeeb08e7dad2a4ae478" in candidates
+
+
+def test_a_learned_id_is_not_repeated_among_the_fallbacks():
+    from sendspin_bridge.services.music_assistant import ma_runtime_state
+    from sendspin_bridge.services.music_assistant.ma_monitor import solo_queue_candidates
+
+    ma_runtime_state.set_ma_player_ids({CLIENT_ID: "up8e34f1108d9b5eeeb08e7dad2a4ae478"})
+    try:
+        candidates = solo_queue_candidates(CLIENT_ID)
+    finally:
+        ma_runtime_state.set_ma_player_ids({})
+
+    assert candidates.count("up8e34f1108d9b5eeeb08e7dad2a4ae478") == 1
+
+
+# ── the monitor learns it on every refresh ───────────────────────────────
+
+
+def test_the_groups_refresh_also_learns_the_player_ids(monkeypatch):
+    """One `players/all` answer carries both facts; both are kept."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from sendspin_bridge.services.music_assistant import ma_runtime_state
+    from sendspin_bridge.services.music_assistant.ma_monitor import MaMonitor
+
+    monitor = MaMonitor.__new__(MaMonitor)
+    monitor._next_id = lambda: 1
+    monitor._defer_incoming_event = lambda _evt: None
+    monitor._track_background_task = lambda task: task
+
+    monkeypatch.setattr(
+        "sendspin_bridge.services.music_assistant.ma_monitor._send",
+        lambda *_a, **_kw: asyncio.sleep(0),
+    )
+    monkeypatch.setattr(
+        "sendspin_bridge.services.music_assistant.ma_monitor._recv",
+        lambda *_a, **_kw: _answer(),
+    )
+    monkeypatch.setattr(
+        "sendspin_bridge.services.music_assistant.ma_monitor._active_bridge_clients",
+        lambda: [SimpleNamespace(player_id=CLIENT_ID, player_name="ENEBY Portable @ local-test")],
+    )
+
+    async def _answer():
+        return {"message_id": 1, "result": PLAYERS}
+
+    ma_runtime_state.set_ma_player_ids({})
+    try:
+        asyncio.run(monitor._refresh_groups_via_ws(object()))
+        assert ma_runtime_state.get_ma_player_id(CLIENT_ID) == "up4098e820"
+    finally:
+        ma_runtime_state.set_ma_player_ids({})


### PR DESCRIPTION
Ran the bridge locally against real hardware — two USB Bluetooth controllers, an ENEBY Portable paired through the bridge's own scan/pair flow and streaming over the second controller, a live Music Assistant server on the LAN. Four defects turned up that the suite could not see, each with a test that fails without the fix.

## Queue controls were aimed at a queue that does not exist

A speaker in no sync group has its own MA queue, and the bridge addressed it by deriving an id from its own client id — `up` + the id with the dashes stripped. That is how an older server numbered players. Measured against the live one:

```
player_queues/get up8e34f1108d9b5eeeb08e7dad2a4ae478   -> null
player_queues/get 8e34f110-8d9b-5eee-b08e-7dad2a4ae478 -> null
player_queues/get up4098e820                           -> ENEBY Portable @ local-test
```

Every queue command for an ungrouped speaker therefore reached nothing, and no queue state came back for it. That empty state is also what the device card reads to decide whether MA is reachable — so the card said "Music Assistant API is not connected" while the same payload carried `ma_connected: true`.

MA publishes the link rather than making it derivable: the player fronting our speaker lists our client id among its `output_protocols`. The monitor already fetches `players/all` for the sync-group cache; it now reads the player ids out of the same answer, and a command aims at the learned id first. The derived forms stay behind it for servers that do number players that way.

Verified live: `MA queue cmd (monitor): shuffle value=False -> up4098e820 ack=8ms`, and the queue controls on the device card became available.

## The bundle described a runtime it never measured

`/api/diagnostics` built its state model from `diag.get("preflight")` — a key the bundle does not have. The state model always read an empty preflight, concluded D-Bus was unavailable, and the recovery card announced:

> The bridge runtime cannot reach the host D-Bus services required for Bluetooth control.

on a host that was paired, connected and playing. `/api/status`, which collects a real preflight, said nothing of the kind. The two disagreed precisely where a bug report is taken — the same class of defect #443 was about, one layer further in. Diagnostics now collects its own preflight and hands it to the state model and to both assistants.

## A restart could leave a daemon nobody was watching

```
21:09:30,246  Sendspin daemon subprocess started (PID 3039094)
21:09:30,247  Sendspin daemon subprocess started (PID 3039095)
```

Two spawns a millisecond apart. The second overwrote the tracked handle; the first kept the Bluetooth sink and the listen port with nothing watching it — no exit was ever logged for it, and it had to be killed by hand.

`start_sendspin` coalesces concurrent starts behind a lock. `warm_restart` stopped and respawned outside that lock, so it could neither see a start in flight nor be seen by one; the watchdog restart took the same route. Both now restart inside that lock.

## A speaker on the second adapter counted as no speaker at all

The preflight probe asked only the first controller for paired devices. With the speaker bonded to the second adapter it counted zero, and setup guidance announced:

> No paired Bluetooth speakers are currently available to the bridge.

while that speaker was connected and streaming. Every controller is asked now, unioned by address so one speaker bonded twice still counts once.

## Verified live

Same hardware, after the fixes:

- `paired_devices: 2` where it read `0`
- recovery issues: `[]` — the false D-Bus and false "no speakers" cards both gone
- `/api/status` and `/api/diagnostics` agree on the issue list
- one spawn per start, one daemon running
- queue controls available; a real queue command acknowledged by MA in 8 ms against the correct queue
- pairing, A2DP routing (`bluez_output.6C_5C_3D_35_17_99.1`), the calibration metronome (audible, no player left behind on stop) and supervisor backoff (`restart_delay` 1.0 -> 2.0 after a kill, back to 1.0 once the daemon stayed up) all exercised on the device

## Known, not fixed here

The device card still derives "is Music Assistant reachable" from the device's own now-playing cache rather than the runtime connection flag. With solo queues resolving, that cache now fills for ungrouped speakers too, so the misleading message is no longer reachable in the common case — but a device MA does not know at all would still be reported as "Music Assistant API is not connected", with a remediation that cannot help. Worth a follow-up that separates "MA is down" from "MA does not know this device".

Gate: 3467 passed, 1 skipped; ruff clean; changelog clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
