### PR TITLE
refactor(bluetooth): one address, one sink-name grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   measure the host when asked, and a saved config or an adapter power toggle
   makes the next update measure again.
 
+### Fixed
+
+- The sink name WirePlumber publishes on Ubuntu 26.04 is understood
+  everywhere it appears. The bridge already selected that name when
+  connecting a speaker, but the code that reads sink names back did not
+  recognise it.
+
 ## [2.75.0-rc.4] - 2026-08-25
 
 ### Fixed

--- a/src/sendspin_bridge/bluetooth/adapter_map.py
+++ b/src/sendspin_bridge/bluetooth/adapter_map.py
@@ -1,0 +1,26 @@
+"""Looking a controller up in the map the kernel gives us.
+
+``build_hci_map()`` keys its controllers by the bare address form, and the
+routes and the orchestrator used to strip the colons and fold the case
+themselves before every lookup — four copies of the same two calls.  One of
+them forgetting either step means the controller maps nowhere, and that
+surfaces as a pair or a scan running against the wrong physical adapter
+(issue #340).
+
+Kept outside ``bluetooth/bluez/`` on purpose: that package is stdlib-only so
+it can be imported from anywhere without a cycle.
+"""
+
+from __future__ import annotations
+
+from sendspin_bridge.bluetooth.address import DeviceAddress
+
+__all__ = ["hci_for"]
+
+
+def hci_for(mapping: dict[str, str], mac: object) -> str:
+    """The ``hciN`` name *mac* is registered as, or ``""`` when it is in none."""
+    address = DeviceAddress.parse(mac)
+    if address is None:
+        return ""
+    return mapping.get(address.bare, "")

--- a/src/sendspin_bridge/bluetooth/adapter_session.py
+++ b/src/sendspin_bridge/bluetooth/adapter_session.py
@@ -41,6 +41,7 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from sendspin_bridge.bluetooth.address import DeviceAddress
 from sendspin_bridge.bluetooth.bluez import Adapter, Outcome, get_bluez
 
 if TYPE_CHECKING:
@@ -250,8 +251,8 @@ class AdapterHandle:
             return self._adapter.upper()
         for mac, hci in self.bluez.hci_map().items():
             if hci == self._adapter:
-                stripped = mac.replace(":", "").upper()
-                return ":".join(stripped[i : i + 2] for i in range(0, 12, 2))
+                address = DeviceAddress.parse(mac)
+                return address.colons if address else ""
         return ""
 
     @property
@@ -269,9 +270,11 @@ class AdapterHandle:
             return self._hci_name
         if not self._adapter:
             return ""
-        wanted = self._adapter.replace(":", "").upper()
+        wanted = DeviceAddress.parse(self._adapter)
+        if wanted is None:
+            return ""
         for mac, hci in self.bluez.hci_map().items():
-            if mac.replace(":", "").upper() == wanted:
+            if DeviceAddress.parse(mac) == wanted:
                 self._hci_name = hci
                 return hci
         return ""
@@ -285,7 +288,10 @@ class AdapterHandle:
         hci = self.hci_name
         if not hci:
             return None
-        return f"/org/bluez/{hci}/dev_{mac.upper().replace(':', '_')}"
+        address = DeviceAddress.parse(mac)
+        if address is None:
+            return None
+        return f"/org/bluez/{hci}/{address.dbus_node}"
 
     # -- reads (no lease: a read cannot corrupt another operation) ------
 

--- a/src/sendspin_bridge/bluetooth/address.py
+++ b/src/sendspin_bridge/bluetooth/address.py
@@ -1,0 +1,79 @@
+"""One address, however it is spelled.
+
+The same speaker address is written three ways here.  BlueZ and the config
+use colons.  Audio sink names, D-Bus object paths and MPRIS paths use
+underscores.  The sysfs adapter map is keyed bare.  Fifteen call sites did
+that conversion by hand — ``mac.upper().replace(":", "_")`` and its cousins —
+and each one had to remember on its own to fold case before comparing.
+
+A type that knows all three spellings takes the remembering out of it: parse
+once at the edge, ask for the spelling the consumer needs, and let equality be
+equality.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = ["DeviceAddress"]
+
+#: Six hex pairs, separated by colons, underscores, or nothing at all.
+_ADDRESS_RE = re.compile(r"^(?:[0-9A-Fa-f]{2}([:_]?)(?:[0-9A-Fa-f]{2}\1){4}[0-9A-Fa-f]{2})$")
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceAddress:
+    """A Bluetooth device address, canonical and comparable.
+
+    Built through :meth:`parse` or :meth:`require` — the constructor takes the
+    canonical bare form and does not check it, so nothing but those two ways
+    in can produce one.
+    """
+
+    bare: str
+
+    # -- coming in ------------------------------------------------------
+
+    @classmethod
+    def parse(cls, text: object) -> DeviceAddress | None:
+        """The address *text* names, or ``None`` when it names none."""
+        if isinstance(text, DeviceAddress):
+            return text
+        if not isinstance(text, str):
+            return None
+        candidate = text.strip()
+        if not _ADDRESS_RE.match(candidate):
+            return None
+        return cls(candidate.replace(":", "").replace("_", "").upper())
+
+    @classmethod
+    def require(cls, text: object) -> DeviceAddress:
+        """Like :meth:`parse`, for callers that cannot continue without one."""
+        address = cls.parse(text)
+        if address is None:
+            raise ValueError(f"{text!r} is not a Bluetooth device address")
+        return address
+
+    # -- going out ------------------------------------------------------
+
+    @property
+    def colons(self) -> str:
+        """``AA:BB:CC:DD:EE:FF`` — BlueZ, bluetoothctl, the config file."""
+        return self._grouped(":")
+
+    @property
+    def underscores(self) -> str:
+        """``AA_BB_CC_DD_EE_FF`` — audio sink names and D-Bus paths."""
+        return self._grouped("_")
+
+    @property
+    def dbus_node(self) -> str:
+        """``dev_AA_BB_CC_DD_EE_FF`` — the leaf of a BlueZ object path."""
+        return f"dev_{self.underscores}"
+
+    def _grouped(self, separator: str) -> str:
+        return separator.join(self.bare[i : i + 2] for i in range(0, 12, 2))
+
+    def __str__(self) -> str:
+        return self.colons

--- a/src/sendspin_bridge/bluetooth/audio.py
+++ b/src/sendspin_bridge/bluetooth/audio.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 from typing import TYPE_CHECKING
 
+from sendspin_bridge.bluetooth.address import DeviceAddress
 from sendspin_bridge.bluetooth.dbus import _dbus_get_media_transport_state, _dbus_has_media_endpoint
 from sendspin_bridge.config import CONFIG_FILE, save_device_sink
 from sendspin_bridge.config import config_lock as config_lock
@@ -26,6 +27,7 @@ from sendspin_bridge.services.audio.pulse import (
     set_sink_mute,
     set_sink_volume,
 )
+from sendspin_bridge.services.audio.sink_names import is_bluez_sink_name, sink_name_candidates
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -195,7 +197,8 @@ def configure_bluetooth_audio(
     AVDTP collision window.
     """
     try:
-        pa_mac = mac_address.replace(":", "_")
+        address = DeviceAddress.require(mac_address)
+        pa_mac = address.underscores
 
         # Try cached sink name first — avoids 3s A2DP delay on service restart
         cached_sink = None
@@ -249,18 +252,9 @@ def configure_bluetooth_audio(
             # Find the Bluetooth sink
             # CRITICAL: Audio routing — sink discovery with bounded retries (_SINK_RETRY_COUNT).
             # If no sink found after retries, BT speaker will connect but play no audio.
-            # Sink naming differs between PipeWire and PulseAudio — order matters.
-            # The raw-colon `bluez_output.{mac_address}` variant is what
-            # WirePlumber publishes on Ubuntu 26.04+; kept last so the
-            # more specific PipeWire/PulseAudio patterns win when both
-            # exist. Issue #314.
-            sink_names = [
-                f"bluez_output.{pa_mac}.1",  # PipeWire format
-                f"bluez_output.{pa_mac}.a2dp-sink",
-                f"bluez_sink.{pa_mac}.a2dp_sink",  # Legacy PulseAudio format
-                f"bluez_sink.{pa_mac}",
-                f"bluez_output.{mac_address}",  # PipeWire / WirePlumber (Ubuntu 26.04, raw MAC)
-            ]
+            # The names come from the shared grammar, which is also what reads
+            # them back, so the two cannot drift apart again.
+            sink_names = sink_name_candidates(address)
             known_names = {s["name"] for s in sinks}
 
             success = False
@@ -392,7 +386,7 @@ def _warn_pipewire_session(known_sink_names: set[str], device_path: str | None =
     if not server or "pipewire" not in str(server).lower():
         return
 
-    has_bt_sink = any(n.startswith(("bluez_output.", "bluez_sink.")) for n in known_sink_names)
+    has_bt_sink = any(is_bluez_sink_name(n) for n in known_sink_names)
     if has_bt_sink:
         return
 

--- a/src/sendspin_bridge/bridge/orchestrator.py
+++ b/src/sendspin_bridge/bridge/orchestrator.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Coroutine
 
+from sendspin_bridge.bluetooth.adapter_map import hci_for
 from sendspin_bridge.config import (
     CONFIG_FILE,
     detect_ha_addon_channel,
@@ -193,7 +194,7 @@ def _apply_adapter_device_class_overrides(adapters: list[dict[str, Any]]) -> Non
                 continue
             if hci_map is None:
                 hci_map = build_hci_map()
-            hci_label = hci_map.get(mac.upper().replace(":", ""), "")
+            hci_label = hci_for(hci_map, mac)
             if not hci_label:
                 logger.warning(
                     "CoD: cannot apply device_class=%s — sysfs has no hci entry for adapter %s",

--- a/src/sendspin_bridge/services/audio/sink_monitor.py
+++ b/src/sendspin_bridge/services/audio/sink_monitor.py
@@ -28,10 +28,10 @@ import contextlib
 import errno
 import logging
 import os
-import re
 from typing import TYPE_CHECKING, Any
 
 from sendspin_bridge.services.audio.pulse import _PULSECTL_AVAILABLE
+from sendspin_bridge.services.audio.sink_names import address_from_sink_name, is_bluez_sink_name
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -48,9 +48,6 @@ __all__ = ["SinkMonitor", "extract_mac_from_sink"]
 _PA_SINK_RUNNING = 0
 _PA_SINK_IDLE = 1
 _PA_SINK_SUSPENDED = 2
-
-# Regex: extract the 17-char underscore-delimited MAC from a bluez sink name.
-_BLUEZ_MAC_RE = re.compile(r"^bluez_(?:sink|output)\.([0-9A-Fa-f]{2}(?:_[0-9A-Fa-f]{2}){5})")
 
 # Reconnect tuning. Public for tests.
 _INITIAL_FAILURE_THRESHOLD = 3
@@ -107,19 +104,14 @@ def _describe_pa_failure(exc: BaseException) -> tuple[str, str]:
 def extract_mac_from_sink(sink_name: str) -> str | None:
     """Extract a colon-delimited MAC address from a bluez sink name.
 
-    Supported patterns::
-
-        bluez_sink.FC_58_FA_EB_08_6C.a2dp_sink
-        bluez_sink.FC_58_FA_EB_08_6C
-        bluez_output.FC_58_FA_EB_08_6C.a2dp-sink
-        bluez_output.FC_58_FA_EB_08_6C.1
+    Reads through the shared grammar, which is also what writes these names
+    in the connect path — the two used to be described separately and had
+    drifted apart on the raw-colon form WirePlumber publishes.
 
     Returns ``None`` for non-bluez or malformed names.
     """
-    m = _BLUEZ_MAC_RE.match(sink_name)
-    if not m:
-        return None
-    return m.group(1).replace("_", ":").upper()
+    address = address_from_sink_name(sink_name)
+    return address.colons if address else None
 
 
 class SinkMonitor:
@@ -312,7 +304,7 @@ class SinkMonitor:
         self._sink_index_to_name[sink_index] = sink_name
 
         # Only track bluez sinks (Bluetooth audio)
-        if not _BLUEZ_MAC_RE.match(sink_name):
+        if not is_bluez_sink_name(sink_name):
             return
 
         new_state = self._classify_state(sink_info.state)
@@ -377,7 +369,7 @@ class SinkMonitor:
             sink_name: str = sink_info.name
             self._sink_index_to_name[sink_info.index] = sink_name
 
-            if not _BLUEZ_MAC_RE.match(sink_name):
+            if not is_bluez_sink_name(sink_name):
                 continue
 
             new_state = self._classify_state(sink_info.state)

--- a/src/sendspin_bridge/services/audio/sink_names.py
+++ b/src/sendspin_bridge/services/audio/sink_names.py
@@ -1,0 +1,62 @@
+"""What an audio server calls a Bluetooth speaker, read and written in one place.
+
+PipeWire, WirePlumber and PulseAudio each name the same speaker differently,
+so the bridge tries several spellings when it looks for a sink and has to
+recognise any of them when one shows up in an event.  Those two halves used to
+be written separately — a list of f-strings in the connect path, a regex in
+the sink monitor — and had already drifted: the raw-colon name WirePlumber
+publishes on Ubuntu 26.04 (issue #314) is one the bridge itself selects, and
+the reader did not know it.
+
+A name the bridge can choose must be a name the bridge can read, so both come
+from here.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sendspin_bridge.bluetooth.address import DeviceAddress
+
+__all__ = ["address_from_sink_name", "is_bluez_sink_name", "sink_name_candidates"]
+
+#: Either audio server's prefix, then the address in either spelling.  The
+#: name may carry a profile or index suffix, or nothing at all.
+_SINK_NAME_RE = re.compile(
+    r"^bluez_(?:sink|output)\."
+    r"(?P<address>[0-9A-Fa-f]{2}(?:[:_][0-9A-Fa-f]{2}){5})"
+    r"(?:\..*)?$"
+)
+
+
+def sink_name_candidates(address: DeviceAddress) -> list[str]:
+    """Every name this speaker's sink might have, most specific first.
+
+    Order matters: the bare forms match a device that has published nothing
+    else yet, so a host that offers both must resolve to the specific one.
+    """
+    underscored = address.underscores
+    return [
+        f"bluez_output.{underscored}.1",  # PipeWire
+        f"bluez_output.{underscored}.a2dp-sink",
+        f"bluez_sink.{underscored}.a2dp_sink",  # PulseAudio
+        f"bluez_sink.{underscored}",
+        # WirePlumber on Ubuntu 26.04 publishes the address unmodified;
+        # last, so the spellings above win wherever both exist (issue #314).
+        f"bluez_output.{address.colons}",
+    ]
+
+
+def address_from_sink_name(sink_name: object) -> DeviceAddress | None:
+    """The speaker a sink name refers to, or ``None`` if it names none."""
+    if not isinstance(sink_name, str):
+        return None
+    match = _SINK_NAME_RE.match(sink_name.strip())
+    if not match:
+        return None
+    return DeviceAddress.parse(match.group("address"))
+
+
+def is_bluez_sink_name(sink_name: object) -> bool:
+    """Whether this name belongs to a Bluetooth speaker at all."""
+    return address_from_sink_name(sink_name) is not None

--- a/src/sendspin_bridge/services/bluetooth/__init__.py
+++ b/src/sendspin_bridge/services/bluetooth/__init__.py
@@ -9,6 +9,7 @@ import re
 import threading
 from pathlib import Path
 
+from sendspin_bridge.bluetooth.adapter_map import hci_for
 from sendspin_bridge.bluetooth.bluez import Adapter, DeviceInfo, Outcome, get_bluez
 
 logger = logging.getLogger(__name__)
@@ -122,8 +123,7 @@ def resolve_hci_for_mac(mac: str) -> str:
     """
     if not mac:
         return ""
-    target = mac.upper().replace(":", "")
-    return build_hci_map().get(target, "")
+    return hci_for(build_hci_map(), mac)
 
 
 def get_adapter_alias(mac: str, *, timeout: int = 5) -> tuple[str, bool]:

--- a/src/sendspin_bridge/services/bluetooth/device_activation.py
+++ b/src/sendspin_bridge/services/bluetooth/device_activation.py
@@ -18,13 +18,14 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from sendspin_bridge.bluetooth.address import DeviceAddress
 from sendspin_bridge.services.audio.mpris_player import (
     MprisPlayer,
     get_registry,
     resolve_avrcp_source_client,
 )
 from sendspin_bridge.services.bluetooth.avrcp_source_tracker import get_tracker as _get_avrcp_source_tracker
-from sendspin_bridge.services.bluetooth.mpris_export import MPRIS_PATH_PREFIX, MprisExport
+from sendspin_bridge.services.bluetooth.mpris_export import MPRIS_PATH_PREFIX, MprisExport, mpris_dbus_path
 from sendspin_bridge.services.diagnostics.sendspin_compat import filter_supported_call_kwargs
 from sendspin_bridge.services.ipc.commands import SetVolume
 
@@ -99,7 +100,7 @@ def _resolve_adapter_device_class(device_adapter: str, adapters: list[dict[str, 
     if not device_adapter or not adapters:
         return ""
     target = device_adapter.strip()
-    target_normalized = target.upper().replace(":", "")
+    target_address = DeviceAddress.parse(target)
     for entry in adapters:
         if not isinstance(entry, dict):
             continue
@@ -107,11 +108,10 @@ def _resolve_adapter_device_class(device_adapter: str, adapters: list[dict[str, 
         if not hex_value:
             continue
         hci_label = str(entry.get("hci") or "").strip()
-        mac = str(entry.get("mac") or "").strip()
-        mac_normalized = mac.upper().replace(":", "")
+        entry_address = DeviceAddress.parse(entry.get("mac"))
         if hci_label and hci_label == target:
             return hex_value
-        if mac_normalized and mac_normalized == target_normalized:
+        if entry_address is not None and entry_address == target_address:
             return hex_value
     return ""
 
@@ -140,12 +140,13 @@ _EXPORTS: dict[str, MprisExport] = {}
 def _mpris_dbus_path(mac: str) -> str:
     """Per-device MPRIS object path on the system bus.
 
-    BlueZ's ``Media1.RegisterPlayer`` expects a unique path per
-    registration on a given adapter — multiple speakers on the same
-    adapter must each get a distinct player object.  MAC colons map
-    to ``_`` because D-Bus paths must be ``[A-Za-z0-9_/]``.
+    BlueZ's ``Media1.RegisterPlayer`` expects a unique path per registration
+    on a given adapter — multiple speakers on the same adapter must each get a
+    distinct player object.  Built by the export module rather than here: a
+    player registered under one spelling and looked up under another is a
+    player that cannot be found.
     """
-    return _MPRIS_PATH_PREFIX + mac.upper().replace(":", "_")
+    return mpris_dbus_path(mac)
 
 
 def _bluez_adapter_path(bt_manager: Any) -> str | None:

--- a/src/sendspin_bridge/services/bluetooth/mpris_export.py
+++ b/src/sendspin_bridge/services/bluetooth/mpris_export.py
@@ -23,6 +23,8 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
+from sendspin_bridge.bluetooth.address import DeviceAddress
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -34,8 +36,12 @@ MPRIS_PATH_PREFIX = "/org/sendspin/players/"
 
 
 def mpris_dbus_path(mac: str) -> str:
-    """The object path this bridge exports a device's player at."""
-    return MPRIS_PATH_PREFIX + mac.upper().replace(":", "_")
+    """The object path this bridge exports a device's player at.
+
+    Raises ``ValueError`` for anything that is not an address: a player
+    exported at a path built from garbage is a player nothing can find again.
+    """
+    return MPRIS_PATH_PREFIX + DeviceAddress.require(mac).underscores
 
 
 def _default_bus_factory():

--- a/src/sendspin_bridge/services/bluetooth/pairing_agent.py
+++ b/src/sendspin_bridge/services/bluetooth/pairing_agent.py
@@ -21,6 +21,8 @@ import logging
 import threading
 from typing import Any
 
+from sendspin_bridge.bluetooth.address import DeviceAddress
+
 logger = logging.getLogger(__name__)
 
 AGENT_PATH = "/io/sendspin/bridge/PairingAgent"
@@ -114,7 +116,8 @@ def _build_agent_iface(pin: str, allow_hfp: bool = False, *, target_mac: str = "
     for the gate's rationale.
     """
     authorized_uuids = _AUTHORIZED_SERVICE_UUIDS | (_HFP_SERVICE_UUIDS if allow_hfp else frozenset())
-    target_suffix = f"/dev_{target_mac.strip().upper().replace(':', '_')}" if target_mac else ""
+    target_address = DeviceAddress.parse(target_mac)
+    target_suffix = f"/{target_address.dbus_node}" if target_address else ""
     from dbus_fast import DBusError  # type: ignore
     from dbus_fast.service import ServiceInterface, method  # type: ignore
 

--- a/src/sendspin_bridge/web/routes/api_bt.py
+++ b/src/sendspin_bridge/web/routes/api_bt.py
@@ -14,6 +14,7 @@ import uuid
 
 from flask import Blueprint, jsonify, request
 
+from sendspin_bridge.bluetooth.adapter_map import hci_for
 from sendspin_bridge.bluetooth.adapter_session import AdapterHandle
 from sendspin_bridge.bluetooth.bluez import Adapter, Outcome, get_bluez
 from sendspin_bridge.bluetooth.dbus import _dbus_get_adapter_address
@@ -504,7 +505,7 @@ def api_bt_adapters():
             # after a USB stick hotplug.  Falls back to the synthetic
             # ``hci{i}`` label only when /sys/class/bluetooth isn't mounted
             # (non-Linux dev box, container missing /sys).
-            kernel_hci_sysfs = hci_map.get(mac.upper().replace(":", ""))
+            kernel_hci_sysfs = hci_for(hci_map, mac) or None
             kernel_hci = kernel_hci_sysfs or f"hci{i}"
             # Use ``show <MAC>`` instead of ``select <MAC>; show`` — the
             # latter is unreliable in piped-stdin mode and surfaced the wrong
@@ -822,7 +823,7 @@ def _resolve_adapter_to_mac(adapter: str) -> str:
     hci_map = build_hci_map()
     if hci_map:
         for mac in macs:
-            if hci_map.get(mac.replace(":", "")) == kernel_hci:
+            if hci_for(hci_map, mac) == kernel_hci:
                 return mac
         return adapter  # mapped nowhere — let the failed select surface loudly
     # Sysfs gave nothing (Docker without /sys, or kernels whose
@@ -1031,7 +1032,7 @@ def _resolve_scan_adapter_macs(adapter: str) -> "list[str]":
         hci_map = build_hci_map()
         if hci_map:
             for mac in adapter_macs:
-                if hci_map.get(mac.upper().replace(":", "")) == kernel_hci:
+                if hci_for(hci_map, mac) == kernel_hci:
                     return [mac.upper()]
             raise ValueError("Selected adapter is not available")
         # No sysfs/hciconfig visibility: the adapters endpoint fell back

--- a/tests/unit/bluetooth/test_adapter_map_keys.py
+++ b/tests/unit/bluetooth/test_adapter_map_keys.py
@@ -1,0 +1,39 @@
+"""The adapter map is keyed by an address, not by a spelling of one.
+
+`build_hci_map()` keys its controllers by the bare form, and four call sites
+across the routes and the orchestrator strip the colons themselves before
+looking one up.  Each of those has to fold case as well — and each is a place
+where forgetting means a controller quietly maps nowhere, which surfaces as a
+pair or scan running against the wrong physical adapter.
+"""
+
+from __future__ import annotations
+
+from sendspin_bridge.bluetooth.address import DeviceAddress
+from sendspin_bridge.bluetooth.bluez._adapters import parse_hciconfig
+
+HCICONFIG = """hci1:\tType: Primary  Bus: USB
+\tBD Address: 00:02:72:0A:E4:3B  ACL MTU: 1017:8  SCO MTU: 64:8
+\tUP RUNNING PSCAN
+hci0:\tType: Primary  Bus: USB
+\tBD Address: c0:fb:f9:62:d7:d6  ACL MTU: 310:10  SCO MTU: 64:8
+\tUP RUNNING PSCAN
+"""
+
+
+def test_a_controller_is_found_however_its_address_was_written():
+    """hciconfig prints lower case on some hosts; the caller may hold upper."""
+    mapping = parse_hciconfig(HCICONFIG)
+
+    assert mapping[DeviceAddress.require("C0:FB:F9:62:D7:D6").bare] == "hci0"
+    assert mapping[DeviceAddress.require("00:02:72:0a:e4:3b").bare] == "hci1"
+
+
+def test_the_map_is_keyed_the_way_the_address_type_spells_it():
+    """So a lookup can be built from an address rather than by hand."""
+    mapping = parse_hciconfig(HCICONFIG)
+
+    assert set(mapping) == {
+        DeviceAddress.require("00:02:72:0A:E4:3B").bare,
+        DeviceAddress.require("C0:FB:F9:62:D7:D6").bare,
+    }

--- a/tests/unit/bluetooth/test_adapter_map_lookup.py
+++ b/tests/unit/bluetooth/test_adapter_map_lookup.py
@@ -1,0 +1,33 @@
+"""A controller lookup that cannot be spelled wrong.
+
+The map from `build_hci_map()` is keyed by the bare address, and four call
+sites stripped the colons and folded the case by hand before each lookup.
+Either step forgotten means the controller maps nowhere — which surfaces as a
+pair or a scan running against the wrong physical adapter (issue #340).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sendspin_bridge.bluetooth.adapter_map import hci_for
+
+MAPPING = {"C0FBF962D7D6": "hci0", "0002720AE43B": "hci1"}
+
+
+@pytest.mark.parametrize(
+    "mac",
+    ["C0:FB:F9:62:D7:D6", "c0:fb:f9:62:d7:d6", "C0_FB_F9_62_D7_D6", "c0fbf962d7d6"],
+)
+def test_however_the_address_is_spelled_the_controller_is_found(mac):
+    assert hci_for(MAPPING, mac) == "hci0"
+
+
+def test_a_controller_the_map_does_not_carry_answers_empty():
+    assert hci_for(MAPPING, "AA:BB:CC:DD:EE:FF") == ""
+
+
+@pytest.mark.parametrize("mac", ["", None, "hci0", 17])
+def test_a_value_that_is_not_an_address_answers_empty_rather_than_raising(mac):
+    """These lookups sit on request paths; a bad argument must not 500."""
+    assert hci_for(MAPPING, mac) == ""

--- a/tests/unit/bluetooth/test_device_address.py
+++ b/tests/unit/bluetooth/test_device_address.py
@@ -1,0 +1,70 @@
+"""One address, however it is spelled.
+
+The same speaker address is written three ways in this codebase: with colons
+for BlueZ and the config, with underscores for audio sink names and D-Bus
+object paths, and bare for the sysfs adapter map.  Fifteen call sites did that
+conversion by hand, each remembering on its own to fold case first.  A type
+that knows all three removes the chance of remembering wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sendspin_bridge.bluetooth.address import DeviceAddress
+
+# ── parsing whatever the caller has ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "FC:58:FA:EB:08:6C",
+        "fc:58:fa:eb:08:6c",
+        "FC_58_FA_EB_08_6C",
+        "fc_58_fa_eb_08_6c",
+        "FC58FAEB086C",
+        "  FC:58:FA:EB:08:6C  ",
+    ],
+)
+def test_the_spellings_all_name_the_same_speaker(text):
+    assert DeviceAddress.require(text) == DeviceAddress.require("FC:58:FA:EB:08:6C")
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", "not-a-mac", "FC:58:FA:EB:08", "FC:58:FA:EB:08:6C:9A", "GG:58:FA:EB:08:6C", None],
+)
+def test_what_is_not_an_address_is_not_accepted(text):
+    assert DeviceAddress.parse(text) is None
+    with pytest.raises(ValueError):
+        DeviceAddress.require(text)
+
+
+# ── writing it the way each consumer needs ───────────────────────────────
+
+
+def test_it_writes_every_spelling_its_consumers_use():
+    address = DeviceAddress.require("fc:58:fa:eb:08:6c")
+
+    assert address.colons == "FC:58:FA:EB:08:6C"
+    assert address.underscores == "FC_58_FA_EB_08_6C"
+    assert address.bare == "FC58FAEB086C"
+    assert str(address) == "FC:58:FA:EB:08:6C"
+
+
+def test_it_writes_the_dbus_node_name_bluez_uses():
+    assert DeviceAddress.require("fc:58:fa:eb:08:6c").dbus_node == "dev_FC_58_FA_EB_08_6C"
+
+
+# ── the property the hand-rolled conversions kept re-deriving ────────────
+
+
+def test_case_never_decides_whether_two_addresses_match():
+    assert DeviceAddress.require("fc:58:fa:eb:08:6c") == DeviceAddress.require("FC:58:FA:EB:08:6C")
+
+
+def test_it_can_be_a_dictionary_key_whatever_it_was_parsed_from():
+    index = {DeviceAddress.require("FC_58_FA_EB_08_6C"): "Kitchen"}
+
+    assert index[DeviceAddress.require("fc:58:fa:eb:08:6c")] == "Kitchen"

--- a/tests/unit/services/audio/test_sink_name_grammar.py
+++ b/tests/unit/services/audio/test_sink_name_grammar.py
@@ -1,0 +1,90 @@
+"""One grammar for bluez sink names, in both directions.
+
+The bridge writes these names in `bluetooth/audio.py` — five candidate
+spellings, because PipeWire, WirePlumber and PulseAudio each name the same
+speaker differently — and reads them back in `sink_monitor.py` with a regex of
+its own.  Two descriptions of one grammar, and they had already drifted: the
+raw-colon form WirePlumber publishes on Ubuntu 26.04 (issue #314) is a name
+the bridge itself selects, and the reader did not recognise it.
+
+A name the bridge can choose must be a name the bridge can read.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sendspin_bridge.bluetooth.address import DeviceAddress
+from sendspin_bridge.services.audio.sink_names import (
+    address_from_sink_name,
+    is_bluez_sink_name,
+    sink_name_candidates,
+)
+
+ADDRESS = DeviceAddress.require("FC:58:FA:EB:08:6C")
+
+
+# ── the property the two halves must share ───────────────────────────────
+
+
+def test_every_name_the_bridge_can_choose_reads_back_as_the_same_speaker():
+    for name in sink_name_candidates(ADDRESS):
+        assert address_from_sink_name(name) == ADDRESS, name
+
+
+def test_the_raw_colon_name_wireplumber_publishes_is_understood():
+    """The drift that was there: selected by the bridge, unreadable to it."""
+    assert address_from_sink_name("bluez_output.FC:58:FA:EB:08:6C") == ADDRESS
+
+
+# ── what the candidates are ──────────────────────────────────────────────
+
+
+def test_the_candidates_cover_both_audio_servers():
+    names = sink_name_candidates(ADDRESS)
+
+    assert "bluez_output.FC_58_FA_EB_08_6C.1" in names  # PipeWire
+    assert "bluez_sink.FC_58_FA_EB_08_6C.a2dp_sink" in names  # PulseAudio
+
+
+def test_the_more_specific_names_are_offered_first():
+    """The bare forms match many things; the specific ones must win."""
+    names = sink_name_candidates(ADDRESS)
+
+    assert names.index("bluez_output.FC_58_FA_EB_08_6C.1") < names.index("bluez_output.FC:58:FA:EB:08:6C")
+
+
+# ── reading names the bridge did not choose ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "bluez_sink.FC_58_FA_EB_08_6C.a2dp_sink",
+        "bluez_sink.FC_58_FA_EB_08_6C",
+        "bluez_output.FC_58_FA_EB_08_6C.a2dp-sink",
+        "bluez_output.FC_58_FA_EB_08_6C.1",
+        "bluez_sink.fc_58_fa_eb_08_6c.a2dp_sink",
+    ],
+)
+def test_the_shapes_seen_in_the_wild_are_read(name):
+    assert address_from_sink_name(name) == ADDRESS
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "alsa_output.pci-0000_00_1f.3.analog-stereo",
+        "sendspin_fallback",
+        "bluez_sink.NOT_A_MAC_AT_ALL",
+        "bluez_output.FC_58_FA_EB_08",
+        "",
+    ],
+)
+def test_a_name_that_is_not_a_speaker_reads_as_nothing(name):
+    assert address_from_sink_name(name) is None
+    assert is_bluez_sink_name(name) is False
+
+
+def test_a_bluez_name_is_recognised_as_one():
+    assert is_bluez_sink_name("bluez_output.FC_58_FA_EB_08_6C.1") is True

--- a/tests/unit/services/bluetooth/test_mpris_path_agreement.py
+++ b/tests/unit/services/bluetooth/test_mpris_path_agreement.py
@@ -1,0 +1,38 @@
+"""One object path per speaker, whoever builds it.
+
+Two modules built the MPRIS object path for a device, each with its own copy
+of the colons-to-underscores conversion: the export helper and the activation
+factory.  A player is registered under one and looked up under the other, so
+the two agreeing is not a nicety — it is what makes the registration findable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sendspin_bridge.services.bluetooth.device_activation import _mpris_dbus_path
+from sendspin_bridge.services.bluetooth.mpris_export import mpris_dbus_path
+
+
+@pytest.mark.parametrize("mac", ["FC:58:FA:EB:08:6C", "fc:58:fa:eb:08:6c", "FC_58_FA_EB_08_6C"])
+def test_both_builders_name_the_same_path(mac):
+    assert _mpris_dbus_path(mac) == mpris_dbus_path(mac)
+
+
+def test_the_path_is_a_legal_dbus_path():
+    """D-Bus paths admit only ``[A-Za-z0-9_/]`` — colons must not survive."""
+    path = mpris_dbus_path("fc:58:fa:eb:08:6c")
+
+    assert path == "/org/sendspin/players/FC_58_FA_EB_08_6C"
+    assert ":" not in path
+
+
+def test_however_the_address_was_written_the_player_is_found_at_one_path():
+    """A config in lower case must not hide the player from its own lookup."""
+    assert mpris_dbus_path("fc:58:fa:eb:08:6c") == mpris_dbus_path("FC:58:FA:EB:08:6C")
+
+
+def test_a_value_that_is_not_an_address_is_refused_rather_than_pathed():
+    """Silently exporting a player at /org/sendspin/players/GARBAGE helps nobody."""
+    with pytest.raises(ValueError):
+        mpris_dbus_path("not-a-mac")


### PR DESCRIPTION
Candidate C11 from the architecture review: a device address type, and one grammar for sink names.

## Three spellings, fifteen conversions

The same speaker address is written three ways in this codebase:

| Spelling | Used by |
|---|---|
| `AA:BB:CC:DD:EE:FF` | BlueZ, bluetoothctl, the config file |
| `AA_BB_CC_DD_EE_FF` | audio sink names, D-Bus object paths, MPRIS paths |
| `AABBCCDDEEFF` | the sysfs adapter map |

Fifteen call sites converted between them by hand — `mac.upper().replace(":", "_")` and its cousins — each remembering on its own to fold case before comparing. `DeviceAddress` parses any of the three (in either case, with surrounding whitespace) and writes whichever the consumer needs; equality is equality, and it can be a dict key.

## A grammar written twice, already drifted

Sink names were described in two places pointing in opposite directions: a list of f-strings in the connect path, a regex in the sink monitor. They had come apart. The raw-colon name WirePlumber publishes on Ubuntu 26.04 (issue #314) is one **the bridge itself selects** when connecting a speaker — and the reader did not recognise it.

Both halves now come from `services/audio/sink_names.py`, with the property test that closes it: every name `sink_name_candidates()` can choose reads back through `address_from_sink_name()` as the same speaker. Checked against the name this very speaker gets on my stand:

```
candidates: ['bluez_output.6C_5C_3D_35_17_99.1', ..., 'bluez_output.6C:5C:3D:35:17:99']
real name selected: True | reads back: True
```

## One MPRIS path, not two

The object path a player is registered at had two builders — the export module and the activation factory — each with its own copy of the conversion. Registering under one spelling and looking up under another is a player that cannot be found, so there is one builder now. It also refuses a value that is not an address instead of exporting a player at `/org/sendspin/players/GARBAGE`.

## Adapter lookups

`build_hci_map()` is keyed by the bare form and four call sites stripped and folded it themselves before each lookup; forgetting either step maps a controller nowhere, which surfaces as a pair or scan running against the wrong physical adapter (issue #340). Those go through `hci_for(mapping, mac)` now.

## Left alone deliberately

`bluetooth/bluez/` keeps its two hand-rolled conversions. That package is stdlib-only under an enforced import rule (`test_bluez_import_rule.py`), and it is the *producer* of the bare-key map rather than a consumer — so the lookup helper lives outside it, in `bluetooth/adapter_map.py`.

## Verification

3546 passed, 1 skipped; ruff clean; changelog clean. The routing path was not exercised on hardware in this pass — the speaker on my stand is powered off at the moment — so the round-trip is covered by the grammar tests plus the check above against the name it actually had while connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
