### PR TITLE
fix(ma): separate "Music Assistant is down" from "no queue for this speaker"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a speaker was connected and streaming.
 - Two restarts arriving together can no longer leave a second audio daemon
   running unwatched, holding the speaker's audio sink and its port.
+- A speaker Music Assistant has no queue for is now described as exactly
+  that, with an action that can help. It used to be reported as "Music
+  Assistant API is not connected" — on a bridge whose connection was fine —
+  and offered a settings page that could not fix it.
 - Queue controls work for a speaker that is not in a Music Assistant sync
   group. The bridge used to guess that speaker's queue address instead of
   asking Music Assistant for it, so every queue command reached nothing and

--- a/src/sendspin_bridge/services/bluetooth/device_health_state.py
+++ b/src/sendspin_bridge/services/bluetooth/device_health_state.py
@@ -503,10 +503,11 @@ def build_device_capabilities(device: Any) -> dict[str, Any]:
             recommended_action="reconnect",
         )
     queue_available = bool(getattr(device, "server_connected", False) and ma_connected and ma_queue_known)
-    if not ma_connected:
-        queue_safe_actions = ["open_ma_settings", "open_diagnostics"]
-    elif not ma_queue_known:
-        queue_safe_actions = ["reconnect", "open_diagnostics"]
+    # The offered actions follow the reason above, in the same order: an
+    # action a caller cannot run is worse than none, and "use the queue" is
+    # not runnable while the thing that serves it is down.
+    if queue_blocked_reason is not None:
+        queue_safe_actions = list(queue_blocked_reason.remediation or ["open_diagnostics"])
     else:
         queue_safe_actions = ["queue_control"]
     queue_control = _capability_payload(

--- a/src/sendspin_bridge/services/bluetooth/device_health_state.py
+++ b/src/sendspin_bridge/services/bluetooth/device_health_state.py
@@ -300,8 +300,13 @@ def _capability_domain_payload(*capabilities: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_device_capabilities(device: Any) -> dict[str, Any]:
-    ma_connected = bool((getattr(device, "ma_now_playing", None) or {}).get("connected"))
     extra = _device_extra(device)
+    # Two different states used to share one answer.  Whether Music Assistant
+    # is reachable is a property of the bridge; whether it has a queue for
+    # *this* speaker is a property of the speaker.  Reading the second and
+    # calling it the first told operators to check settings that were fine.
+    ma_queue_known = bool((getattr(device, "ma_now_playing", None) or {}).get("connected"))
+    ma_connected = bool(extra.get("ma_connected", ma_queue_known))
     reconnecting = bool(extra.get("reconnecting"))
     ma_reconnecting = _device_ma_reconnecting(device)
     stopping = bool(extra.get("stopping"))
@@ -489,11 +494,26 @@ def build_device_capabilities(device: Any) -> dict[str, Any]:
             depends_on=["ma_connected"],
             recommended_action="open_ma_settings",
         )
+    elif not ma_queue_known:
+        queue_blocked_reason = _block_reason_payload(
+            code="ma_queue_unknown",
+            message="Music Assistant has no queue for this speaker yet.",
+            remediation=["reconnect", "open_diagnostics"],
+            depends_on=["ma_player_registered"],
+            recommended_action="reconnect",
+        )
+    queue_available = bool(getattr(device, "server_connected", False) and ma_connected and ma_queue_known)
+    if not ma_connected:
+        queue_safe_actions = ["open_ma_settings", "open_diagnostics"]
+    elif not ma_queue_known:
+        queue_safe_actions = ["reconnect", "open_diagnostics"]
+    else:
+        queue_safe_actions = ["queue_control"]
     queue_control = _capability_payload(
         supported=bool(getattr(device, "server_connected", False)),
-        currently_available=bool(getattr(device, "server_connected", False) and ma_connected),
+        currently_available=queue_available,
         blocked_reason=queue_blocked_reason,
-        safe_actions=["open_ma_settings", "open_diagnostics"] if not ma_connected else ["queue_control"],
+        safe_actions=queue_safe_actions,
     )
 
     diagnostics = _capability_payload(

--- a/src/sendspin_bridge/services/lifecycle/status_snapshot.py
+++ b/src/sendspin_bridge/services/lifecycle/status_snapshot.py
@@ -13,7 +13,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import sendspin_bridge.bridge.state as state
-from sendspin_bridge.bridge.state import get_adapter_name, get_ma_group_for_player_id, get_ma_now_playing_for_group
+from sendspin_bridge.bridge.state import (
+    get_adapter_name,
+    get_ma_group_for_player_id,
+    get_ma_now_playing_for_group,
+    is_ma_connected,
+)
 from sendspin_bridge.config import BUILD_DATE, get_runtime_version, load_config, resolve_device_room_context
 from sendspin_bridge.services.bluetooth import _match_player_name
 from sendspin_bridge.services.bluetooth.device_health_state import (
@@ -221,6 +226,10 @@ class BridgeSnapshot:
 
 
 def _enrich_device_snapshot_with_ma(device: DeviceSnapshot, client_or_player_id="") -> None:
+    # Whether Music Assistant is reachable at all is a bridge-wide fact, and
+    # the device card needs it to tell "MA is down" apart from "MA has no
+    # queue for this speaker" — two states that used to share one answer.
+    device.extra["ma_connected"] = bool(is_ma_connected())
     player_id = device.extra.get("player_id") or (
         client_or_player_id if isinstance(client_or_player_id, str) else getattr(client_or_player_id, "player_id", "")
     )

--- a/src/sendspin_bridge/services/music_assistant/ma_monitor.py
+++ b/src/sendspin_bridge/services/music_assistant/ma_monitor.py
@@ -933,9 +933,13 @@ class MaMonitor:
                     await _hydrate_missing_queue_neighbors(fetch_items, q, np)
                     np["syncgroup_id"] = player_id
                     fresh[player_id] = np
-                # Atomically replace to clear stale entries
+                # Atomically replace to clear stale entries.  An answer with
+                # no queues in it is an answer: a speaker whose queue was
+                # removed used to keep reporting the queue it once had,
+                # because the cache was only replaced when there was
+                # something to put in it.
+                _state.replace_ma_now_playing(fresh)
                 if fresh:
-                    _state.replace_ma_now_playing(fresh)
                     # Reverse-bridge: push playback state to per-device MprisPlayer
                     # so AVRCP-capable speakers (Bose, Sony WH-1000XM, Yandex
                     # mini) reflect MA's now-playing on their display/LEDs.

--- a/src/sendspin_bridge/web/static/app.js
+++ b/src/sendspin_bridge/web/static/app.js
@@ -671,6 +671,7 @@ function _capabilityDependencyLabels(dependsOn) {
         sendspin_connected: 'Sendspin transport',
         audio_sink: 'Resolved audio sink',
         ma_connected: 'Music Assistant link',
+        ma_player_registered: 'Music Assistant player registration',
     };
     return (dependsOn || []).map(function(key) {
         var normalized = String(key || '').trim();

--- a/tests/unit/services/bluetooth/test_queue_capability_reasons.py
+++ b/tests/unit/services/bluetooth/test_queue_capability_reasons.py
@@ -105,3 +105,21 @@ def test_the_device_snapshot_carries_the_runtime_music_assistant_flag(monkeypatc
     snapshot = status_snapshot.build_device_snapshot(client)
 
     assert snapshot.extra["ma_connected"] is True
+
+
+# ── the offered action must match the reason ─────────────────────────────
+
+
+def test_a_blocked_capability_never_offers_the_control_it_blocks():
+    """With the daemon down, "use the queue" is not an action that can run."""
+    capability = _queue(_device(ma_connected=True, queue_known=True, server_connected=False))
+
+    assert capability["currently_available"] is False
+    assert "queue_control" not in capability["safe_actions"]
+
+
+def test_a_daemon_that_is_down_is_the_action_offered():
+    capability = _queue(_device(ma_connected=True, queue_known=True, server_connected=False))
+
+    assert capability["blocked_reason_detail"]["recommended_action"] == "reconnect"
+    assert capability["safe_actions"][0] == "reconnect"

--- a/tests/unit/services/bluetooth/test_queue_capability_reasons.py
+++ b/tests/unit/services/bluetooth/test_queue_capability_reasons.py
@@ -1,0 +1,107 @@
+""" "Music Assistant is down" and "it does not know this speaker" are not the same.
+
+The queue capability decided whether Music Assistant was reachable by looking
+at the device's own now-playing cache.  A speaker Music Assistant has no queue
+for therefore produced "Music Assistant API is not connected" — on a bridge
+whose API connection, socket and queue polling were all healthy — and offered
+"open Music Assistant settings", which cannot fix it.
+
+The two states need different words because they need different actions: one
+is repaired in the MA settings, the other by getting the speaker registered
+with Music Assistant again.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sendspin_bridge.services.bluetooth.device_health_state import build_device_capabilities
+
+
+def _device(*, ma_connected: bool, queue_known: bool, server_connected: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(
+        player_name="Kitchen",
+        server_connected=server_connected,
+        bluetooth_connected=True,
+        bt_management_enabled=True,
+        has_sink=True,
+        enabled=True,
+        extra={"ma_connected": ma_connected},
+        ma_now_playing={"connected": True} if queue_known else {},
+    )
+
+
+def _queue(device) -> dict:
+    return build_device_capabilities(device)["actions"]["queue_control"]
+
+
+def test_a_reachable_queue_is_available():
+    capability = _queue(_device(ma_connected=True, queue_known=True))
+
+    assert capability["currently_available"] is True
+    assert capability["blocked_reason"] is None
+
+
+def test_music_assistant_being_down_is_named_as_such():
+    capability = _queue(_device(ma_connected=False, queue_known=False))
+
+    assert capability["currently_available"] is False
+    assert capability["blocked_reason_detail"]["code"] == "ma_disconnected"
+    assert capability["blocked_reason_detail"]["recommended_action"] == "open_ma_settings"
+
+
+def test_a_speaker_music_assistant_does_not_know_is_a_different_problem():
+    capability = _queue(_device(ma_connected=True, queue_known=False))
+
+    detail = capability["blocked_reason_detail"]
+    assert capability["currently_available"] is False
+    assert detail["code"] == "ma_queue_unknown"
+    assert "not connected" not in capability["blocked_reason"], capability["blocked_reason"]
+    assert detail["recommended_action"] != "open_ma_settings"
+
+
+def test_the_sendspin_daemon_still_wins_over_both():
+    """A daemon that is down is the first thing to fix, whatever MA says."""
+    capability = _queue(_device(ma_connected=True, queue_known=True, server_connected=False))
+
+    assert capability["blocked_reason_detail"]["code"] == "daemon_disconnected"
+
+
+# ── where the runtime flag comes from ────────────────────────────────────
+
+
+def test_the_device_snapshot_carries_the_runtime_music_assistant_flag(monkeypatch):
+    """The capability cannot ask the runtime itself — the snapshot tells it."""
+    import threading
+    from datetime import datetime, timezone
+
+    import sendspin_bridge.services.lifecycle.status_snapshot as status_snapshot
+
+    monkeypatch.setattr(status_snapshot, "is_ma_connected", lambda: True, raising=False)
+
+    client = SimpleNamespace(
+        status={
+            "server_connected": True,
+            "bluetooth_connected": True,
+            "bluetooth_available": True,
+            "playing": False,
+            "volume": 50,
+            "uptime_start": datetime.now(tz=timezone.utc),
+        },
+        _status_lock=threading.Lock(),
+        player_name="Kitchen",
+        player_id="sendspin-kitchen",
+        listen_port=8928,
+        server_host="music-assistant.local",
+        server_port=9000,
+        static_delay_ms=0.0,
+        connected_server_url="",
+        bt_manager=None,
+        bluetooth_sink_name="bluez_sink.AA.a2dp_sink",
+        bt_management_enabled=True,
+        is_running=lambda: True,
+    )
+
+    snapshot = status_snapshot.build_device_snapshot(client)
+
+    assert snapshot.extra["ma_connected"] is True

--- a/tests/unit/services/music_assistant/test_now_playing_cache_clearing.py
+++ b/tests/unit/services/music_assistant/test_now_playing_cache_clearing.py
@@ -1,0 +1,87 @@
+"""A queue that disappears must stop being reported.
+
+The poll replaced the now-playing cache only when it had something to put
+there.  A successful poll that found no queues left the previous snapshot in
+place, so a speaker whose queue was removed went on reporting the queue it
+used to have — and the device card went on offering queue controls for it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from sendspin_bridge.services.music_assistant import ma_runtime_state
+
+
+def _monitor():
+    from sendspin_bridge.services.music_assistant.ma_monitor import MaMonitor
+
+    monitor = MaMonitor.__new__(MaMonitor)
+    monitor._next_id = lambda: 1
+    monitor._defer_incoming_event = lambda _evt: None
+    return monitor
+
+
+def _poll_answering(monkeypatch, queues: list[dict]) -> None:
+    async def _recv(*_a, **_kw):
+        return {"message_id": 1, "result": queues}
+
+    monkeypatch.setattr("sendspin_bridge.services.music_assistant.ma_monitor._send", lambda *_a, **_kw: asyncio.sleep(0))
+    monkeypatch.setattr("sendspin_bridge.services.music_assistant.ma_monitor._recv", _recv)
+    async def _no_syncgroup_queues(_q):
+        return []
+
+    monkeypatch.setattr(
+        "sendspin_bridge.services.music_assistant.ma_monitor._find_syncgroup_queues",
+        _no_syncgroup_queues,
+    )
+    monkeypatch.setattr(
+        "sendspin_bridge.services.music_assistant.ma_monitor._find_solo_player_queues",
+        lambda _q: [],
+    )
+    monkeypatch.setattr(
+        "sendspin_bridge.services.music_assistant.ma_monitor._active_bridge_clients",
+        lambda: [],
+    )
+
+
+def test_a_poll_that_finds_nothing_clears_what_it_replaced(monkeypatch):
+    ma_runtime_state.replace_ma_now_playing({"up4098e820": {"connected": True, "state": "playing"}})
+    assert ma_runtime_state.get_ma_now_playing_for_group("up4098e820")
+
+    _poll_answering(monkeypatch, [])
+    try:
+        asyncio.run(_monitor()._poll_queues(object()))
+
+        assert ma_runtime_state.get_ma_now_playing_for_group("up4098e820") == {}
+    finally:
+        ma_runtime_state.replace_ma_now_playing({})
+
+
+def test_the_device_card_stops_offering_a_queue_that_is_gone(monkeypatch):
+    """The capability reads that cache; a stale entry keeps it available."""
+    from types import SimpleNamespace
+
+    from sendspin_bridge.services.bluetooth.device_health_state import build_device_capabilities
+
+    ma_runtime_state.replace_ma_now_playing({"up4098e820": {"connected": True}})
+    _poll_answering(monkeypatch, [])
+    try:
+        asyncio.run(_monitor()._poll_queues(object()))
+        device = SimpleNamespace(
+            player_name="Kitchen",
+            server_connected=True,
+            bluetooth_connected=True,
+            bt_management_enabled=True,
+            has_sink=True,
+            enabled=True,
+            extra={"ma_connected": True},
+            ma_now_playing=ma_runtime_state.get_ma_now_playing_for_group("up4098e820"),
+        )
+
+        queue = build_device_capabilities(device)["actions"]["queue_control"]
+
+        assert queue["currently_available"] is False
+        assert queue["blocked_reason_detail"]["code"] == "ma_queue_unknown"
+    finally:
+        ma_runtime_state.replace_ma_now_playing({})


### PR DESCRIPTION
Stacked on #444 — review that one first; this branch adds one commit on top of it.

The follow-up #444 called out. The queue capability decided whether Music Assistant was reachable by reading the device's own now-playing cache:

```python
ma_connected = bool((getattr(device, "ma_now_playing", None) or {}).get("connected"))
```

So a speaker Music Assistant has no queue for was reported as **"Music Assistant API is not connected"** — on a bridge whose API connection, socket and queue polling were all healthy — and the card offered to open the Music Assistant settings, which cannot fix it.

Two different states were sharing one answer:

| State | What it means | What helps |
|---|---|---|
| `ma_disconnected` | The bridge cannot reach Music Assistant | Check the Music Assistant settings |
| `ma_queue_unknown` | Music Assistant is reachable but has no queue for this speaker | Reconnect the speaker so it registers again |

Reachability now comes from the runtime connection flag, which the device snapshot carries alongside the per-device facts; a speaker with no queue gets its own reason code, its own dependency label (`ma_player_registered`, added to the frontend label map) and a reconnect as the recommended action. The Sendspin daemon being down still outranks both — it is the first thing to fix whatever Music Assistant says.

## Verified live

On the same hardware as #444, the window where the player mapping had not yet been learned showed the new wording, and it cleared by itself once the queue resolved:

```
queue available: False | reason: Music Assistant has no queue for this speaker yet. | code: ma_queue_unknown
   ... one monitor refresh later ...
queue available: True  | code: None
```

Gate: 3472 passed, 1 skipped; ruff clean; changelog clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
