### PR TITLE
refactor(state, ma): one reader for a snapshot, one for the socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Queue commands are no longer reported as failed when Music Assistant is
+  busy. The bridge waited for an answer through at most ten messages, and a
+  household with several speakers can put more than ten update notifications
+  on the wire between a command and its acknowledgement; the command had in
+  fact been carried out.
+- Queue controls work immediately after the bridge connects to Music
+  Assistant, rather than after the first minute. Which Music Assistant player
+  belongs to which speaker is now learned as part of connecting.
+
 ## [2.75.0-rc.5] - 2026-08-26
 
 ### Changed

--- a/src/sendspin_bridge/services/lifecycle/status_snapshot.py
+++ b/src/sendspin_bridge/services/lifecycle/status_snapshot.py
@@ -420,6 +420,50 @@ def build_device_snapshot_pairs(
     return [(client, build_device_snapshot(client, configured_enabled=resolved_enabled)) for client in clients]
 
 
+def _client_facts(client) -> dict:
+    """The facts a snapshot is built from, read once.
+
+    A client that can read itself atomically does so — that is what keeps a
+    status build free of TOCTOU across twenty-one separate attribute reads.
+    One that cannot (a partially built client, a test double) is read by
+    attribute into the same shape, so the unpacking below exists once rather
+    than in two versions that have to be kept in step by hand.
+    """
+    reader = getattr(type(client), "snapshot", None)
+    if callable(reader):
+        facts = client.snapshot()
+        if isinstance(facts, dict):
+            return facts
+
+    if hasattr(client, "_status_lock"):
+        with client._status_lock:
+            status = client.status.copy()
+    else:
+        status = client.status.copy()
+    bt_mgr = getattr(client, "bt_manager", None)
+    return {
+        "status": status,
+        "bluetooth_sink_name": getattr(client, "bluetooth_sink_name", None),
+        "bt_management_enabled": getattr(client, "bt_management_enabled", True),
+        "connected_server_url": getattr(client, "connected_server_url", ""),
+        "is_running": client.is_running() if hasattr(client, "is_running") else None,
+        "player_name": getattr(client, "player_name", None),
+        "player_id": getattr(client, "player_id", ""),
+        "listen_port": getattr(client, "listen_port", None),
+        "server_host": getattr(client, "server_host", None),
+        "server_port": getattr(client, "server_port", None),
+        "static_delay_ms": getattr(client, "static_delay_ms", None),
+        "bt_manager": bt_mgr,
+        "bluetooth_mac": getattr(bt_mgr, "mac_address", None) if bt_mgr else None,
+        "effective_adapter_mac": getattr(bt_mgr, "effective_adapter_mac", None) if bt_mgr else None,
+        "adapter": getattr(bt_mgr, "adapter", None) if bt_mgr else None,
+        "adapter_hci_name": getattr(bt_mgr, "adapter_hci_name", "") if bt_mgr else "",
+        "battery_level": getattr(bt_mgr, "battery_level", None) if bt_mgr else None,
+        "paired": getattr(bt_mgr, "paired", None) if bt_mgr else None,
+        "max_reconnect_fails": int(getattr(bt_mgr, "max_reconnect_fails", 0) or 0) if bt_mgr else 0,
+    }
+
+
 def build_device_snapshot(client, *, configured_enabled: dict[str, bool] | None = None) -> DeviceSnapshot:
     """Build a typed device snapshot from a runtime client object."""
     if client is None:
@@ -428,53 +472,26 @@ def build_device_snapshot(client, *, configured_enabled: dict[str, bool] | None 
     if not hasattr(client, "status"):
         return DeviceSnapshot(error="Client initializing")
 
-    # Prefer atomic snapshot() to avoid TOCTOU across separate lock acquisitions.
-    # Check type(client) to avoid false positives with MagicMock in tests.
-    _snap = client.snapshot() if hasattr(type(client), "snapshot") else None
-    if _snap is not None:
-        status = _snap["status"]
-        _snap_bt_mgr = _snap["bt_manager"]
-        _snap_sink = _snap["bluetooth_sink_name"]
-        _snap_bt_mgmt = _snap["bt_management_enabled"]
-        _snap_server_url = _snap["connected_server_url"]
-        _snap_is_running = _snap["is_running"]
-        _snap_player_name = _snap["player_name"]
-        _snap_player_id = _snap["player_id"]
-        _snap_listen_port = _snap["listen_port"]
-        _snap_server_host = _snap["server_host"]
-        _snap_server_port = _snap["server_port"]
-        _snap_delay = _snap["static_delay_ms"]
-        _snap_mac = _snap["bluetooth_mac"]
-        _snap_eff_adapter = _snap["effective_adapter_mac"]
-        _snap_adapter = _snap["adapter"]
-        _snap_hci = _snap["adapter_hci_name"]
-        _snap_battery = _snap["battery_level"]
-        _snap_paired = _snap["paired"]
-        _snap_max_reconn = _snap["max_reconnect_fails"]
-    else:
-        if hasattr(client, "_status_lock"):
-            with client._status_lock:
-                status = client.status.copy()
-        else:
-            status = client.status.copy()
-        _snap_bt_mgr = getattr(client, "bt_manager", None)
-        _snap_sink = getattr(client, "bluetooth_sink_name", None)
-        _snap_bt_mgmt = getattr(client, "bt_management_enabled", True)
-        _snap_server_url = getattr(client, "connected_server_url", "")
-        _snap_is_running = client.is_running() if hasattr(client, "is_running") else None
-        _snap_player_name = getattr(client, "player_name", None)
-        _snap_player_id = getattr(client, "player_id", "")
-        _snap_listen_port = getattr(client, "listen_port", None)
-        _snap_server_host = getattr(client, "server_host", None)
-        _snap_server_port = getattr(client, "server_port", None)
-        _snap_delay = getattr(client, "static_delay_ms", None)
-        _snap_mac = _snap_bt_mgr.mac_address if _snap_bt_mgr else None
-        _snap_eff_adapter = getattr(_snap_bt_mgr, "effective_adapter_mac", None) if _snap_bt_mgr else None
-        _snap_adapter = getattr(_snap_bt_mgr, "adapter", None) if _snap_bt_mgr else None
-        _snap_hci = getattr(_snap_bt_mgr, "adapter_hci_name", "") if _snap_bt_mgr else ""
-        _snap_battery = getattr(_snap_bt_mgr, "battery_level", None) if _snap_bt_mgr else None
-        _snap_paired = getattr(_snap_bt_mgr, "paired", None) if _snap_bt_mgr else None
-        _snap_max_reconn = int(getattr(_snap_bt_mgr, "max_reconnect_fails", 0) or 0) if _snap_bt_mgr else 0
+    _snap = _client_facts(client)
+    status = _snap["status"]
+    _snap_bt_mgr = _snap["bt_manager"]
+    _snap_sink = _snap["bluetooth_sink_name"]
+    _snap_bt_mgmt = _snap["bt_management_enabled"]
+    _snap_server_url = _snap["connected_server_url"]
+    _snap_is_running = _snap["is_running"]
+    _snap_player_name = _snap["player_name"]
+    _snap_player_id = _snap["player_id"]
+    _snap_listen_port = _snap["listen_port"]
+    _snap_server_host = _snap["server_host"]
+    _snap_server_port = _snap["server_port"]
+    _snap_delay = _snap["static_delay_ms"]
+    _snap_mac = _snap["bluetooth_mac"]
+    _snap_eff_adapter = _snap["effective_adapter_mac"]
+    _snap_adapter = _snap["adapter"]
+    _snap_hci = _snap["adapter_hci_name"]
+    _snap_battery = _snap["battery_level"]
+    _snap_paired = _snap["paired"]
+    _snap_max_reconn = _snap["max_reconnect_fails"]
 
     bt_mgr = _snap_bt_mgr
     resolved_enabled = configured_enabled if configured_enabled is not None else _configured_enabled_by_player_name()

--- a/src/sendspin_bridge/services/music_assistant/ma_dispatch.py
+++ b/src/sendspin_bridge/services/music_assistant/ma_dispatch.py
@@ -1,0 +1,133 @@
+"""One connection, many conversations, one place that sorts them out.
+
+The bridge holds a single WebSocket to Music Assistant and carries several
+logical conversations over it at once: queue commands, queue polls, player
+refreshes, and the stream of events the server pushes on its own.  Every
+caller that wanted an answer used to read the socket itself, hunting for its
+own ``message_id`` and stashing whatever else turned up on the way.  Three
+such hunts existed, with three different bounds — ten messages, twenty,
+thirty — and past the bound the answer was dropped: the caller returned an
+empty payload and reported failure for a command the server had carried out.
+
+Routing is not a search.  One reader takes each message and hands it to
+whoever is waiting for that id, or to the event handler when nobody is.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["MessageDispatcher"]
+
+
+class MessageDispatcher:
+    """Routes messages off one socket to the callers waiting for them."""
+
+    def __init__(
+        self,
+        recv: Callable[[], Awaitable[Any]],
+        *,
+        on_event: Callable[[str], None],
+        on_unclaimed: Callable[[dict], None] | None = None,
+    ):
+        self._recv = recv
+        self._on_event = on_event
+        self._on_unclaimed = on_unclaimed
+        self._waiting: dict[str, asyncio.Future] = {}
+
+    # -- who is listening ----------------------------------------------
+
+    @property
+    def pending(self) -> int:
+        """How many callers are waiting for an answer."""
+        return len(self._waiting)
+
+    def expect(self, message_id: object) -> asyncio.Future:
+        """Register interest in *message_id* before the request goes out."""
+        key = str(message_id)
+        existing = self._waiting.get(key)
+        if existing is not None and not existing.done():
+            return existing
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._waiting[key] = future
+        return future
+
+    def forget(self, message_id: object) -> None:
+        """Stop waiting for *message_id* — a caller that gave up leaves nothing."""
+        self._waiting.pop(str(message_id), None)
+
+    def fail_all(self, error: BaseException) -> None:
+        """The socket is gone: nobody waiting on it can be answered."""
+        waiting, self._waiting = self._waiting, {}
+        for future in waiting.values():
+            if not future.done():
+                future.set_exception(error)
+
+    # -- reading -------------------------------------------------------
+
+    async def pump_once(self) -> dict | None:
+        """Read one message and give it to whoever it belongs to."""
+        raw = await self._recv()
+        message = raw if isinstance(raw, dict) else json.loads(raw)
+        self.dispatch(message)
+        return message
+
+    def dispatch(self, message: dict) -> None:
+        """Route one already-decoded message."""
+        message_id = message.get("message_id")
+        if message_id is not None:
+            future = self._waiting.pop(str(message_id), None)
+            if future is not None:
+                if not future.done():
+                    future.set_result(message)
+                return
+        event = message.get("event")
+        if event:
+            self._on_event(str(event))
+            return
+        if self._on_unclaimed is not None:
+            self._on_unclaimed(message)
+        else:
+            logger.debug("MA dispatch: nobody claimed message id=%s", message_id)
+
+    # -- asking --------------------------------------------------------
+
+    async def request(
+        self,
+        send: Callable[[str], Awaitable[None]],
+        *,
+        message_id: object,
+        timeout: float,
+        pump: bool = False,
+    ) -> dict:
+        """Send a request and wait for its answer.
+
+        With *pump*, this reads the socket while it waits — for the caller
+        that owns the connection.  Without it, some other task is pumping and
+        this only waits.  Either way the wait ends on the answer or the
+        timeout, never on a number of intervening messages.
+        """
+        key = str(message_id)
+        future = self.expect(key)
+        try:
+            await send(key)
+            if not pump:
+                return await asyncio.wait_for(future, timeout=timeout)
+
+            async def _pump_until_answered() -> dict:
+                while not future.done():
+                    await self.pump_once()
+                return future.result()
+
+            return await asyncio.wait_for(_pump_until_answered(), timeout=timeout)
+        except BaseException:
+            self.forget(key)
+            raise

--- a/src/sendspin_bridge/services/music_assistant/ma_monitor.py
+++ b/src/sendspin_bridge/services/music_assistant/ma_monitor.py
@@ -24,6 +24,7 @@ import sendspin_bridge.bridge.state as _state
 from sendspin_bridge.services.bluetooth.device_registry import get_device_registry_snapshot
 from sendspin_bridge.services.diagnostics.internal_events import DeviceEventType
 from sendspin_bridge.services.music_assistant.ma_artwork import build_artwork_proxy_url
+from sendspin_bridge.services.music_assistant.ma_dispatch import MessageDispatcher
 from sendspin_bridge.services.music_assistant.ma_player_map import learn_ma_player_ids
 
 if TYPE_CHECKING:
@@ -32,6 +33,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _POLL_INTERVAL = 15  # seconds between polling cycles when events unavailable
+#: How long a single request may wait for its answer before we call it lost.
+_REQUEST_TIMEOUT_S = 15.0
 _GROUPS_REFRESH_INTERVAL = 60  # seconds between syncgroup cache refreshes
 _RECONNECT_BASE = 2  # seconds — first reconnect delay
 _RECONNECT_MAX = 60  # seconds — max reconnect delay
@@ -573,24 +576,14 @@ class MaMonitor:
             except asyncio.QueueEmpty:
                 break
             try:
-                mid = self._next_id()
-                await _send(ws, mid, command, args)
-                # Match response by message_id; forward interleaved events
-                for _ in range(10):
-                    resp = await _recv(ws, timeout=5.0)
-                    if str(resp.get("message_id")) == str(mid):
-                        if not fut.done():
-                            fut.set_result(resp)
-                        break
-                    evt = resp.get("event")
-                    if evt:
-                        logger.debug("MA monitor: interleaved event '%s' during cmd drain", evt)
-                        self._defer_incoming_event(evt)
+                # The same routed round-trip every other caller uses: the wait
+                # ends on the answer or the timeout, not after ten messages.
+                resp = await self._request_command(ws, command, args, flush=False)
+                if not fut.done():
+                    if resp:
+                        fut.set_result(resp)
                     else:
-                        logger.debug("MA monitor: non-matching msg (id=%s) during cmd drain", resp.get("message_id"))
-                else:
-                    if not fut.done():
-                        fut.set_exception(TimeoutError(f"No matching response for {command}"))
+                        fut.set_exception(TimeoutError(f"No answer to {command}"))
             except Exception as e:
                 if not fut.done():
                     fut.set_exception(e)
@@ -603,25 +596,43 @@ class MaMonitor:
     async def _send_queue_cmd(self, ws, command: str, args: dict) -> dict:
         return await self._request_command(ws, command, args)
 
-    async def _request_command(self, ws, command: str, args: dict) -> dict:
-        """Send a WS command and return the matching response payload."""
+    async def _request_command(
+        self,
+        ws,
+        command: str,
+        args: dict,
+        *,
+        timeout: float = _REQUEST_TIMEOUT_S,
+        flush: bool = True,
+    ) -> dict:
+        """Send a WS command and return its answer.
+
+        The wait ends on the answer or on *timeout* — never on a number of
+        intervening messages.  This used to read at most ten and give up,
+        which a household with several speakers can exceed between a command
+        and its acknowledgement: the bridge then reported a command as failed
+        that the server had carried out.
+        """
+        dispatcher = MessageDispatcher(
+            lambda: _recv(ws, timeout=timeout),
+            on_event=self._defer_incoming_event,
+        )
         mid = self._next_id()
-        await _send(ws, mid, command, args)
-        # Read messages until we get the one with our message_id
-        for _ in range(10):
-            resp = await _recv(ws, timeout=5.0)
-            if str(resp.get("message_id")) == str(mid):
-                await self._flush_deferred_updates(ws)
-                return resp
-            evt = resp.get("event")
-            if evt:
-                logger.debug("MA monitor: interleaved event '%s' during queue cmd", evt)
-                self._defer_incoming_event(evt)
-            else:
-                logger.debug("MA monitor: non-matching msg (id=%s) during queue cmd", resp.get("message_id"))
-        logger.warning("No matching response for command %s after %d messages", command, 10)
-        await self._flush_deferred_updates(ws)
-        return {}
+        try:
+            response = await dispatcher.request(
+                lambda _key: _send(ws, mid, command, args),
+                message_id=mid,
+                timeout=timeout,
+                pump=True,
+            )
+        except TimeoutError:
+            logger.warning("No answer to %s within %.0fs", command, timeout)
+            response = {}
+        if flush:
+            # The refreshers below are themselves what a flush runs; asking
+            # for one from inside them would call them again.
+            await self._flush_deferred_updates(ws)
+        return response
 
     async def _fetch_queue_items(self, ws, queue_id: str, limit: int = 1, offset: int = 0) -> list[dict]:
         """Fetch a slice of queue items for a queue via MA WebSocket API."""
@@ -631,6 +642,7 @@ class MaMonitor:
             ws,
             "player_queues/items",
             {"queue_id": queue_id, "limit": limit, "offset": offset},
+            flush=False,
         )
         result = resp.get("result")
         return result if isinstance(result, list) else []
@@ -736,17 +748,9 @@ class MaMonitor:
     async def _refresh_groups_via_ws(self, ws) -> None:
         """Fetch players/all via WS and rebuild the syncgroup cache in state."""
         try:
-            mid = self._next_id()
-            await _send(ws, mid, "players/all", {})
-            for _ in range(30):
-                resp = await _recv(ws, timeout=10.0)
-                if str(resp.get("message_id")) == str(mid):
-                    players = resp.get("result") or []
-                    break
-                evt = resp.get("event")
-                if evt:
-                    self._defer_incoming_event(evt)
-            else:
+            resp = await self._request_command(ws, "players/all", {}, flush=False)
+            players = resp.get("result") or []
+            if not players:
                 return
 
             id_to_name: dict[str, str] = {
@@ -906,55 +910,47 @@ class MaMonitor:
     async def _poll_queues(self, ws) -> None:
         """Fetch player_queues/all and update now-playing cache per syncgroup and solo player."""
         try:
-            mid = self._next_id()
-            await _send(ws, mid, "player_queues/all", {})
-            for _ in range(20):
-                resp = await _recv(ws, timeout=10.0)
-                if str(resp.get("message_id")) != str(mid):
-                    evt = resp.get("event")
-                    if evt:
-                        self._defer_incoming_event(evt)
-                    continue
-                queues = resp.get("result") or []
-                fresh: dict[str, dict] = {}
+            resp = await self._request_command(ws, "player_queues/all", {}, flush=False)
+            queues = resp.get("result") or []
+            fresh: dict[str, dict] = {}
 
-                async def fetch_items(queue_id: str, limit: int = 1, offset: int = 0) -> list[dict]:
-                    return await self._fetch_queue_items(ws, queue_id, limit=limit, offset=offset)
+            async def fetch_items(queue_id: str, limit: int = 1, offset: int = 0) -> list[dict]:
+                return await self._fetch_queue_items(ws, queue_id, limit=limit, offset=offset)
 
-                # Syncgroup players
-                syncgroup_queues = await _find_syncgroup_queues(queues)
-                for q in syncgroup_queues:
-                    np = _build_now_playing(q)
-                    await _hydrate_missing_queue_neighbors(fetch_items, q, np)
-                    fresh[np["syncgroup_id"]] = np
-                # Solo (ungrouped) players — keyed by their own player_id
-                for player_id, q in _find_solo_player_queues(queues):
-                    np = _build_now_playing(q)
-                    await _hydrate_missing_queue_neighbors(fetch_items, q, np)
-                    np["syncgroup_id"] = player_id
-                    fresh[player_id] = np
-                # Atomically replace to clear stale entries.  An answer with
-                # no queues in it is an answer: a speaker whose queue was
-                # removed used to keep reporting the queue it once had,
-                # because the cache was only replaced when there was
-                # something to put in it.
-                _state.replace_ma_now_playing(fresh)
-                if fresh:
-                    # Reverse-bridge: push playback state to per-device MprisPlayer
-                    # so AVRCP-capable speakers (Bose, Sony WH-1000XM, Yandex
-                    # mini) reflect MA's now-playing on their display/LEDs.
-                    # Best-effort — failures here must not stop polling.
-                    try:
-                        from sendspin_bridge.services.audio.mpris_player import get_registry as _get_mpris_registry
+            # Syncgroup players
+            syncgroup_queues = await _find_syncgroup_queues(queues)
+            for q in syncgroup_queues:
+                np = _build_now_playing(q)
+                await _hydrate_missing_queue_neighbors(fetch_items, q, np)
+                fresh[np["syncgroup_id"]] = np
+            # Solo (ungrouped) players — keyed by their own player_id
+            for player_id, q in _find_solo_player_queues(queues):
+                np = _build_now_playing(q)
+                await _hydrate_missing_queue_neighbors(fetch_items, q, np)
+                np["syncgroup_id"] = player_id
+                fresh[player_id] = np
+            # Atomically replace to clear stale entries.  An answer with
+            # no queues in it is an answer: a speaker whose queue was
+            # removed used to keep reporting the queue it once had,
+            # because the cache was only replaced when there was
+            # something to put in it.
+            _state.replace_ma_now_playing(fresh)
+            if fresh:
+                # Reverse-bridge: push playback state to per-device MprisPlayer
+                # so AVRCP-capable speakers (Bose, Sony WH-1000XM, Yandex
+                # mini) reflect MA's now-playing on their display/LEDs.
+                # Best-effort — failures here must not stop polling.
+                try:
+                    from sendspin_bridge.services.audio.mpris_player import get_registry as _get_mpris_registry
 
-                        await push_now_playing_to_mpris(
-                            fresh,
-                            _active_bridge_clients(),
-                            _get_mpris_registry(),
-                        )
-                    except Exception as exc:
-                        logger.debug("MPRIS reverse-push failed: %s", exc)
-                return
+                    await push_now_playing_to_mpris(
+                        fresh,
+                        _active_bridge_clients(),
+                        _get_mpris_registry(),
+                    )
+                except Exception as exc:
+                    logger.debug("MPRIS reverse-push failed: %s", exc)
+            return
         except Exception as exc:
             logger.debug("MA monitor poll error: %s", exc)
 

--- a/src/sendspin_bridge/services/music_assistant/ma_monitor.py
+++ b/src/sendspin_bridge/services/music_assistant/ma_monitor.py
@@ -879,11 +879,7 @@ class MaMonitor:
             self._ws = ws  # type: ignore[assignment]
 
             try:
-                # Check and refresh stale player metadata (once per connect session)
-                await self._refresh_stale_player_metadata(ws)
-
-                # Initial poll
-                await self._poll_queues(ws)
+                await self._prime_session(ws)
 
                 # Subscribe to events
                 events_ok = False
@@ -906,6 +902,22 @@ class MaMonitor:
             finally:
                 self._cancel_pending_cmd_futures()
                 self._ws = None
+
+    async def _prime_session(self, ws) -> None:
+        """Everything a fresh connection needs before it starts listening.
+
+        The player map is learned here rather than waiting for the sixty-second
+        refresh timer: until it exists, a queue command for a speaker in no
+        sync group is aimed at an id no current server knows, and the first
+        queue poll cannot recognise that speaker's queue either.  A server
+        that will not answer costs us the map, not the session.
+        """
+        await self._refresh_stale_player_metadata(ws)
+        try:
+            await self._refresh_groups_via_ws(ws)
+        except Exception as exc:
+            logger.debug("MA monitor: could not learn players at connect: %s", exc)
+        await self._poll_queues(ws)
 
     async def _poll_queues(self, ws) -> None:
         """Fetch player_queues/all and update now-playing cache per syncgroup and solo player."""

--- a/tests/unit/services/lifecycle/test_snapshot_paths_agree.py
+++ b/tests/unit/services/lifecycle/test_snapshot_paths_agree.py
@@ -1,0 +1,182 @@
+"""Both ways of reading a client must describe it the same.
+
+`build_device_snapshot` reads a client twice over: through `client.snapshot()`
+when the client offers one — an atomic read under the status lock — and
+through a pile of `getattr` calls when it does not. Two extractions of the
+same twenty-one facts, side by side, with nothing checking that they agree.
+
+The fallback is not dead code: it is what every partially-built client and
+every test double takes.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from sendspin_bridge.services.lifecycle.status_snapshot import build_device_snapshot
+
+UTC = timezone.utc
+
+
+class _Client:
+    """A client that can answer either way, on demand."""
+
+    def __init__(self) -> None:
+        self.status = {
+            "server_connected": True,
+            "bluetooth_connected": True,
+            "bluetooth_available": True,
+            "playing": True,
+            "volume": 42,
+            "muted": False,
+            "reconnect_attempt": 2,
+            "uptime_start": datetime.now(tz=UTC),
+        }
+        self._status_lock = threading.Lock()
+        self.player_name = "Kitchen"
+        self.player_id = "sendspin-kitchen"
+        self.listen_port = 8928
+        self.server_host = "music-assistant.local"
+        self.server_port = 9000
+        self.static_delay_ms = 120.0
+        self.required_lead_time_ms = 250
+        self.min_buffer_ms = 250
+        self.connected_server_url = ""
+        self.bluetooth_sink_name = "bluez_output.AA_BB_CC_DD_EE_FF.1"
+        self.bt_management_enabled = True
+        self.bt_manager = SimpleNamespace(
+            mac_address="AA:BB:CC:DD:EE:FF",
+            effective_adapter_mac="C0:FB:F9:62:D7:D6",
+            adapter="hci0",
+            adapter_hci_name="hci0",
+            battery_level=77,
+            paired=True,
+            max_reconnect_fails=5,
+        )
+
+    def is_running(self) -> bool:
+        return True
+
+    def snapshot(self) -> dict:
+        with self._status_lock:
+            bt = self.bt_manager
+            return {
+                "status": self.status.copy(),
+                "bluetooth_sink_name": self.bluetooth_sink_name,
+                "bt_management_enabled": self.bt_management_enabled,
+                "connected_server_url": self.connected_server_url,
+                "is_running": True,
+                "player_name": self.player_name,
+                "player_id": self.player_id,
+                "listen_port": self.listen_port,
+                "server_host": self.server_host,
+                "server_port": self.server_port,
+                "static_delay_ms": self.static_delay_ms,
+                "required_lead_time_ms": self.required_lead_time_ms,
+                "min_buffer_ms": self.min_buffer_ms,
+                "bt_manager": bt,
+                "bluetooth_mac": bt.mac_address,
+                "effective_adapter_mac": bt.effective_adapter_mac,
+                "adapter": bt.adapter,
+                "adapter_hci_name": bt.adapter_hci_name,
+                "battery_level": bt.battery_level,
+                "paired": bt.paired,
+                "max_reconnect_fails": bt.max_reconnect_fails,
+            }
+
+
+def _without_snapshot(client: _Client) -> object:
+    """The same facts on an object that cannot answer atomically."""
+    plain = SimpleNamespace(
+        status=client.status,
+        _status_lock=client._status_lock,
+        player_name=client.player_name,
+        player_id=client.player_id,
+        listen_port=client.listen_port,
+        server_host=client.server_host,
+        server_port=client.server_port,
+        static_delay_ms=client.static_delay_ms,
+        required_lead_time_ms=client.required_lead_time_ms,
+        min_buffer_ms=client.min_buffer_ms,
+        connected_server_url=client.connected_server_url,
+        bluetooth_sink_name=client.bluetooth_sink_name,
+        bt_management_enabled=client.bt_management_enabled,
+        bt_manager=client.bt_manager,
+        is_running=client.is_running,
+    )
+    return plain
+
+
+def _volatile(payload: dict) -> dict:
+    """Drop the fields that move on their own between two reads."""
+    out = dict(payload)
+    out.pop("uptime", None)
+    extra = dict(out.get("extra") or {})
+    extra.pop("uptime", None)
+    out["extra"] = extra
+    return out
+
+
+def test_the_two_reads_of_one_client_describe_it_identically():
+    client = _Client()
+    atomic = build_device_snapshot(client, configured_enabled={})
+    by_attribute = build_device_snapshot(_without_snapshot(_Client()), configured_enabled={})
+
+    assert _volatile(atomic.to_dict()) == _volatile(by_attribute.to_dict())
+
+
+def test_a_client_whose_atomic_read_is_not_callable_is_read_by_attribute():
+    """`snapshot = None` on a class used to crash the whole status build.
+
+    The old guard asked whether the *class* had the attribute, which a
+    ``None`` placeholder satisfies, and then called it.
+    """
+    client = _Client()
+    broken = SimpleNamespace(
+        snapshot=None,
+        status=client.status,
+        _status_lock=client._status_lock,
+        player_name=client.player_name,
+        player_id=client.player_id,
+        listen_port=client.listen_port,
+        server_host=client.server_host,
+        server_port=client.server_port,
+        static_delay_ms=client.static_delay_ms,
+        connected_server_url=client.connected_server_url,
+        bluetooth_sink_name=client.bluetooth_sink_name,
+        bt_management_enabled=client.bt_management_enabled,
+        bt_manager=client.bt_manager,
+        is_running=client.is_running,
+    )
+
+    snapshot = build_device_snapshot(broken, configured_enabled={})
+
+    assert snapshot.player_name == "Kitchen"
+    assert snapshot.sink_name == "bluez_output.AA_BB_CC_DD_EE_FF.1"
+
+
+def test_a_client_that_answers_with_something_else_is_read_by_attribute():
+    """A stub returning a Mock must not become the snapshot's facts."""
+    client = _Client()
+    odd = SimpleNamespace(
+        snapshot=lambda: "not a mapping",
+        status=client.status,
+        _status_lock=client._status_lock,
+        player_name=client.player_name,
+        player_id=client.player_id,
+        listen_port=client.listen_port,
+        server_host=client.server_host,
+        server_port=client.server_port,
+        static_delay_ms=client.static_delay_ms,
+        connected_server_url=client.connected_server_url,
+        bluetooth_sink_name=client.bluetooth_sink_name,
+        bt_management_enabled=client.bt_management_enabled,
+        bt_manager=client.bt_manager,
+        is_running=client.is_running,
+    )
+
+    snapshot = build_device_snapshot(odd, configured_enabled={})
+
+    assert snapshot.player_name == "Kitchen"

--- a/tests/unit/services/lifecycle/test_snapshot_paths_agree.py
+++ b/tests/unit/services/lifecycle/test_snapshot_paths_agree.py
@@ -127,56 +127,39 @@ def test_the_two_reads_of_one_client_describe_it_identically():
     assert _volatile(atomic.to_dict()) == _volatile(by_attribute.to_dict())
 
 
-def test_a_client_whose_atomic_read_is_not_callable_is_read_by_attribute():
-    """`snapshot = None` on a class used to crash the whole status build.
+class _ClientWithBrokenSnapshot(_Client):
+    """A class carrying `snapshot = None` — the shape that used to crash.
 
-    The old guard asked whether the *class* had the attribute, which a
-    ``None`` placeholder satisfies, and then called it.
+    It has to be on the *class*: the old guard asked `hasattr(type(client),
+    "snapshot")`, which an instance attribute does not satisfy, so a
+    `SimpleNamespace` would have taken the attribute path and proved nothing.
     """
-    client = _Client()
-    broken = SimpleNamespace(
-        snapshot=None,
-        status=client.status,
-        _status_lock=client._status_lock,
-        player_name=client.player_name,
-        player_id=client.player_id,
-        listen_port=client.listen_port,
-        server_host=client.server_host,
-        server_port=client.server_port,
-        static_delay_ms=client.static_delay_ms,
-        connected_server_url=client.connected_server_url,
-        bluetooth_sink_name=client.bluetooth_sink_name,
-        bt_management_enabled=client.bt_management_enabled,
-        bt_manager=client.bt_manager,
-        is_running=client.is_running,
-    )
 
-    snapshot = build_device_snapshot(broken, configured_enabled={})
+    snapshot = None  # type: ignore[assignment]
+
+
+class _ClientAnsweringSomethingElse(_Client):
+    """A stub whose atomic read answers with something that is not a mapping."""
+
+    def snapshot(self):  # type: ignore[override]
+        return "not a mapping"
+
+
+def test_a_client_whose_atomic_read_is_not_callable_is_read_by_attribute():
+    """`snapshot = None` on a class used to take down the whole status build.
+
+    The old guard asked whether the class had the attribute, which a `None`
+    placeholder satisfies, and then called it.
+    """
+    snapshot = build_device_snapshot(_ClientWithBrokenSnapshot(), configured_enabled={})
 
     assert snapshot.player_name == "Kitchen"
     assert snapshot.sink_name == "bluez_output.AA_BB_CC_DD_EE_FF.1"
 
 
 def test_a_client_that_answers_with_something_else_is_read_by_attribute():
-    """A stub returning a Mock must not become the snapshot's facts."""
-    client = _Client()
-    odd = SimpleNamespace(
-        snapshot=lambda: "not a mapping",
-        status=client.status,
-        _status_lock=client._status_lock,
-        player_name=client.player_name,
-        player_id=client.player_id,
-        listen_port=client.listen_port,
-        server_host=client.server_host,
-        server_port=client.server_port,
-        static_delay_ms=client.static_delay_ms,
-        connected_server_url=client.connected_server_url,
-        bluetooth_sink_name=client.bluetooth_sink_name,
-        bt_management_enabled=client.bt_management_enabled,
-        bt_manager=client.bt_manager,
-        is_running=client.is_running,
-    )
-
-    snapshot = build_device_snapshot(odd, configured_enabled={})
+    """A stub returning a string must not become the snapshot's facts."""
+    snapshot = build_device_snapshot(_ClientAnsweringSomethingElse(), configured_enabled={})
 
     assert snapshot.player_name == "Kitchen"
+    assert snapshot.sink_name == "bluez_output.AA_BB_CC_DD_EE_FF.1"

--- a/tests/unit/services/music_assistant/test_ma_connect_learns_players.py
+++ b/tests/unit/services/music_assistant/test_ma_connect_learns_players.py
@@ -16,8 +16,6 @@ speaker's queue, so it belongs before that poll, not after it.
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from sendspin_bridge.services.music_assistant.ma_monitor import MaMonitor
@@ -53,7 +51,7 @@ async def test_a_failing_refresh_does_not_stop_the_session(monkeypatch):
     polled: list[str] = []
 
     async def _groups(_ws):
-        raise asyncio.TimeoutError
+        raise TimeoutError
 
     async def _poll(_ws):
         polled.append("poll")

--- a/tests/unit/services/music_assistant/test_ma_connect_learns_players.py
+++ b/tests/unit/services/music_assistant/test_ma_connect_learns_players.py
@@ -1,0 +1,70 @@
+"""The player map must exist before the first command, not a minute later.
+
+Which Music Assistant player fronts each of our speakers is learned from a
+`players/all` answer, and that answer was only asked for on the sixty-second
+refresh timer. For up to a minute after every connect — which includes every
+bridge start and every reconnect — the map was empty, so a queue command for
+an ungrouped speaker fell through to the derived ids that no current server
+knows. Reproduced on the live bridge right after a restart:
+
+    MA queue cmd rejected: shuffle value=False → up8e34f1108d9b…
+    MA queue cmd rejected: shuffle value=False → 8e34f110-8d9b…
+
+The same answer is also what lets the first queue poll recognise a solo
+speaker's queue, so it belongs before that poll, not after it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sendspin_bridge.services.music_assistant.ma_monitor import MaMonitor
+
+
+@pytest.mark.asyncio
+async def test_a_connect_learns_the_players_before_polling_queues(monkeypatch):
+    monitor = MaMonitor.__new__(MaMonitor)
+    order: list[str] = []
+
+    async def _groups(_ws):
+        order.append("groups")
+
+    async def _poll(_ws):
+        order.append("poll")
+
+    async def _stale(_ws):
+        order.append("stale")
+
+    monitor._refresh_groups_via_ws = _groups
+    monitor._poll_queues = _poll
+    monitor._refresh_stale_player_metadata = _stale
+
+    await MaMonitor._prime_session(monitor, object())
+
+    assert order == ["stale", "groups", "poll"], order
+
+
+@pytest.mark.asyncio
+async def test_a_failing_refresh_does_not_stop_the_session(monkeypatch):
+    """A server that will not answer players/all must not cost us the poll."""
+    monitor = MaMonitor.__new__(MaMonitor)
+    polled: list[str] = []
+
+    async def _groups(_ws):
+        raise asyncio.TimeoutError
+
+    async def _poll(_ws):
+        polled.append("poll")
+
+    async def _stale(_ws):
+        return None
+
+    monitor._refresh_groups_via_ws = _groups
+    monitor._poll_queues = _poll
+    monitor._refresh_stale_player_metadata = _stale
+
+    await MaMonitor._prime_session(monitor, object())
+
+    assert polled == ["poll"]

--- a/tests/unit/services/music_assistant/test_ma_dispatch.py
+++ b/tests/unit/services/music_assistant/test_ma_dispatch.py
@@ -1,0 +1,135 @@
+"""One connection, many conversations, one place that sorts them out.
+
+Every caller that wanted an answer from Music Assistant read the socket
+itself, hunting for its own `message_id` and stashing whatever else turned up
+along the way. Three such hunts exist, with three different bounds — ten
+messages, twenty, thirty — and past the bound the answer is simply dropped:
+the caller returns an empty payload and reports failure for a command the
+server carried out.
+
+A dispatcher makes that a routing question instead of a search: one reader
+takes each message and hands it to whoever is waiting for it, or to the event
+handler if nobody is.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sendspin_bridge.services.music_assistant.ma_dispatch import MessageDispatcher
+
+
+class _Socket:
+    """A socket that yields a scripted sequence of messages."""
+
+    def __init__(self, messages: list[dict]) -> None:
+        self._messages = list(messages)
+        self.sent: list[dict] = []
+
+    async def recv(self) -> dict:
+        if not self._messages:
+            await asyncio.sleep(3600)  # nothing more will arrive
+        return self._messages.pop(0)
+
+    async def send(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+
+def _dispatcher(messages: list[dict], events: list[str] | None = None) -> tuple[MessageDispatcher, _Socket]:
+    socket = _Socket(messages)
+    collected = events if events is not None else []
+    return MessageDispatcher(socket.recv, on_event=collected.append), socket
+
+
+# ── routing ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_an_answer_reaches_the_caller_that_asked_for_it():
+    dispatcher, _socket = _dispatcher([{"message_id": "7", "result": "mine"}])
+
+    waiting = dispatcher.expect("7")
+    await dispatcher.pump_once()
+
+    assert (await waiting)["result"] == "mine"
+
+
+@pytest.mark.asyncio
+async def test_two_callers_do_not_take_each_other_s_answers():
+    dispatcher, _socket = _dispatcher([{"message_id": "2", "result": "second"}, {"message_id": "1", "result": "first"}])
+
+    first = dispatcher.expect("1")
+    second = dispatcher.expect("2")
+    await dispatcher.pump_once()
+    await dispatcher.pump_once()
+
+    assert (await first)["result"] == "first"
+    assert (await second)["result"] == "second"
+
+
+@pytest.mark.asyncio
+async def test_a_message_nobody_waits_for_goes_to_the_event_handler():
+    seen: list[str] = []
+    dispatcher, _socket = _dispatcher([{"event": "player_queue_updated"}], events=seen)
+
+    await dispatcher.pump_once()
+
+    assert seen == ["player_queue_updated"]
+
+
+@pytest.mark.asyncio
+async def test_events_do_not_consume_a_caller_s_patience():
+    """The defect: past a fixed number of interleaved events, the answer was lost."""
+    noise = [{"event": "player_updated"} for _ in range(50)]
+    dispatcher, socket = _dispatcher([*noise, {"message_id": "1", "result": "arrived late"}])
+
+    answer = await dispatcher.request(
+        lambda mid: socket.send({"command": "player_queues/shuffle", "message_id": mid}),
+        message_id="1",
+        timeout=5.0,
+        pump=True,
+    )
+
+    assert answer["result"] == "arrived late"
+
+
+# ── when the answer does not come ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_silent_server_times_out_rather_than_waiting_forever():
+    dispatcher, socket = _dispatcher([])
+
+    with pytest.raises(asyncio.TimeoutError):
+        await dispatcher.request(
+            lambda mid: socket.send({"message_id": mid}),
+            message_id="1",
+            timeout=0.05,
+            pump=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_timed_out_caller_stops_being_waited_on():
+    """Otherwise a late answer resolves a future nobody holds, and leaks."""
+    dispatcher, socket = _dispatcher([])
+
+    with pytest.raises(asyncio.TimeoutError):
+        await dispatcher.request(lambda mid: socket.send({"message_id": mid}), message_id="1", timeout=0.05, pump=True)
+
+    assert dispatcher.pending == 0
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_connection_fails_everyone_waiting():
+    """A caller must not hang on a socket that is gone."""
+    dispatcher, _socket = _dispatcher([])
+    waiting = dispatcher.expect("1")
+
+    dispatcher.fail_all(ConnectionError("socket closed"))
+
+    with pytest.raises(ConnectionError):
+        await waiting
+    assert dispatcher.pending == 0

--- a/tests/unit/services/music_assistant/test_ma_request_no_bound.py
+++ b/tests/unit/services/music_assistant/test_ma_request_no_bound.py
@@ -1,0 +1,100 @@
+"""A queue command's answer must not be lost to a busy server.
+
+`_request_command` read up to ten messages looking for its own reply. Music
+Assistant pushes `player_updated` and `player_queue_updated` on its own, and a
+household with several speakers can easily put more than ten of those on the
+wire between a command and its acknowledgement. Past the tenth, the method
+gave up and returned an empty payload — the bridge then reported the command
+as failed, while the server had carried it out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from sendspin_bridge.services.music_assistant.ma_monitor import MaMonitor
+
+
+class _BusySocket:
+    """Answers after *noise* unrelated events have gone past."""
+
+    def __init__(self, noise: int) -> None:
+        self._pending: list[dict] = [{"event": "player_updated"} for _ in range(noise)]
+        self.sent: list[dict] = []
+
+    async def send(self, raw: str) -> None:
+        message = json.loads(raw)
+        self.sent.append(message)
+        self._pending.append({"message_id": message["message_id"], "result": {"ok": True}})
+
+    async def recv(self) -> str:
+        if not self._pending:
+            await asyncio.sleep(3600)
+        return json.dumps(self._pending.pop(0))
+
+
+def _monitor() -> MaMonitor:
+    import itertools
+
+    monitor = MaMonitor.__new__(MaMonitor)
+    monitor._msg_id = itertools.count(1)
+    monitor._pending_queue_refresh = False
+    monitor._pending_groups_refresh = False
+    return monitor
+
+
+@pytest.mark.asyncio
+async def test_an_answer_behind_fifty_events_still_arrives():
+    monitor = _monitor()
+    socket = _BusySocket(noise=50)
+
+    response = await monitor._request_command(socket, "player_queues/shuffle", {"shuffle_enabled": False})
+
+    assert response.get("result") == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_the_events_that_went_past_are_not_thrown_away():
+    """They drive the now-playing refresh; losing them stalls the UI."""
+    monitor = _monitor()
+    socket = _BusySocket(noise=3)
+
+    flushed: list[str] = []
+    monitor._pending_groups_refresh = False
+    monitor._pending_queue_refresh = False
+
+    async def _flush(_ws):
+        if monitor._pending_groups_refresh:
+            flushed.append("player_updated")
+            monitor._pending_groups_refresh = False
+        if monitor._pending_queue_refresh:
+            flushed.append("player_queue_updated")
+            monitor._pending_queue_refresh = False
+
+    monitor._flush_deferred_updates = _flush
+
+    await monitor._request_command(socket, "player_queues/shuffle", {})
+
+    assert flushed == ["player_updated"], "the events that went past were dropped"
+
+
+@pytest.mark.asyncio
+async def test_a_queued_command_also_survives_a_busy_server():
+    """The UI's queue buttons go through the command queue, not the direct path."""
+    monitor = _monitor()
+    monitor._cmd_queue = asyncio.Queue()
+    monitor._flush_deferred_updates = _noop_flush
+    socket = _BusySocket(noise=40)
+    answer: asyncio.Future = asyncio.get_running_loop().create_future()
+    await monitor._cmd_queue.put(("player_queues/next", {}, answer))
+
+    await monitor._drain_cmd_queue(socket)
+
+    assert (await answer)["result"] == {"ok": True}
+
+
+async def _noop_flush(_ws):
+    return None


### PR DESCRIPTION
Finishes C8 and does C10. Two candidates, one branch, separate commits — both are about one owner for something that had several.

## C8, the remaining half: one reader turns a client into a snapshot

`build_device_snapshot` read a client twice over — through `client.snapshot()` when the client offers one (an atomic read under the status lock), and through a pile of `getattr` calls when it does not. Two extractions of the same twenty-one facts, side by side, kept in step by hand. The fallback is not dead code: every partially-built client and every test double takes it.

`_client_facts()` owns the choice now, and there is one unpacking after it. A test asserts both routes describe the same client identically, so they cannot drift.

Two crashes went with the duplication. The old guard asked whether the *class* had a `snapshot` attribute and then called it, so a class carrying `snapshot = None` took down the whole status build; and a stub answering with something that is not a mapping would have become the snapshot's facts. Both fall through to the attribute read now.

## C10: one reader decides who a message belongs to

The bridge holds a single WebSocket to Music Assistant and carries several conversations over it: queue commands, queue polls, player refreshes, and the events the server pushes unprompted. Every caller that wanted an answer read the socket itself, hunting for its own `message_id` and stashing whatever else turned up. **Four** such hunts, with three different bounds — ten messages, twenty, thirty — and past the bound the answer was dropped.

Ten is not many. Music Assistant pushes `player_updated` and `player_queue_updated` on its own; a household with several speakers exceeds ten between a command and its acknowledgement without trying. The bridge then reported a command as failed that the server had carried out:

```
No matching response for command player_queues/shuffle after 10 messages
```

`MessageDispatcher` makes it a routing question: one reader takes each message and hands it to whoever waits for that id, or to the event handler when nobody does. The wait ends on the answer or a timeout, never on a count. All four call sites go through it; deferred events still flush exactly as before, except from inside the two refreshers — which are themselves what a flush runs, and would otherwise have called themselves. That re-entrancy was already there through `player_queues/items`.

## And the gap that only a restart shows

With the dispatcher reporting rejections instead of silently returning empty, a live restart surfaced this:

```
MA queue cmd rejected: shuffle value=False → up8e34f1108d9b…
MA queue cmd rejected: shuffle value=False → 8e34f110-8d9b…
```

The map from our client to Music Assistant's player id is built from a `players/all` answer, and that was only requested on the sixty-second refresh timer. Every connect began with an empty map, so for up to a minute a queue command for an ungrouped speaker went to the derived id no current server knows. It is learned at connect now, before the first poll — which needs it too, to recognise a solo speaker's queue.

Live afterwards: the map appeared 15 ms after authentication, and a shuffle sent 22 seconds into the session was accepted against `up4098e820`, the learned id.

## Verification

3579 passed, 1 skipped; ruff clean; changelog clean. Every fix here has a test that fails without it — checked by reverting the change under each, including the two dispatcher ones (`assert None == {'ok': True}` and `TimeoutError: No matching response for player_queues/next`).

## What is left of the plan

C12 — the frontend, 15 515 lines with no tests — is the only candidate still untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
