### PR TITLE
fix(state): the device state was reading facts nobody writes, and a stranded daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A speaker whose audio daemon lost its log reader is restarted instead of
+  wedging. The daemon blocks once nothing drains its output, which stopped it
+  responding to volume, stop and reconnect while it still looked healthy —
+  seen on a live bridge, where one sat blocked for eleven minutes with nothing
+  in the log.
 - Device state reports the audio sink a speaker is actually playing through.
   It read the sink name from a field nothing ever filled, so every device
   showed no sink name while reporting, in the same breath, that it had one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Device state reports the audio sink a speaker is actually playing through.
+  It read the sink name from a field nothing ever filled, so every device
+  showed no sink name while reporting, in the same breath, that it had one.
 - The sink name WirePlumber publishes on Ubuntu 26.04 is understood
   everywhere it appears. The bridge already selected that name when
   connecting a speaker, but the code that reads sink names back did not

--- a/src/sendspin_bridge/bridge/client.py
+++ b/src/sendspin_bridge/bridge/client.py
@@ -1821,12 +1821,22 @@ class SendspinClient:
         """
 
         def _on_reader_done(task: asyncio.Task) -> None:
-            if task.cancelled() or task.exception() is None:
+            # A cancelled reader is the bridge stopping it; that path owns the
+            # daemon.  Anything else — an exception *or* a quiet return, which
+            # the reader does when its process handle is already gone — means
+            # the daemon has nobody reading it any more.  Only the exception
+            # used to count, and a daemon whose reader simply returned sat
+            # blocked in a full pipe with nothing in the log to say so.
+            if task.cancelled():
                 return
-            logger.error("[%s] stdout reader error: %s", self.player_name, task.exception())
             proc = self._daemon_proc
             if proc is None or proc.returncode is not None:
                 return
+            error = task.exception()
+            if error is not None:
+                logger.error("[%s] stdout reader error: %s", self.player_name, error)
+            else:
+                logger.error("[%s] stdout reader stopped while the daemon is still running", self.player_name)
             logger.error(
                 "[%s] Killing daemon PID %s — its stdout is no longer being read",
                 self.player_name,
@@ -1849,6 +1859,10 @@ class SendspinClient:
         dead subprocess, and what a status update should trigger here.
         """
         if self._daemon_proc is None or self._daemon_proc.stdout is None:
+            # Nothing to read: the handle went away between the spawn and this
+            # task's first run.  Said out loud, because a daemon left with no
+            # reader blocks in a full pipe and looks healthy from outside.
+            logger.warning("[%s] stdout reader started with no daemon handle", self.player_name)
             return
         await self._ipc_service.read_stream(
             self._daemon_proc.stdout,

--- a/src/sendspin_bridge/services/bluetooth/device_health_state.py
+++ b/src/sendspin_bridge/services/bluetooth/device_health_state.py
@@ -7,9 +7,9 @@ from typing import Any
 
 from sendspin_bridge.services.infrastructure._helpers import (
     _device_audio_streaming,
-    _device_extra,
     _device_ma_reconnecting,
 )
+from sendspin_bridge.services.ipc.device_facts import DeviceFacts
 
 
 def _append_reason(reasons: list[str], reason: str) -> None:
@@ -67,7 +67,7 @@ class DeviceHealthState:
 
 def compute_device_health_state(device: Any) -> DeviceHealthState:
     reasons: list[str] = []
-    extra = _device_extra(device)
+    facts = DeviceFacts(device)
     audio_streaming = _device_audio_streaming(device)
     ma_reconnecting = _device_ma_reconnecting(device)
     recent_events = list(getattr(device, "recent_events", []) or [])
@@ -83,19 +83,19 @@ def compute_device_health_state(device: Any) -> DeviceHealthState:
             last_event_at=last_event_at,
         )
 
-    if extra.get("last_error"):
+    if facts.last_error:
         _append_reason(reasons, "last_error")
         for reason in event_reasons:
             _append_reason(reasons, reason)
         return DeviceHealthState(
             state="degraded",
             severity="error",
-            summary=str(extra["last_error"]),
+            summary=str(facts.last_error),
             reasons=reasons,
-            last_event_at=extra.get("last_error_at") or last_event_at,
+            last_event_at=facts.last_error_at or last_event_at,
         )
 
-    if extra.get("stopping"):
+    if facts.stopping:
         _append_reason(reasons, "stopping")
         for reason in event_reasons:
             _append_reason(reasons, reason)
@@ -107,7 +107,7 @@ def compute_device_health_state(device: Any) -> DeviceHealthState:
             last_event_at=last_event_at,
         )
 
-    if extra.get("reconnecting"):
+    if facts.reconnecting:
         _append_reason(reasons, "reconnecting")
         for reason in event_reasons:
             _append_reason(reasons, reason)
@@ -119,7 +119,7 @@ def compute_device_health_state(device: Any) -> DeviceHealthState:
             last_event_at=last_event_at,
         )
 
-    if extra.get("reanchoring"):
+    if facts.reanchoring:
         _append_reason(reasons, "reanchoring")
         for reason in event_reasons:
             _append_reason(reasons, reason)
@@ -177,8 +177,8 @@ def compute_device_health_state(device: Any) -> DeviceHealthState:
         )
 
     if (
-        extra.get("sink_muted")
-        and not extra.get("muted")
+        facts.sink_muted
+        and not facts.muted
         and getattr(device, "bluetooth_connected", False)
         and getattr(device, "bluetooth_sink_name", None)
     ):
@@ -300,19 +300,22 @@ def _capability_domain_payload(*capabilities: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_device_capabilities(device: Any) -> dict[str, Any]:
-    extra = _device_extra(device)
+    facts = DeviceFacts(device)
     # Two different states used to share one answer.  Whether Music Assistant
     # is reachable is a property of the bridge; whether it has a queue for
     # *this* speaker is a property of the speaker.  Reading the second and
     # calling it the first told operators to check settings that were fine.
     ma_queue_known = bool((getattr(device, "ma_now_playing", None) or {}).get("connected"))
-    ma_connected = bool(extra.get("ma_connected", ma_queue_known))
-    reconnecting = bool(extra.get("reconnecting"))
+    # Absent and false are different: a snapshot that says nothing about the
+    # bridge's Music Assistant link falls back to whether this speaker has a
+    # queue, but one that says the link is down is believed.
+    ma_connected = facts.ma_connected if facts.knows("ma_connected") else ma_queue_known
+    reconnecting = facts.reconnecting
     ma_reconnecting = _device_ma_reconnecting(device)
-    stopping = bool(extra.get("stopping"))
+    stopping = facts.stopping
     released = getattr(device, "bt_management_enabled", True) is False
     has_sink = bool(getattr(device, "has_sink", False))
-    bluetooth_paired = extra.get("bluetooth_paired")
+    bluetooth_paired = facts.bluetooth_paired
 
     reconnect_blocked_reason: BlockReason | None = None
     if released:

--- a/src/sendspin_bridge/services/ipc/bridge_state_model.py
+++ b/src/sendspin_bridge/services/ipc/bridge_state_model.py
@@ -117,13 +117,11 @@ def build_normalized_device_state(device: Any) -> NormalizedDeviceState:
     bluetooth_mac = _obj_get(device, "bluetooth_mac")
     player_name = str(_obj_get(device, "player_name", "") or "")
     reconnect_attempt = extra.get("reconnect_attempt")
-    # The device snapshot writes the configured limit as "max_reconnect_fails";
-    # "bt_max_reconnect_fails" is the spelling the config layer uses.  Read
-    # both, or the limit arrives as None and every screen reading this state
-    # loses the "3/10, 7 remain" half of the sentence.
+    # The device snapshot writes the configured limit as "max_reconnect_fails".
+    # (The config layer spells it BT_MAX_RECONNECT_FAILS, which is where the
+    # dead "bt_max_reconnect_fails" read here came from; nothing ever put that
+    # spelling into a snapshot.)
     max_reconnect_fails = extra.get("max_reconnect_fails")
-    if max_reconnect_fails is None:
-        max_reconnect_fails = extra.get("bt_max_reconnect_fails")
     reconnect_attempts_remaining = None
     if isinstance(reconnect_attempt, int) and isinstance(max_reconnect_fails, int):
         reconnect_attempts_remaining = max(max_reconnect_fails - reconnect_attempt, 0)
@@ -156,7 +154,10 @@ def build_normalized_device_state(device: Any) -> NormalizedDeviceState:
         },
         audio={
             "has_sink": bool(_obj_get(device, "has_sink", False)),
-            "sink_name": extra.get("resolved_sink_name"),
+            # The snapshot names this "sink_name"; asking for a key nothing
+            # writes reported every device as having no sink while saying in
+            # the same breath that it had one.
+            "sink_name": _obj_get(device, "sink_name") or extra.get("sink_name"),
             "streaming": bool(extra.get("audio_streaming")),
         },
         transport={

--- a/src/sendspin_bridge/services/ipc/bridge_state_model.py
+++ b/src/sendspin_bridge/services/ipc/bridge_state_model.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from sendspin_bridge.services.bluetooth.device_health_state import compute_device_health_state
-from sendspin_bridge.services.infrastructure._helpers import _device_extra
+from sendspin_bridge.services.ipc.device_facts import DeviceFacts
 
 
 def _obj_get(source: Any, name: str, default: Any = None) -> Any:
@@ -110,55 +110,43 @@ def build_runtime_substrate_status(preflight: dict[str, Any] | None) -> RuntimeS
 
 
 def build_normalized_device_state(device: Any) -> NormalizedDeviceState:
-    extra = _device_extra(device)
+    # Read through the named facts rather than the untyped bag: a question
+    # this device cannot answer is an error at the ask, not a None on screen.
+    facts = DeviceFacts(device)
     health = _obj_get(device, "health_summary") or compute_device_health_state(device).to_dict()
     ma_now_playing = _obj_get(device, "ma_now_playing") or {}
     recent_events = list(_obj_get(device, "recent_events", []) or [])
-    bluetooth_mac = _obj_get(device, "bluetooth_mac")
-    player_name = str(_obj_get(device, "player_name", "") or "")
-    reconnect_attempt = extra.get("reconnect_attempt")
-    # The device snapshot writes the configured limit as "max_reconnect_fails".
-    # (The config layer spells it BT_MAX_RECONNECT_FAILS, which is where the
-    # dead "bt_max_reconnect_fails" read here came from; nothing ever put that
-    # spelling into a snapshot.)
-    max_reconnect_fails = extra.get("max_reconnect_fails")
-    reconnect_attempts_remaining = None
-    if isinstance(reconnect_attempt, int) and isinstance(max_reconnect_fails, int):
-        reconnect_attempts_remaining = max(max_reconnect_fails - reconnect_attempt, 0)
     return NormalizedDeviceState(
-        player_name=player_name,
-        enabled=bool(_obj_get(device, "enabled", True)),
+        player_name=facts.player_name,
+        enabled=facts.enabled,
         management={
             "bridge_managed": bool(_obj_get(device, "bt_management_enabled", True)),
             "released": _obj_get(device, "bt_management_enabled", True) is False,
-            "release_reason": extra.get("bt_released_by"),
+            "release_reason": facts.released_by,
         },
         bluetooth={
-            "mac": bluetooth_mac,
-            "connected": bool(_obj_get(device, "bluetooth_connected", False)),
-            "paired": extra.get("bluetooth_paired"),
-            "adapter": extra.get("bluetooth_adapter"),
-            "adapter_hci": extra.get("bluetooth_adapter_hci"),
-            "adapter_name": extra.get("bluetooth_adapter_name"),
-            "reconnect_attempt": reconnect_attempt,
-            "max_reconnect_fails": max_reconnect_fails,
-            "reconnect_attempts_remaining": reconnect_attempts_remaining,
-            "standby": bool(extra.get("bt_standby")),
-            "pair_failure_kind": extra.get("pair_failure_kind"),
-            "pair_failure_adapter_mac": extra.get("pair_failure_adapter_mac"),
-            "pair_failure_at": extra.get("pair_failure_at"),
+            "mac": facts.bluetooth_mac,
+            "connected": facts.bluetooth_connected,
+            "paired": facts.bluetooth_paired,
+            "adapter": facts.bluetooth_adapter,
+            "adapter_hci": facts.bluetooth_adapter_hci,
+            "adapter_name": facts.bluetooth_adapter_name,
+            "reconnect_attempt": facts.reconnect_attempt,
+            "max_reconnect_fails": facts.max_reconnect_fails,
+            "reconnect_attempts_remaining": facts.reconnect_attempts_remaining,
+            "standby": facts.standby,
+            "pair_failure_kind": facts.pair_failure_kind,
+            "pair_failure_adapter_mac": facts.pair_failure_adapter_mac,
+            "pair_failure_at": facts.pair_failure_at,
             # v2.70.0-rc.2 (#260, #263) — never_paired drives the recovery
             # banner branch + Start pairing device-card button + auto-disable.
-            "never_paired": bool(extra.get("never_paired", False)),
-            "never_paired_since": extra.get("never_paired_since"),
+            "never_paired": facts.never_paired,
+            "never_paired_since": facts.never_paired_since,
         },
         audio={
-            "has_sink": bool(_obj_get(device, "has_sink", False)),
-            # The snapshot names this "sink_name"; asking for a key nothing
-            # writes reported every device as having no sink while saying in
-            # the same breath that it had one.
-            "sink_name": _obj_get(device, "sink_name") or extra.get("sink_name"),
-            "streaming": bool(extra.get("audio_streaming")),
+            "has_sink": facts.has_sink,
+            "sink_name": facts.sink_name,
+            "streaming": facts.audio_streaming,
         },
         transport={
             "daemon_connected": bool(_obj_get(device, "server_connected", False)),
@@ -169,10 +157,10 @@ def build_normalized_device_state(device: Any) -> NormalizedDeviceState:
             "playing": bool(_obj_get(device, "playing", False)),
         },
         async_ops={
-            "reconnecting": bool(extra.get("reconnecting")),
-            "ma_reconnecting": bool(extra.get("ma_reconnecting")),
-            "stopping": bool(extra.get("stopping")),
-            "reanchoring": bool(extra.get("reanchoring")),
+            "reconnecting": facts.reconnecting,
+            "ma_reconnecting": facts.ma_reconnecting,
+            "stopping": facts.stopping,
+            "reanchoring": facts.reanchoring,
         },
         music_assistant={
             "connected": bool(ma_now_playing.get("connected")),

--- a/src/sendspin_bridge/services/ipc/device_facts.py
+++ b/src/sendspin_bridge/services/ipc/device_facts.py
@@ -1,0 +1,172 @@
+"""The facts about one device, named once.
+
+A device snapshot carries its facts two ways: as typed fields, and as
+``extra`` — the whole runtime status dict plus three dozen keys added by
+hand.  Everything that describes a device to an operator reads from that bag
+by string: the normalised state, the capability builder, the guidance.  Every
+one of those strings is a chance to ask for a key nobody writes, and the
+answer to such a question is not an error but a ``None`` that travels to the
+screen.  Two of them shipped: the audio sink name and the reconnect limit,
+each reported as missing on devices that had one.
+
+This is that bag with names on it.  Ask it a question it does not know and
+you get an ``AttributeError`` where the mistake is, instead of a blank field
+somewhere else.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["DeviceFacts"]
+
+
+class DeviceFacts:
+    """A read-only view of one device snapshot's facts.
+
+    Typed fields on the snapshot win over the bag: the bag is a copy of the
+    runtime status made at snapshot time, and where the snapshot resolved a
+    fact of its own — the sink it actually found, for instance — that is the
+    answer.
+    """
+
+    __slots__ = ("_extra", "_snapshot")
+
+    def __init__(self, snapshot: Any):
+        self._snapshot = snapshot
+        extra = getattr(snapshot, "extra", None)
+        if not isinstance(extra, dict) and isinstance(snapshot, dict):
+            extra = snapshot.get("extra")
+        self._extra = extra if isinstance(extra, dict) else {}
+
+    # -- how a fact is found -------------------------------------------
+
+    def _field(self, name: str, default: Any = None) -> Any:
+        value = getattr(self._snapshot, name, None)
+        if value is None and isinstance(self._snapshot, dict):
+            value = self._snapshot.get(name)
+        return default if value is None else value
+
+    def _fact(self, name: str, default: Any = None) -> Any:
+        value = self._extra.get(name)
+        return default if value is None else value
+
+    # -- identity -------------------------------------------------------
+
+    @property
+    def player_name(self) -> str:
+        return str(self._field("player_name", "") or "")
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._field("enabled", True))
+
+    # -- bluetooth ------------------------------------------------------
+
+    @property
+    def bluetooth_mac(self) -> str | None:
+        return self._field("bluetooth_mac")
+
+    @property
+    def bluetooth_connected(self) -> bool:
+        return bool(self._field("bluetooth_connected", False))
+
+    @property
+    def bluetooth_paired(self) -> bool | None:
+        return self._fact("bluetooth_paired")
+
+    @property
+    def bluetooth_adapter(self) -> str | None:
+        return self._fact("bluetooth_adapter")
+
+    @property
+    def bluetooth_adapter_hci(self) -> str | None:
+        return self._fact("bluetooth_adapter_hci")
+
+    @property
+    def bluetooth_adapter_name(self) -> str | None:
+        return self._fact("bluetooth_adapter_name")
+
+    @property
+    def standby(self) -> bool:
+        return bool(self._fact("bt_standby", False))
+
+    @property
+    def released_by(self) -> str | None:
+        return self._fact("bt_released_by")
+
+    @property
+    def never_paired(self) -> bool:
+        return bool(self._fact("never_paired", False))
+
+    @property
+    def never_paired_since(self) -> Any:
+        return self._fact("never_paired_since")
+
+    @property
+    def pair_failure_kind(self) -> str | None:
+        return self._fact("pair_failure_kind")
+
+    @property
+    def pair_failure_adapter_mac(self) -> str | None:
+        return self._fact("pair_failure_adapter_mac")
+
+    @property
+    def pair_failure_at(self) -> Any:
+        return self._fact("pair_failure_at")
+
+    # -- reconnect ------------------------------------------------------
+
+    @property
+    def reconnecting(self) -> bool:
+        return bool(self._fact("reconnecting", False))
+
+    @property
+    def reconnect_attempt(self) -> int | None:
+        value = self._fact("reconnect_attempt")
+        return value if isinstance(value, int) else None
+
+    @property
+    def max_reconnect_fails(self) -> int | None:
+        value = self._fact("max_reconnect_fails")
+        return value if isinstance(value, int) else None
+
+    @property
+    def reconnect_attempts_remaining(self) -> int | None:
+        """Derived, not stored — two places used to compute it separately."""
+        attempt, limit = self.reconnect_attempt, self.max_reconnect_fails
+        if attempt is None or limit is None:
+            return None
+        return max(limit - attempt, 0)
+
+    # -- audio ----------------------------------------------------------
+
+    @property
+    def has_sink(self) -> bool:
+        return bool(self._field("has_sink", False))
+
+    @property
+    def sink_name(self) -> str | None:
+        return self._field("sink_name") or self._fact("sink_name")
+
+    @property
+    def audio_streaming(self) -> bool:
+        return bool(self._fact("audio_streaming", False))
+
+    # -- runtime --------------------------------------------------------
+
+    @property
+    def stopping(self) -> bool:
+        return bool(self._fact("stopping", False))
+
+    @property
+    def reanchoring(self) -> bool:
+        return bool(self._fact("reanchoring", False))
+
+    @property
+    def ma_reconnecting(self) -> bool:
+        return bool(self._fact("ma_reconnecting", False))
+
+    @property
+    def ma_connected(self) -> bool:
+        return bool(self._fact("ma_connected", False))

--- a/src/sendspin_bridge/services/ipc/device_facts.py
+++ b/src/sendspin_bridge/services/ipc/device_facts.py
@@ -47,6 +47,15 @@ class DeviceFacts:
             value = self._snapshot.get(name)
         return default if value is None else value
 
+    def knows(self, name: str) -> bool:
+        """Whether this snapshot carried *name* at all.
+
+        Absent and false are different answers for a fact a caller has a
+        fallback for — a bridge that reports Music Assistant as unreachable is
+        not the same as one that said nothing about it.
+        """
+        return name in self._extra
+
     def _fact(self, name: str, default: Any = None) -> Any:
         value = self._extra.get(name)
         return default if value is None else value
@@ -169,4 +178,26 @@ class DeviceFacts:
 
     @property
     def ma_connected(self) -> bool:
+        """Whether the *bridge* can reach Music Assistant at all.
+
+        Bridge-wide rather than per-device, and carried on the snapshot so the
+        device card can tell "Music Assistant is down" apart from "Music
+        Assistant has no queue for this speaker".
+        """
         return bool(self._fact("ma_connected", False))
+
+    @property
+    def muted(self) -> bool:
+        return bool(self._fact("muted", False))
+
+    @property
+    def sink_muted(self) -> bool:
+        return bool(self._fact("sink_muted", False))
+
+    @property
+    def last_error(self) -> str | None:
+        return self._fact("last_error")
+
+    @property
+    def last_error_at(self) -> Any:
+        return self._fact("last_error_at")

--- a/src/sendspin_bridge/services/lifecycle/status_snapshot.py
+++ b/src/sendspin_bridge/services/lifecycle/status_snapshot.py
@@ -230,7 +230,7 @@ def _enrich_device_snapshot_with_ma(device: DeviceSnapshot, client_or_player_id=
     # the device card needs it to tell "MA is down" apart from "MA has no
     # queue for this speaker" — two states that used to share one answer.
     device.extra["ma_connected"] = bool(is_ma_connected())
-    player_id = device.extra.get("player_id") or (
+    player_id = device.player_id or (
         client_or_player_id if isinstance(client_or_player_id, str) else getattr(client_or_player_id, "player_id", "")
     )
     if not player_id:
@@ -253,7 +253,7 @@ def _enrich_device_snapshot_with_ma(device: DeviceSnapshot, client_or_player_id=
 
 def _get_device_event_id(client_or_player_id, device: DeviceSnapshot) -> str:
     player_id = str(
-        device.extra.get("player_id")
+        device.player_id
         or (
             client_or_player_id
             if isinstance(client_or_player_id, str)

--- a/tests/unit/bridge/test_reader_exit_guard.py
+++ b/tests/unit/bridge/test_reader_exit_guard.py
@@ -48,8 +48,8 @@ async def test_a_reader_that_returns_quietly_still_frees_the_daemon():
 
     task = asyncio.ensure_future(_reader_that_gives_up())
     task.add_done_callback(client._make_reader_done_handler())
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)  # done callbacks run on the next tick
 
     assert proc.killed, "the daemon was left writing into a pipe nobody reads"
 
@@ -65,8 +65,8 @@ async def test_a_reader_that_raises_still_frees_the_daemon():
 
     task = asyncio.ensure_future(_reader_that_breaks())
     task.add_done_callback(client._make_reader_done_handler())
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)  # done callbacks run on the next tick
 
     assert proc.killed
 
@@ -84,8 +84,8 @@ async def test_a_daemon_that_has_already_exited_is_left_alone():
 
     task = asyncio.ensure_future(_reader())
     task.add_done_callback(client._make_reader_done_handler())
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)  # done callbacks run on the next tick
 
     assert not proc.killed
 

--- a/tests/unit/bridge/test_reader_exit_guard.py
+++ b/tests/unit/bridge/test_reader_exit_guard.py
@@ -1,0 +1,109 @@
+"""A stdout reader that ends leaves nobody draining the daemon.
+
+The daemon writes its status with a blocking `print`. Once the 64 KB pipe
+fills, its event loop wedges: no commands, no stop, no reconnect — while the
+audio thread keeps playing and the speaker looks healthy from the outside.
+
+The bridge already killed the daemon when its reader raised. It did not when
+the reader simply *returned* — and the reader has an early return, for the
+case where the process handle is gone by the time the task first runs. Seen on
+the stand: a daemon alive for eleven minutes, listening on its port, blocked
+in `anon_pipe_write`, with nothing in the log.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sendspin_bridge.bridge.client import SendspinClient
+
+
+class _LiveProc:
+    """A daemon that is still running — returncode stays None."""
+
+    def __init__(self) -> None:
+        self.pid = 4242
+        self.returncode = None
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+
+def _client() -> SendspinClient:
+    return SendspinClient("Test Player", "localhost", 9000)
+
+
+@pytest.mark.asyncio
+async def test_a_reader_that_returns_quietly_still_frees_the_daemon():
+    client = _client()
+    proc = _LiveProc()
+    client._daemon_proc = proc
+
+    async def _reader_that_gives_up():
+        return None
+
+    task = asyncio.ensure_future(_reader_that_gives_up())
+    task.add_done_callback(client._make_reader_done_handler())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert proc.killed, "the daemon was left writing into a pipe nobody reads"
+
+
+@pytest.mark.asyncio
+async def test_a_reader_that_raises_still_frees_the_daemon():
+    client = _client()
+    proc = _LiveProc()
+    client._daemon_proc = proc
+
+    async def _reader_that_breaks():
+        raise RuntimeError("stdout decode failed")
+
+    task = asyncio.ensure_future(_reader_that_breaks())
+    task.add_done_callback(client._make_reader_done_handler())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert proc.killed
+
+
+@pytest.mark.asyncio
+async def test_a_daemon_that_has_already_exited_is_left_alone():
+    """The ordinary end of a reader: the process it was reading is gone."""
+    client = _client()
+    proc = _LiveProc()
+    proc.returncode = 0
+    client._daemon_proc = proc
+
+    async def _reader():
+        return None
+
+    task = asyncio.ensure_future(_reader())
+    task.add_done_callback(client._make_reader_done_handler())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert not proc.killed
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_reader_is_the_bridge_stopping_it():
+    client = _client()
+    proc = _LiveProc()
+    client._daemon_proc = proc
+
+    async def _reader():
+        await asyncio.sleep(10)
+
+    task = asyncio.ensure_future(_reader())
+    task.add_done_callback(client._make_reader_done_handler())
+    await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    assert not proc.killed, "a stop cancelled the reader; the stop path owns the daemon"

--- a/tests/unit/services/ipc/test_device_facts.py
+++ b/tests/unit/services/ipc/test_device_facts.py
@@ -1,0 +1,103 @@
+"""The facts a device state is built from, named once.
+
+The normalised state read nineteen facts out of an untyped bag by string, and
+the capability builder and the guidance read more of the same bag beside it.
+Every one of those strings is a chance to ask for a key nobody writes — which
+is how the sink name and the reconnect limit both came to be reported as
+missing on devices that had them.
+
+`DeviceFacts` is that bag with names: it takes a snapshot and answers the
+questions, so a typo is an attribute error at the call rather than a `None`
+on somebody's screen.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sendspin_bridge.services.ipc.device_facts import DeviceFacts
+
+
+def _snapshot(**extra) -> SimpleNamespace:
+    return SimpleNamespace(
+        player_name="Kitchen",
+        enabled=True,
+        has_sink=True,
+        sink_name="bluez_output.AA_BB_CC_DD_EE_FF.1",
+        bluetooth_connected=True,
+        extra=dict(extra),
+    )
+
+
+# ── reading what is there ────────────────────────────────────────────────
+
+
+def test_it_answers_from_the_typed_field_before_the_bag():
+    facts = DeviceFacts(_snapshot(sink_name="stale-from-the-bag"))
+
+    assert facts.sink_name == "bluez_output.AA_BB_CC_DD_EE_FF.1"
+
+
+def test_it_falls_back_to_the_bag_for_facts_with_no_field():
+    facts = DeviceFacts(_snapshot(reconnect_attempt=3, max_reconnect_fails=10))
+
+    assert facts.reconnect_attempt == 3
+    assert facts.max_reconnect_fails == 10
+
+
+def test_the_remaining_attempts_are_derived_not_stored():
+    facts = DeviceFacts(_snapshot(reconnect_attempt=3, max_reconnect_fails=10))
+
+    assert facts.reconnect_attempts_remaining == 7
+
+
+def test_an_overshoot_does_not_report_negative_attempts():
+    facts = DeviceFacts(_snapshot(reconnect_attempt=12, max_reconnect_fails=10))
+
+    assert facts.reconnect_attempts_remaining == 0
+
+
+def test_without_a_limit_there_is_no_remaining_count():
+    facts = DeviceFacts(_snapshot(reconnect_attempt=3))
+
+    assert facts.reconnect_attempts_remaining is None
+
+
+# ── reading what is not ──────────────────────────────────────────────────
+
+
+def test_an_absent_fact_answers_its_documented_default():
+    facts = DeviceFacts(_snapshot())
+
+    assert facts.never_paired is False
+    assert facts.pair_failure_kind is None
+    assert facts.reconnect_attempt is None
+
+
+def test_a_fact_that_does_not_exist_is_an_error_rather_than_a_none():
+    """The property this type exists for."""
+    facts = DeviceFacts(_snapshot())
+
+    try:
+        facts.resolved_sink_name  # noqa: B018 — the point is that it raises
+    except AttributeError:
+        return
+    raise AssertionError("a misspelled fact answered instead of failing")
+
+
+# ── the shapes the state model publishes ─────────────────────────────────
+
+
+def test_the_bluetooth_block_matches_what_the_state_model_publishes():
+    from sendspin_bridge.services.ipc.bridge_state_model import build_normalized_device_state
+
+    snapshot = _snapshot(reconnect_attempt=2, max_reconnect_fails=5, bluetooth_paired=True)
+    snapshot.bluetooth_mac = "AA:BB:CC:DD:EE:FF"
+
+    bluetooth = build_normalized_device_state(snapshot).to_dict()["bluetooth"]
+    facts = DeviceFacts(snapshot)
+
+    assert bluetooth["reconnect_attempt"] == facts.reconnect_attempt
+    assert bluetooth["max_reconnect_fails"] == facts.max_reconnect_fails
+    assert bluetooth["reconnect_attempts_remaining"] == facts.reconnect_attempts_remaining
+    assert bluetooth["paired"] == facts.bluetooth_paired

--- a/tests/unit/services/ipc/test_device_facts.py
+++ b/tests/unit/services/ipc/test_device_facts.py
@@ -101,3 +101,21 @@ def test_the_bluetooth_block_matches_what_the_state_model_publishes():
     assert bluetooth["max_reconnect_fails"] == facts.max_reconnect_fails
     assert bluetooth["reconnect_attempts_remaining"] == facts.reconnect_attempts_remaining
     assert bluetooth["paired"] == facts.bluetooth_paired
+
+
+# ── absent is not the same as false ──────────────────────────────────────
+
+
+def test_a_fact_that_was_never_carried_is_distinguishable_from_a_false_one():
+    """Callers with a fallback need to tell "no" from "nothing said"."""
+    said_no = DeviceFacts(_snapshot(ma_connected=False))
+    said_nothing = DeviceFacts(_snapshot())
+
+    assert said_no.ma_connected is False
+    assert said_nothing.ma_connected is False
+    assert said_no.knows("ma_connected") is True
+    assert said_nothing.knows("ma_connected") is False
+
+
+def test_a_carried_true_is_known():
+    assert DeviceFacts(_snapshot(ma_connected=True)).knows("ma_connected") is True

--- a/tests/unit/services/ipc/test_state_model_facts.py
+++ b/tests/unit/services/ipc/test_state_model_facts.py
@@ -1,0 +1,77 @@
+"""The normalised state must read facts that something actually produces.
+
+The device snapshot and the normalised state meet through an untyped bag of
+some sixty string keys: `DeviceSnapshot.extra`, which is the whole runtime
+status dict plus a few dozen keys added by hand.  Nothing checks that a key
+the reader asks for is a key the writer wrote, so a misspelling is not an
+error — it is a `None` that travels all the way to the screen.
+
+Twice now that has happened.  The reconnect limit arrived as `None` because
+the reader asked for `bt_max_reconnect_fails` while the writer wrote
+`max_reconnect_fails`.  And the audio block asks for `resolved_sink_name`,
+which nothing has ever written, so every device in the state model reports a
+sink name of `None` next to `has_sink: true`.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+
+from sendspin_bridge.services.ipc.bridge_state_model import build_normalized_device_state
+from sendspin_bridge.services.lifecycle.status_snapshot import build_device_snapshot
+
+UTC = timezone.utc
+
+
+def _client(*, sink_name: str = "bluez_output.6C_5C_3D_35_17_99.1") -> object:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        status={
+            "server_connected": True,
+            "bluetooth_connected": True,
+            "bluetooth_available": True,
+            "playing": False,
+            "volume": 50,
+            "uptime_start": datetime.now(tz=UTC),
+        },
+        _status_lock=threading.Lock(),
+        player_name="Kitchen",
+        player_id="sendspin-kitchen",
+        listen_port=8928,
+        server_host="music-assistant.local",
+        server_port=9000,
+        static_delay_ms=0.0,
+        connected_server_url="",
+        bt_manager=SimpleNamespace(
+            mac_address="6C:5C:3D:35:17:99",
+            effective_adapter_mac="C0:FB:F9:62:D7:D6",
+            adapter="hci0",
+            adapter_hci_name="hci0",
+            battery_level=None,
+            max_reconnect_fails=5,
+        ),
+        bluetooth_sink_name=sink_name,
+        bt_management_enabled=True,
+        is_running=lambda: True,
+    )
+
+
+def test_the_sink_a_device_is_playing_through_is_named_in_its_state():
+    """`has_sink: true` beside `sink_name: null` is a contradiction on screen."""
+    snapshot = build_device_snapshot(_client())
+
+    audio = build_normalized_device_state(snapshot).to_dict()["audio"]
+
+    assert audio["has_sink"] is True
+    assert audio["sink_name"] == "bluez_output.6C_5C_3D_35_17_99.1"
+
+
+def test_a_device_without_a_sink_still_says_so():
+    snapshot = build_device_snapshot(_client(sink_name=""))
+
+    audio = build_normalized_device_state(snapshot).to_dict()["audio"]
+
+    assert audio["has_sink"] is False
+    assert audio["sink_name"] in (None, "")

--- a/tests/unit/services/ipc/test_state_model_key_contract.py
+++ b/tests/unit/services/ipc/test_state_model_key_contract.py
@@ -19,7 +19,6 @@ import ast
 import pathlib
 
 SRC = pathlib.Path(__file__).parents[4] / "src" / "sendspin_bridge"
-SNAPSHOT = SRC / "services" / "lifecycle" / "status_snapshot.py"
 CLIENT = SRC / "bridge" / "client.py"
 
 #: Keys read from ``extra`` that no producer writes, on purpose.  Empty, and

--- a/tests/unit/services/ipc/test_state_model_key_contract.py
+++ b/tests/unit/services/ipc/test_state_model_key_contract.py
@@ -1,0 +1,105 @@
+"""Every fact the normalised state reads must have something that writes it.
+
+`DeviceSnapshot.extra` is an untyped bag: the whole runtime status dict, plus
+three dozen keys the snapshot builder adds by hand.  The normalised state, the
+capability builder and the guidance all reach into it by string.  A key that
+nobody writes is not an error there — it is a `None` that reaches the screen,
+which is how the reconnect limit and the audio sink name both came to be
+reported as missing on devices that had them.
+
+This walks the readers and the writers and insists the first is covered by
+the second.  It is a coarse rule — it cannot tell a genuinely optional key
+from a misspelled one — so keys that are legitimately absent are listed here
+by name, with the reason.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+SRC = pathlib.Path(__file__).parents[4] / "src" / "sendspin_bridge"
+SNAPSHOT = SRC / "services" / "lifecycle" / "status_snapshot.py"
+CLIENT = SRC / "bridge" / "client.py"
+
+#: Keys read from ``extra`` that no producer writes, on purpose.  Empty, and
+#: worth keeping that way: every entry here is a read that can only answer
+#: ``None``, which is what this test exists to catch.
+KNOWN_ABSENT: set[str] = set()
+
+
+def _device_status_fields() -> set[str]:
+    tree = ast.parse(CLIENT.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "DeviceStatus":
+            return {
+                item.target.id
+                for item in node.body
+                if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name)
+            }
+    raise AssertionError("DeviceStatus not found — this test needs rewiring")
+
+
+def _written_extra_keys() -> set[str]:
+    written: set[str] = set()
+    for path in SRC.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and isinstance(target.slice, ast.Constant)
+                    and isinstance(target.slice.value, str)
+                    and getattr(target.value, "attr", None) == "extra"
+                ):
+                    written.add(target.slice.value)
+    return written
+
+
+def _read_extra_keys(path: pathlib.Path) -> dict[str, int]:
+    """``{key: line}`` for every ``extra[...]`` / ``extra.get(...)`` read."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found: dict[str, int] = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            base = node.func.value
+            if (getattr(base, "attr", None) or getattr(base, "id", None)) == "extra":
+                found.setdefault(node.args[0].value, node.lineno)
+        if (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.slice, ast.Constant)
+            and isinstance(node.slice.value, str)
+        ):
+            base = node.value
+            if (getattr(base, "attr", None) or getattr(base, "id", None)) == "extra":
+                found.setdefault(node.slice.value, node.lineno)
+    return found
+
+
+def test_every_fact_the_readers_ask_for_is_one_something_writes():
+    produced = _device_status_fields() | _written_extra_keys() | KNOWN_ABSENT
+    orphans: list[str] = []
+
+    for path in SRC.rglob("*.py"):
+        for key, line in _read_extra_keys(path).items():
+            if key not in produced:
+                orphans.append(f"{path.relative_to(SRC).as_posix()}:{line} reads extra[{key!r}]")
+
+    assert not orphans, "these reads can only ever answer None:\n  " + "\n  ".join(sorted(orphans))
+
+
+def test_the_allow_list_does_not_outlive_its_reason():
+    """A key that gained a writer must leave the list, or it hides the next one."""
+    produced = _device_status_fields() | _written_extra_keys()
+    stale = sorted(KNOWN_ABSENT & produced)
+
+    assert not stale, f"these are written now and no longer need listing: {stale}"


### PR DESCRIPTION
Candidate C8 from the architecture review, first batch: give the junction between the device snapshot and everything that describes a device a contract.

## The junction had none, and it had already cost twice

`DeviceSnapshot.extra` is an untyped bag — the whole runtime status dict, plus three dozen keys the snapshot builder adds by hand. The normalised state, the capability builder and the guidance all reach into it by string. Nothing checked that a key the reader asks for is a key the writer wrote, so a misspelling is not an error: it is a `None` that travels to the screen.

Two had shipped. The reconnect limit (fixed in #444) asked for `bt_max_reconnect_fails` while the writer wrote `max_reconnect_fails`. And this one, found by walking the tree here and confirmed against the live bridge while its speaker was playing:

```
top-level sink_name: bluez_output.6C_5C_3D_35_17_99.1
state_model audio  : {"has_sink": true, "sink_name": null, "streaming": false}
```

The audio block asked for `resolved_sink_name` — a key nothing has ever written. `has_sink: true` beside `sink_name: null` in one object.

## Three orphan reads, and a guard so there is no fourth

Fixed: `resolved_sink_name` (the live defect), the dead `bt_max_reconnect_fails` fallback, and two reads that took `player_id` out of the bag when the snapshot has a typed field for it.

A test now walks every `extra[...]` read in the tree and insists something produces it — a `DeviceStatus` field or an explicit write. Its allow-list is **empty**, and a second test fails if an entry ever gains a writer, so the list cannot quietly become cover for the next misspelling.

## Names instead of strings

`DeviceFacts` is that bag with names on it: the typed snapshot field wins where there is one, the bag is the fallback where there is not, and derived answers like "attempts remaining" are computed in one place rather than at each reader. Thirty reads moved onto it — nineteen in the normalised state, eleven in the builder behind every device card.

One needed care. Whether the bridge can reach Music Assistant falls back to whether this speaker has a queue, but only when the snapshot said nothing about the link at all; a snapshot reporting the link *down* is believed. `get(name, fallback)` did that by accident, an attribute cannot, so `DeviceFacts.knows()` keeps absent and false apart.

## What C8 still owes

The three representations are still three: `DeviceStatus` (101 typed fields, live), `DeviceSnapshot` (35 fields plus the bag, read-side), `NormalizedDeviceState` (nine grouped dicts, derived). This batch makes the seam between the second and third safe to cross; collapsing them is the larger half and is not done here.

## A wedged daemon, found while verifying this

The speaker came back on mid-review, and the run that followed showed something else: a daemon alive for eleven minutes, listening on its port, blocked in `anon_pipe_write` — writing status into a pipe nobody was draining — with nothing in the log. The audio thread keeps playing through that, so the speaker looks healthy while the daemon answers no command, no stop and no reconnect.

The bridge already killed a daemon whose stdout reader *raised*. It did not when the reader simply returned, and the reader has exactly that path: it gives up quietly when the process handle is gone by the time the task first runs. Any end other than cancellation counts now — cancellation is the bridge stopping the reader itself, and that path owns the daemon — and the quiet return says so in the log, which was the one thing that could have named this from outside.

## Verification

Live, on this branch, with the speaker back on:

```
server: True | bt: True
state_model audio: {"has_sink": true, "sink_name": "bluez_output.6C_5C_3D_35_17_99.1", "streaming": false}
```

That is the field this PR fixes, carrying the sink the speaker is actually connected through, where it read `null` before.

3564 passed, 1 skipped; ruff clean; changelog clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
