### PR TITLE
perf(status): give the host probe its own clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Live status updates no longer re-probe the host on every tick. The
+  Bluetooth, audio and D-Bus checks behind the status payload are now sampled
+  at a bounded rate and shared between listeners, which takes a status update
+  from about 62 ms to about 6 ms — the saving multiplies by every open browser
+  tab. Diagnostics, the setup verification page and the operator checks still
+  measure the host when asked, and a saved config or an adapter power toggle
+  makes the next update measure again.
+
 ## [2.75.0-rc.4] - 2026-08-25
 
 ### Fixed

--- a/src/sendspin_bridge/services/diagnostics/status_derivation.py
+++ b/src/sendspin_bridge/services/diagnostics/status_derivation.py
@@ -1,0 +1,121 @@
+"""The host probe, on its own clock.
+
+A status payload has two halves that change at different rates and cost
+different amounts.  Runtime state — who is connected, what is playing, where
+the volume sits — lives in memory and changes many times a second.  The other
+half describes the *host*: the Bluetooth controllers, the audio server, D-Bus,
+memory.  It changes on the order of seconds and costs subprocesses to find
+out.
+
+They were fused: every SSE tick rebuilt both, so the rate of the first drove
+the cost of the second.  Measured on a live bridge, ``/api/preflight`` — the
+host probe alone — takes ~56 ms of the ~62 ms a full status build takes; the
+guidance derived on top of it costs a few milliseconds.  An idle bridge with
+one speaker ticks about every six seconds, per connected client, and every
+browser tab watching the dashboard multiplied those probes.
+
+This gives the probe its own cadence while everything derived from it stays
+as fresh as the tick.  Readers never wait on a probe already in flight: they
+are served what was last true, because making them wait would put the cost
+straight back on the tick.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["StatusDerivation"]
+
+#: Long enough to collapse a burst of status changes, short enough that an
+#: operator watching the dashboard cannot tell.
+DEFAULT_MIN_INTERVAL_S = 2.0
+
+
+class StatusDerivation[T]:
+    """Builds *build()* at most once per interval, and never twice at once."""
+
+    def __init__(
+        self,
+        build: Callable[[], T],
+        *,
+        min_interval_s: float = DEFAULT_MIN_INTERVAL_S,
+        clock: Callable[[], float] = time.monotonic,
+        label: str = "status derivation",
+        wait_timeout_s: float = 10.0,
+    ):
+        self._build = build
+        self._min_interval_s = float(min_interval_s)
+        self._clock = clock
+        self._label = label
+        self._wait_timeout_s = float(wait_timeout_s)
+        self._state = threading.Condition()
+        self._building = False
+        self._value: T | None = None
+        self._has_value = False
+        self._built_at = 0.0
+
+    def invalidate(self) -> None:
+        """Make the next read rebuild, whatever the interval says.
+
+        For the changes an operator makes and expects to see at once — a saved
+        config, a speaker added or released.  Costs nothing on its own: the
+        rebuild happens when somebody actually reads.
+        """
+        with self._state:
+            self._has_value = False
+
+    def current(self) -> T:
+        """The derived half, rebuilt only when it is due.
+
+        Raises whatever *build* raises, but only when there is nothing cached
+        to serve instead: once a value exists, a failed rebuild leaves it
+        standing rather than blanking the operator's screen.
+        """
+        with self._state:
+            while True:
+                if self._building:
+                    if self._has_value:
+                        # Somebody is already probing the host.  Waiting for
+                        # them would put the probe's cost back on this tick.
+                        return self._value  # type: ignore[return-value]
+                    # Nothing to serve yet, so there is no shortcut: wait for
+                    # the build in flight rather than starting a second one.
+                    self._state.wait(timeout=self._wait_timeout_s)
+                    continue
+                if not self._is_due():
+                    return self._value  # type: ignore[return-value]
+                self._building = True
+                break
+
+        try:
+            value = self._build()
+        except Exception:
+            with self._state:
+                self._building = False
+                self._state.notify_all()
+                if self._has_value:
+                    logger.warning("%s failed; serving the last known state", self._label, exc_info=True)
+                    return self._value  # type: ignore[return-value]
+            raise
+
+        with self._state:
+            self._value = value
+            self._has_value = True
+            self._built_at = self._clock()
+            self._building = False
+            self._state.notify_all()
+        return value
+
+    def _is_due(self) -> bool:
+        """Caller holds the condition."""
+        if not self._has_value:
+            return True
+        return (self._clock() - self._built_at) >= self._min_interval_s

--- a/src/sendspin_bridge/services/diagnostics/status_derivation.py
+++ b/src/sendspin_bridge/services/diagnostics/status_derivation.py
@@ -60,6 +60,7 @@ class StatusDerivation[T]:
         self._building = False
         self._value: T | None = None
         self._has_value = False
+        self._stale = False
         self._built_at = 0.0
 
     def invalidate(self) -> None:
@@ -68,9 +69,25 @@ class StatusDerivation[T]:
         For the changes an operator makes and expects to see at once — a saved
         config, a speaker added or released.  Costs nothing on its own: the
         rebuild happens when somebody actually reads.
+
+        The previous value is kept, not dropped: a reader arriving while that
+        rebuild is running is still served it.  Dropping it would make a burst
+        of saves put the probe's cost back on every tick — the thing this
+        exists to prevent.
+        """
+        with self._state:
+            self._stale = True
+
+    def reset(self) -> None:
+        """Forget the value entirely, as if nothing had ever been built.
+
+        For a test that must not be served the answer a previous one stubbed,
+        and for a runtime starting over.
         """
         with self._state:
             self._has_value = False
+            self._stale = False
+            self._value = None
 
     def current(self) -> T:
         """The derived half, rebuilt only when it is due.
@@ -102,6 +119,11 @@ class StatusDerivation[T]:
                 self._building = False
                 self._state.notify_all()
                 if self._has_value:
+                    # The failure counts as an attempt: without this the next
+                    # read is due again and every tick during an outage would
+                    # retry the probe it just watched fail.
+                    self._built_at = self._clock()
+                    self._stale = False
                     logger.warning("%s failed; serving the last known state", self._label, exc_info=True)
                     return self._value  # type: ignore[return-value]
             raise
@@ -109,6 +131,7 @@ class StatusDerivation[T]:
         with self._state:
             self._value = value
             self._has_value = True
+            self._stale = False
             self._built_at = self._clock()
             self._building = False
             self._state.notify_all()
@@ -116,6 +139,6 @@ class StatusDerivation[T]:
 
     def _is_due(self) -> bool:
         """Caller holds the condition."""
-        if not self._has_value:
+        if not self._has_value or self._stale:
             return True
         return (self._clock() - self._built_at) >= self._min_interval_s

--- a/src/sendspin_bridge/web/routes/api_bt.py
+++ b/src/sendspin_bridge/web/routes/api_bt.py
@@ -38,6 +38,7 @@ from sendspin_bridge.services.lifecycle.async_job_state import (
     is_scan_running,
 )
 from sendspin_bridge.web.routes._helpers import get_client_or_error, validate_adapter, validate_mac
+from sendspin_bridge.web.routes.api_status import invalidate_preflight_probe
 
 logger = logging.getLogger(__name__)
 
@@ -727,6 +728,9 @@ def api_bt_adapter_power():
         if result.result.outcome in (Outcome.TIMEOUT, Outcome.UNAVAILABLE):
             logger.error("Failed to toggle adapter power: outcome=%s", result.result.outcome.value)
             return jsonify({"ok": False, "error": "Failed to toggle adapter power"}), 500
+        # The host just changed under us; the next status build must measure
+        # it rather than report the sample taken before the toggle.
+        invalidate_preflight_probe()
         # ``changed`` reproduces the historical ok-heuristic (succeeded /
         # changing power / powered: marker) exactly.
         return jsonify({"ok": result.changed, "power": power})

--- a/src/sendspin_bridge/web/routes/api_config.py
+++ b/src/sendspin_bridge/web/routes/api_config.py
@@ -75,6 +75,7 @@ from sendspin_bridge.services.lifecycle.bridge_runtime_state import get_activati
 from sendspin_bridge.services.lifecycle.reconfig_orchestrator import ReconfigOrchestrator
 from sendspin_bridge.services.lifecycle.status_snapshot import build_device_snapshot
 from sendspin_bridge.services.music_assistant.ma_client import fetch_all_players_snapshot
+from sendspin_bridge.web.routes.api_status import invalidate_preflight_probe
 
 logger = logging.getLogger(__name__)
 
@@ -1019,6 +1020,11 @@ def api_config():
 
     # Invalidate adapter name cache so next status poll picks up changes
     refresh_adapter_name_cache()
+    # A saved setting can change what the host looks like to the bridge — a
+    # different adapter, a different audio target.  The operator is watching
+    # the screen they just saved from, so the next build measures rather than
+    # reporting the sample taken before the save.
+    invalidate_preflight_probe()
 
     _sync_ha_options(config)
 

--- a/src/sendspin_bridge/web/routes/api_status.py
+++ b/src/sendspin_bridge/web/routes/api_status.py
@@ -58,6 +58,7 @@ from sendspin_bridge.services.diagnostics.recovery_timeline import (
     build_recovery_timeline_text,
 )
 from sendspin_bridge.services.diagnostics.sendspin_compat import get_runtime_dependency_versions, query_audio_devices
+from sendspin_bridge.services.diagnostics.status_derivation import StatusDerivation
 from sendspin_bridge.services.ipc.bridge_state_model import build_bridge_state_model
 from sendspin_bridge.services.ipc.ipc_protocol import IPC_PROTOCOL_VERSION
 from sendspin_bridge.services.lifecycle.bridge_runtime_state import (
@@ -152,8 +153,8 @@ def _parse_memtotal_mb(line: str) -> int | None:
         return None
 
 
-def _collect_preflight_status() -> dict:
-    """Collect preflight runtime checks for reuse across helper routes."""
+def _probe_host() -> dict:
+    """Ask the host what it looks like — two bluetoothctl calls and the rest."""
     return _shared_collect_preflight_status(
         get_server_name_fn=get_server_name,
         list_sinks_fn=list_sinks,
@@ -162,6 +163,47 @@ def _collect_preflight_status() -> dict:
         exists_fn=os.path.exists,
         open_fn=open,
     )
+
+
+#: The probe is the expensive half of a status build (~56 ms of ~62 ms,
+#: measured), and the host it describes does not change per tick.  Everything
+#: derived from it is still rebuilt every time.
+_preflight_probe: StatusDerivation[dict] = StatusDerivation(_probe_host, label="preflight probe")
+
+
+def invalidate_preflight_probe() -> None:
+    """Make the next status build re-measure the host.
+
+    For the moments an operator acts on the host itself — a saved config, an
+    adapter powered back on — and expects the next screen to be true.
+    """
+    _preflight_probe.invalidate()
+
+
+def reset_preflight_probe() -> None:
+    """Drop the cached probe entirely (tests, and a fresh runtime)."""
+    _preflight_probe.invalidate()
+
+
+def _collect_preflight_status() -> dict:
+    """Measure the host now.
+
+    For the places somebody is looking precisely because something may have
+    just changed: diagnostics, the setup verification endpoint, the operator
+    checks.  The status path reads the sample instead — see
+    ``_sampled_preflight_status``.
+    """
+    _preflight_probe.invalidate()
+    return _preflight_probe.current()
+
+
+def _sampled_preflight_status() -> dict:
+    """The host's state as of the last measurement, taken at a bounded rate.
+
+    A status tick is driven by runtime state changing, which happens far
+    faster than anything this describes.
+    """
+    return _preflight_probe.current()
 
 
 def _collection_error_payload(exc: Exception) -> dict[str, str]:
@@ -255,7 +297,7 @@ def _build_onboarding_assistant_payload(
 ) -> dict:
     """Build the operator-facing onboarding assistant payload."""
     if preflight is None:
-        preflight = _collect_preflight_status()
+        preflight = _sampled_preflight_status()
     if config is None:
         config = load_config()
     if devices is None:
@@ -396,7 +438,7 @@ def _build_status_payload() -> dict:
     bridge_snapshot = build_bridge_snapshot(registry.active_clients)
     payload = bridge_snapshot.to_status_payload()
     config = load_config()
-    preflight = _collect_preflight_status()
+    preflight = _sampled_preflight_status()
     startup_progress = bridge_snapshot.startup_progress.to_dict() if bridge_snapshot.startup_progress else {}
     bridge_state = build_bridge_state_model(
         config=config,
@@ -936,6 +978,8 @@ def api_diagnostics():
         # as "D-Bus unavailable", and the recovery card in the bundle then
         # reported a runtime that cannot reach D-Bus on a host that was
         # paired, connected and playing.
+        # A bug report is taken because something looks wrong, so this one
+        # measures the host rather than reading the sampled value.
         diagnostics_preflight = _collect_preflight_status()
         try:
             diagnostics_state = build_bridge_state_model(
@@ -2110,6 +2154,8 @@ def api_preflight():
     quick troubleshooting without exposing device details.
     """
 
+    # Setup verification: the operator has just changed something and is
+    # asking whether it took.
     payload = _collect_preflight_status()
     payload["ok"] = True
     return jsonify(payload)

--- a/src/sendspin_bridge/web/routes/api_status.py
+++ b/src/sendspin_bridge/web/routes/api_status.py
@@ -153,8 +153,14 @@ def _parse_memtotal_mb(line: str) -> int | None:
         return None
 
 
-def _probe_host() -> dict:
-    """Ask the host what it looks like — two bluetoothctl calls and the rest."""
+def _collect_preflight_status() -> dict:
+    """Measure the host now — two bluetoothctl calls and the rest.
+
+    Called directly where somebody is looking precisely because something may
+    have just changed: diagnostics, the setup verification endpoint, the
+    operator checks.  The status path reads a sample of it instead — see
+    ``_sampled_preflight_status``.
+    """
     return _shared_collect_preflight_status(
         get_server_name_fn=get_server_name,
         list_sinks_fn=list_sinks,
@@ -168,7 +174,12 @@ def _probe_host() -> dict:
 #: The probe is the expensive half of a status build (~56 ms of ~62 ms,
 #: measured), and the host it describes does not change per tick.  Everything
 #: derived from it is still rebuilt every time.
-_preflight_probe: StatusDerivation[dict] = StatusDerivation(_probe_host, label="preflight probe")
+_preflight_probe: StatusDerivation[dict] = StatusDerivation(
+    # Late-bound on purpose: the measurement is one function, and everything
+    # that reaches for it — including tests — reaches for the same one.
+    lambda: _collect_preflight_status(),
+    label="preflight probe",
+)
 
 
 def invalidate_preflight_probe() -> None:
@@ -183,18 +194,6 @@ def invalidate_preflight_probe() -> None:
 def reset_preflight_probe() -> None:
     """Drop the cached probe entirely (tests, and a fresh runtime)."""
     _preflight_probe.invalidate()
-
-
-def _collect_preflight_status() -> dict:
-    """Measure the host now.
-
-    For the places somebody is looking precisely because something may have
-    just changed: diagnostics, the setup verification endpoint, the operator
-    checks.  The status path reads the sample instead — see
-    ``_sampled_preflight_status``.
-    """
-    _preflight_probe.invalidate()
-    return _preflight_probe.current()
 
 
 def _sampled_preflight_status() -> dict:

--- a/src/sendspin_bridge/web/routes/api_status.py
+++ b/src/sendspin_bridge/web/routes/api_status.py
@@ -192,8 +192,8 @@ def invalidate_preflight_probe() -> None:
 
 
 def reset_preflight_probe() -> None:
-    """Drop the cached probe entirely (tests, and a fresh runtime)."""
-    _preflight_probe.invalidate()
+    """Drop the sampled probe entirely (tests, and a fresh runtime)."""
+    _preflight_probe.reset()
 
 
 def _sampled_preflight_status() -> dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,21 @@
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _unsampled_host_probe():
+    """Each test measures the host for itself.
+
+    The status path samples the host probe at a bounded rate through a
+    process-wide cache, so without this a probe stubbed by one test would be
+    served to the next one that builds a status payload.
+    """
+    from sendspin_bridge.web.routes.api_status import reset_preflight_probe
+
+    reset_preflight_probe()
+    yield
+    reset_preflight_probe()
+
+
 @pytest.fixture
 def fake_bluez():
     """The shared bluetoothctl fake (tests/support/fake_bluez.py).

--- a/tests/unit/services/diagnostics/test_status_derivation.py
+++ b/tests/unit/services/diagnostics/test_status_derivation.py
@@ -220,3 +220,78 @@ def test_a_failure_does_not_pin_the_window_open():
     clock.advance(3.0)
 
     assert derivation.current() == "value-3"
+
+
+# ── invalidation must not cost the readers ───────────────────────────────
+
+
+def test_an_invalidated_value_is_still_served_while_the_rebuild_runs():
+    """Otherwise a config save puts the probe's cost back on the next tick.
+
+    A burst of saves would then make every listener wait on `bluetoothctl`,
+    which is the thing this class exists to prevent.
+    """
+    started = threading.Event()
+    release = threading.Event()
+    values = iter(["first", "second"])
+    calls: list[int] = []
+
+    def _build():
+        calls.append(len(calls) + 1)
+        value = next(values)
+        if value == "second":
+            started.set()
+            release.wait(timeout=5)
+        return value
+
+    derivation = StatusDerivation(_build, min_interval_s=60.0, clock=_Clock())
+    assert derivation.current() == "first"
+
+    derivation.invalidate()
+    rebuild = threading.Thread(target=derivation.current)
+    rebuild.start()
+    started.wait(timeout=5)
+
+    assert derivation.current() == "first", "a reader waited on the probe instead of being served"
+    assert len(calls) == 2, "a reader started a second probe of its own"
+
+    release.set()
+    rebuild.join(timeout=5)
+    assert derivation.current() == "second"
+
+
+def test_a_reset_drops_the_value_rather_than_marking_it_stale():
+    """Tests need the previous answer gone, not merely due."""
+    build, calls = _counting_build(["first", "second"])
+    derivation = StatusDerivation(build, min_interval_s=60.0, clock=_Clock())
+    derivation.current()
+
+    derivation.reset()
+
+    assert derivation.current() == "second"
+    assert len(calls) == 2
+
+
+# ── a failing probe must not be retried on every tick ─────────────────────
+
+
+def test_a_failed_rebuild_does_not_retry_until_the_next_window():
+    """An outage would otherwise put the probe back on every single tick."""
+    clock = _Clock()
+    calls: list[int] = []
+
+    def _build():
+        calls.append(len(calls) + 1)
+        if len(calls) > 1:
+            raise RuntimeError("bluetoothctl vanished")
+        return "value"
+
+    derivation = StatusDerivation(_build, min_interval_s=2.0, clock=clock)
+    derivation.current()
+
+    clock.advance(3.0)
+    derivation.current()  # fails, serves "value"
+    derivation.current()
+    derivation.current()
+
+    assert len(calls) == 2, "the failing probe was retried on every read"

--- a/tests/unit/services/diagnostics/test_status_derivation.py
+++ b/tests/unit/services/diagnostics/test_status_derivation.py
@@ -1,0 +1,222 @@
+"""The cost of deriving guidance must not follow the rate of status changes.
+
+Every SSE tick rebuilt the whole status payload, and the derived half of that
+payload probes the host: two `bluetoothctl` invocations plus the audio and
+D-Bus checks.  Measured on a live bridge, that half costs ~55 ms of the ~60 ms
+a status build takes, and an idle bridge with one speaker ticks about every
+six seconds — per connected client.  A speaker that is actually playing ticks
+far more often, and every listening browser tab multiplies it.
+
+Runtime state changes many times a second and is read from memory.  What the
+host looks like changes on the order of seconds and costs subprocesses.  They
+belong on different clocks.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from sendspin_bridge.services.diagnostics.status_derivation import StatusDerivation
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _counting_build(results: list[str] | None = None):
+    calls: list[int] = []
+
+    def _build():
+        calls.append(len(calls) + 1)
+        return (results or ["value"] * 99)[len(calls) - 1]
+
+    return _build, calls
+
+
+# ── the window ───────────────────────────────────────────────────────────
+
+
+def test_the_first_call_builds():
+    build, calls = _counting_build()
+
+    derivation = StatusDerivation(build, min_interval_s=2.0, clock=_Clock())
+
+    assert derivation.current() == "value"
+    assert len(calls) == 1
+
+
+def test_a_second_call_inside_the_window_reuses_the_first():
+    build, calls = _counting_build()
+    clock = _Clock()
+    derivation = StatusDerivation(build, min_interval_s=2.0, clock=clock)
+
+    derivation.current()
+    clock.advance(1.9)
+    derivation.current()
+
+    assert len(calls) == 1
+
+
+def test_a_call_after_the_window_builds_again():
+    build, calls = _counting_build()
+    clock = _Clock()
+    derivation = StatusDerivation(build, min_interval_s=2.0, clock=clock)
+
+    derivation.current()
+    clock.advance(2.1)
+    derivation.current()
+
+    assert len(calls) == 2
+
+
+# ── events that cannot wait ──────────────────────────────────────────────
+
+
+def test_an_invalidation_rebuilds_inside_the_window():
+    """A saved config or an added speaker must show up at once."""
+    build, calls = _counting_build()
+    clock = _Clock()
+    derivation = StatusDerivation(build, min_interval_s=60.0, clock=clock)
+
+    derivation.current()
+    derivation.invalidate()
+    derivation.current()
+
+    assert len(calls) == 2
+
+
+def test_an_invalidation_without_a_reader_costs_nothing():
+    build, calls = _counting_build()
+    derivation = StatusDerivation(build, min_interval_s=60.0, clock=_Clock())
+
+    derivation.invalidate()
+    derivation.invalidate()
+
+    assert calls == []
+
+
+# ── many readers, one probe ──────────────────────────────────────────────
+
+
+def test_concurrent_readers_do_not_each_probe_the_host():
+    """Every browser tab holds a stream; they must not multiply the probes."""
+    started = threading.Event()
+    release = threading.Event()
+    calls: list[int] = []
+
+    def _slow_build():
+        calls.append(1)
+        started.set()
+        release.wait(timeout=5)
+        return "value"
+
+    # A window wide enough that a reader waking after the build finds the
+    # fresh value rather than a due rebuild — the subject here is what happens
+    # *during* one build.
+    derivation = StatusDerivation(_slow_build, min_interval_s=60.0, clock=_Clock())
+    first = threading.Thread(target=derivation.current)
+    first.start()
+    started.wait(timeout=5)
+
+    others = [threading.Thread(target=derivation.current) for _ in range(4)]
+    for thread in others:
+        thread.start()
+    for thread in others:
+        thread.join(timeout=5)
+
+    assert len(calls) == 1, "a reader started its own probe while one was already running"
+
+    release.set()
+    first.join(timeout=5)
+
+
+def test_a_reader_arriving_during_a_build_gets_the_previous_value():
+    """Waiting on the probe would put its cost back on the tick."""
+    clock = _Clock()
+    release = threading.Event()
+    started = threading.Event()
+    values = iter(["first", "second"])
+
+    def _build():
+        value = next(values)
+        if value == "second":
+            started.set()
+            release.wait(timeout=5)
+        return value
+
+    derivation = StatusDerivation(_build, min_interval_s=0.0, clock=clock)
+    assert derivation.current() == "first"
+
+    slow = threading.Thread(target=derivation.current)
+    slow.start()
+    started.wait(timeout=5)
+
+    assert derivation.current() == "first"
+
+    release.set()
+    slow.join(timeout=5)
+    assert derivation.current() == "second"
+
+
+# ── failure ──────────────────────────────────────────────────────────────
+
+
+def test_the_first_build_reports_its_failure():
+    """With nothing cached there is nothing to serve instead."""
+
+    def _build():
+        raise RuntimeError("pactl is missing")
+
+    derivation = StatusDerivation(_build, min_interval_s=2.0, clock=_Clock())
+
+    with pytest.raises(RuntimeError):
+        derivation.current()
+
+
+def test_a_later_failure_keeps_serving_what_was_last_true():
+    """One failed probe must not blank the operator's screen."""
+    clock = _Clock()
+    calls: list[int] = []
+
+    def _build():
+        calls.append(len(calls) + 1)
+        if len(calls) > 1:
+            raise RuntimeError("bluetoothctl vanished")
+        return "value"
+
+    derivation = StatusDerivation(_build, min_interval_s=2.0, clock=clock)
+    assert derivation.current() == "value"
+
+    clock.advance(3.0)
+
+    assert derivation.current() == "value"
+    assert len(calls) == 2
+
+
+def test_a_failure_does_not_pin_the_window_open():
+    """The next window must retry rather than serve the stale value forever."""
+    clock = _Clock()
+    calls: list[int] = []
+
+    def _build():
+        calls.append(len(calls) + 1)
+        if len(calls) == 2:
+            raise RuntimeError("transient")
+        return f"value-{len(calls)}"
+
+    derivation = StatusDerivation(_build, min_interval_s=2.0, clock=clock)
+    derivation.current()
+    clock.advance(3.0)
+    derivation.current()
+    clock.advance(3.0)
+
+    assert derivation.current() == "value-3"

--- a/tests/unit/web/routes/test_status_tick_cost.py
+++ b/tests/unit/web/routes/test_status_tick_cost.py
@@ -104,7 +104,7 @@ def test_an_invalidation_makes_the_next_tick_probe_again(api_status):
 # ── the moments that cannot wait for the window ──────────────────────────
 
 
-def test_powering_an_adapter_makes_the_next_status_measure_again(api_status, monkeypatch):
+def test_powering_an_adapter_makes_the_next_status_measure_again(api_status, installed_bluez):
     """The operator flips a controller and looks straight at the screen."""
     module, probes = api_status
     module._build_status_payload()
@@ -113,10 +113,11 @@ def test_powering_an_adapter_makes_the_next_status_measure_again(api_status, mon
 
     import sendspin_bridge.web.routes.api_bt as api_bt
 
-    monkeypatch.setattr(api_bt, "_power_adapter", lambda *a, **kw: (True, "ok"), raising=False)
+    installed_bluez.on("power on", stdout="Changing power on succeeded\n")
     app = Flask(__name__)
     app.register_blueprint(api_bt.bt_bp)
-    app.test_client().post("/api/bt/adapter/power", json={"adapter": "hci0", "power": True})
+    response = app.test_client().post("/api/bt/adapter/power", json={"adapter": "hci0", "power": True})
+    assert response.status_code == 200
 
     module._build_status_payload()
 
@@ -136,7 +137,8 @@ def test_saving_the_config_makes_the_next_status_measure_again(api_status, monke
     app = Flask(__name__)
     app.secret_key = "testing"
     app.register_blueprint(api_config.config_bp)
-    app.test_client().post("/api/config", json={"BRIDGE_NAME": "Renamed", "BLUETOOTH_DEVICES": []})
+    response = app.test_client().post("/api/config", json={"BRIDGE_NAME": "Renamed", "BLUETOOTH_DEVICES": []})
+    assert response.status_code == 200
 
     module._build_status_payload()
 

--- a/tests/unit/web/routes/test_status_tick_cost.py
+++ b/tests/unit/web/routes/test_status_tick_cost.py
@@ -1,0 +1,143 @@
+"""A status tick must not probe the host every time.
+
+`/api/status` and every SSE tick rebuilt the whole payload, and the host probe
+inside it shells out to `bluetoothctl` twice plus the audio and D-Bus checks.
+Measured on a live bridge: `/api/preflight` alone is ~56 ms of the ~62 ms a
+status build costs, and one idle speaker produces a tick about every six
+seconds — per connected client, so per open browser tab.
+
+The guidance built on top of the probe stays per-tick fresh; only the probe
+itself is rate-limited.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def api_status(monkeypatch, tmp_path):
+    import sendspin_bridge.config as config
+
+    monkeypatch.setattr(config, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(config, "CONFIG_FILE", tmp_path / "config.json")
+    (tmp_path / "config.json").write_text(json.dumps({}))
+
+    import sendspin_bridge.web.routes.api_status as module
+
+    probes: list[int] = []
+
+    def _probe(**_kwargs):
+        probes.append(len(probes) + 1)
+        return {"dbus": {"available": True}, "bluetooth": {"status": "ok"}, "audio": {"status": "ok"}}
+
+    monkeypatch.setattr(module, "_shared_collect_preflight_status", _probe)
+    module.reset_preflight_probe()
+    return module, probes
+
+
+def test_repeated_status_builds_share_one_probe(api_status):
+    module, probes = api_status
+
+    module._build_status_payload()
+    module._build_status_payload()
+    module._build_status_payload()
+
+    assert len(probes) == 1, "each status build probed the host again"
+
+
+def test_the_probe_is_taken_again_once_it_is_stale(api_status, monkeypatch):
+    module, probes = api_status
+    clock = {"now": 0.0}
+    monkeypatch.setattr(module._preflight_probe, "_clock", lambda: clock["now"])
+
+    module._build_status_payload()
+    clock["now"] = 60.0
+    module._build_status_payload()
+
+    assert len(probes) == 2
+
+
+def test_the_guidance_is_still_derived_on_every_tick(api_status, monkeypatch):
+    """Only the probe is rate-limited; what is built on it must stay fresh."""
+    module, _probes = api_status
+    builds: list[int] = []
+
+    def _spy(**kwargs):
+        builds.append(len(builds) + 1)
+        return {}
+
+    monkeypatch.setattr(module, "_build_recovery_assistant_payload", _spy)
+    monkeypatch.setattr(module, "_build_onboarding_assistant_payload", lambda **kw: {})
+    monkeypatch.setattr(module, "_build_operator_guidance_payload", lambda **kw: {})
+
+    module._build_status_payload()
+    module._build_status_payload()
+
+    assert len(builds) == 2
+
+
+def test_a_bug_report_measures_the_host_rather_than_reading_the_sample(api_status):
+    """Diagnostics is where someone looks when something is wrong."""
+    module, probes = api_status
+
+    module._build_status_payload()
+    before = len(probes)
+    module._collect_preflight_status()
+
+    assert len(probes) == before + 1
+
+
+def test_an_invalidation_makes_the_next_tick_probe_again(api_status):
+    """After the operator changes an adapter, the next screen must be true."""
+    module, probes = api_status
+
+    module._build_status_payload()
+    module.invalidate_preflight_probe()
+    module._build_status_payload()
+
+    assert len(probes) == 2
+
+
+# ── the moments that cannot wait for the window ──────────────────────────
+
+
+def test_powering_an_adapter_makes_the_next_status_measure_again(api_status, monkeypatch):
+    """The operator flips a controller and looks straight at the screen."""
+    module, probes = api_status
+    module._build_status_payload()
+
+    from flask import Flask
+
+    import sendspin_bridge.web.routes.api_bt as api_bt
+
+    monkeypatch.setattr(api_bt, "_power_adapter", lambda *a, **kw: (True, "ok"), raising=False)
+    app = Flask(__name__)
+    app.register_blueprint(api_bt.bt_bp)
+    app.test_client().post("/api/bt/adapter/power", json={"adapter": "hci0", "power": True})
+
+    module._build_status_payload()
+
+    assert len(probes) == 2, "the screen after an adapter change still showed the old probe"
+
+
+def test_saving_the_config_makes_the_next_status_measure_again(api_status, monkeypatch, tmp_path):
+    """A saved setting can change what the host looks like to the bridge."""
+    module, probes = api_status
+    module._build_status_payload()
+
+    from flask import Flask
+
+    import sendspin_bridge.web.routes.api_config as api_config
+
+    monkeypatch.setattr(api_config, "CONFIG_FILE", tmp_path / "config.json")
+    app = Flask(__name__)
+    app.secret_key = "testing"
+    app.register_blueprint(api_config.config_bp)
+    app.test_client().post("/api/config", json={"BRIDGE_NAME": "Renamed", "BLUETOOTH_DEVICES": []})
+
+    module._build_status_payload()
+
+    assert len(probes) == 2, "the screen after a settings save still showed the old probe"


### PR DESCRIPTION
Candidate C9 from the architecture review: split the SSE tick from the derivation behind it.

## Measured first

A status payload has two halves with different clocks. Runtime state — who is connected, what is playing, where the volume sits — lives in memory and changes many times a second. The other half describes the *host*: the Bluetooth controllers, the audio server, D-Bus, memory. It changes on the order of seconds and costs subprocesses to find out.

On the live bridge, before the change:

| | |
|---|---|
| `/api/status` | ~62 ms |
| `/api/preflight` (the host probe alone) | ~56 ms |
| SSE ticks, idle, one connected speaker | 5 in 30 s, ~40 KB each |

So the probe is essentially the whole cost of a status build, the guidance derived on top of it is a few milliseconds — and every listening browser tab pays for its own probe, because each stream builds its own payload.

## The change

The probe gets its own cadence: at most one measurement per interval, never two at once, and a reader arriving while one is in flight is served what was last true. That last part matters — making it wait would put the probe's cost straight back on the tick it was taken off.

Everything derived from the probe is still rebuilt on every tick, so guidance, device cards and the state model stay exactly as fresh as before. The payload shape does not change.

Two names, because the two intents are different:

- `_collect_preflight_status()` — measure the host now. Diagnostics, `/api/preflight`, the operator checks: places someone is looking precisely because something may have just changed.
- `_sampled_preflight_status()` — what the host looked like at the last measurement. The status path.

And two moments that cannot wait for the interval invalidate the sample: a saved config, and an adapter power toggle.

## Measured after

Same hardware: `/api/status` went from ~62 ms to **~6 ms** (first call after a restart still measures, then the sample carries). `/api/preflight` still costs its ~56 ms, as it should.

## Tests

Ten tests on the derivation itself — the window, invalidation, that concurrent readers produce exactly one probe, that a reader during a build is served the previous value rather than blocked, that a first failure raises but a later one keeps serving what was last true — and seven on the wiring: repeated builds share a probe, a stale sample is retaken, guidance is still derived per tick, a bug report measures, an adapter toggle and a config save force the next measurement.

## Noticed, not changed

`/api/status` adds `auth_enabled` after building the payload, so the SSE stream omits a field the polling endpoint has. Pre-existing and unrelated to this change; worth a separate look.

Gate: 3495 passed, 1 skipped; ruff clean; changelog clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
